### PR TITLE
Feature/optimize loading of participants

### DIFF
--- a/app/components/agenda/modal.js
+++ b/app/components/agenda/modal.js
@@ -20,7 +20,6 @@ export default class AgendaModalComponent extends Component {
   @tracked afterAgendapuntOptions;
   @tracked error;
   toBeDeleted = [];
-  unsavedBehandelingen = [];
 
   get afterSave() {
     return this.args.afterSave || (() => {});
@@ -161,7 +160,6 @@ export default class AgendaModalComponent extends Component {
       behandeling.aanwezigen = this.args.zitting.aanwezigenBijStart;
       behandeling.voorzitter = this.args.zitting.voorzitter;
       behandeling.secretaris = this.args.zitting.secretaris;
-      this.unsavedBehandelingen.push(behandeling);
     }
   }
 

--- a/app/components/behandeling-van-agendapunt.hbs
+++ b/app/components/behandeling-van-agendapunt.hbs
@@ -6,8 +6,8 @@
     {{t "behandelingVanAgendapunten.visibility"}} <AuLabel><Input @type="checkbox" @checked={{this.openbaar}} {{on "input" this.toggleOpenbaar}} /> &nbsp;{{t "behandelingVanAgendapunten.openbaarLabel"}}</AuLabel>
   </div>
   <Treatment::Participation
-                 @behandeling={{@behandeling}}
-                 @bestuursorgaan={{@bestuursorgaan}}
+    @behandeling={{@behandeling}}
+    @possibleParticipants={{@possibleParticipants}}
   />
 
   <div class="au-u-padding-bottom-large">

--- a/app/components/behandeling-van-agendapunt.hbs
+++ b/app/components/behandeling-van-agendapunt.hbs
@@ -6,8 +6,8 @@
     {{t "behandelingVanAgendapunten.visibility"}} <AuLabel><Input @type="checkbox" @checked={{this.openbaar}} {{on "input" this.toggleOpenbaar}} /> &nbsp;{{t "behandelingVanAgendapunten.openbaarLabel"}}</AuLabel>
   </div>
   <Treatment::Participation
-    @behandeling={{@behandeling}}
-    @bestuursorgaan={{@bestuursorgaan}}
+                 @behandeling={{@behandeling}}
+                 @bestuursorgaan={{@bestuursorgaan}}
   />
 
   <div class="au-u-padding-bottom-large">

--- a/app/components/behandeling-van-agendapunt.js
+++ b/app/components/behandeling-van-agendapunt.js
@@ -12,6 +12,7 @@ export default class BehandelingVanAgendapuntComponent extends Component {
   @service currentSession;
   @tracked behandeling;
   @tracked editor;
+  @tracked aanwezigen = new Array();
 
   constructor() {
     super(...arguments);
@@ -19,9 +20,22 @@ export default class BehandelingVanAgendapuntComponent extends Component {
     this.behandeling = this.args.behandeling;
     this.documentContainer = this.args.behandeling.documentContainer;
     this.tryToFetchDocument.perform();
+    this.fetchParticipants.perform();
   }
+
   get hasParticipants() {
-    return this.args.behandeling.aanwezigen.length;
+    return this.aanwezigen.length;
+  }
+
+  @task
+  *fetchParticipants() {
+    let queryParams = {
+      'filter[aanwezig-bij-behandeling]': this.behandeling.get('uri'),
+      include: 'is-bestuurlijke-alias-van',
+      page: { size: 100 } //arbitrary number, later we will make sure there is previous last. (also like this in the plugin)
+    };
+    const aanwezigen = yield this.store.query('mandataris', queryParams);
+    this.aanwezigen = aanwezigen.sortBy('isBestuurlijkeAliasVan.achternaam');
   }
 
   @task

--- a/app/components/meeting-form.hbs
+++ b/app/components/meeting-form.hbs
@@ -66,10 +66,10 @@
         <a href="#sectionFour" class="au-c-link au-c-link--secondary">
           {{t "meetingForm.fourthSectionTitle"}}
         </a>
-        {{#if this.fetchBehandelingen.isRunning}}
+        {{#if this.fetchTreatments.isRunning}}
           <p class="loader"><span class="u-visually-hidden">{{t "participationList.loadingLoader"}}</span></p>
         {{/if}}
-        {{#if this.fetchBehandelingen.lastSuccessful}}
+        {{#if this.fetchTreatments.lastSuccessful}}
           <ul class="au-c-list-divider">
             {{#each this.behandelingen as |behandeling|}}
               <li class="au-c-list-divider__item">
@@ -125,7 +125,7 @@
             {{t "meetingForm.thirdSectionNotFilledWarning"}}
           </span>
         </AuHeading>
-        <ManageAgendaZitting @zitting={{@zitting}} @onChange={{perform this.fetchBehandelingen}}> </ManageAgendaZitting>
+        <ManageAgendaZitting @zitting={{@zitting}} @onChange={{perform this.fetchTreatments}}> </ManageAgendaZitting>
         <AuHeading id="sectionFour" @level="2" @skin="3" class="au-c-onboarding-wrapper">
           {{t "meetingForm.fourthSectionTitle"}}
           <span class="au-c-onboarding">
@@ -133,13 +133,13 @@
             {{t "meetingForm.fourthSectionNotFilledWarning"}}
           </span>
         </AuHeading>
-        {{#if this.fetchBehandelingen.isRunning}}
+        {{#if this.fetchTreatments.isRunning}}
           <p class="loader"><span class="u-visually-hidden">{{t "participationList.loadingLoader"}}</span></p>
         {{/if}}
-        {{#if this.fetchBehandelingen.lastSuccessful}}
+        {{#if this.fetchTreatments.lastSuccessful}}
           {{#each this.behandelingen as |behandeling|}}
             <div>
-              <BehandelingVanAgendapunt @behandeling={{behandeling}} @bestuursorgaan={{this.zitting.bestuursorgaan}}/>
+              <BehandelingVanAgendapunt @aanwezigenBijStart={{this.aanwezigenBijStart}} @behandeling={{behandeling}} @bestuursorgaan={{this.zitting.bestuursorgaan}}/>
             </div>
           {{/each}}
         {{/if}}

--- a/app/components/meeting-form.hbs
+++ b/app/components/meeting-form.hbs
@@ -102,46 +102,54 @@
       <Zitting::ManageZittingsdata
         @zitting={{@zitting}}
         @onCreate={{@onCreateMeeting}}
+        @onChange={{this.meetingInfoUpdate}}
       />
+      {{#if this.bestuursorgaan}}
+        {{#if this.loadData.isRunning}}
+          <p>{{t "participationList.loadingTitle"}}</p>
+          <p class="loader"><span class="u-visually-hidden">{{t "participationList.loadingTitle"}}</span></p>
+        {{else}}
+          <AuHeading id="sectionTwo" @level="2" @skin="3" class="au-c-onboarding-wrapper">
+            {{t "meetingForm.secondSectionTitle"}}
+            <span class="au-c-onboarding">
+              <AuIcon @icon="info-circle"/>
+              {{t "meetingForm.secondSectionNotFilledWarning"}}
+            </span>
+          </AuHeading>
+          <ParticipationList
+            @voorzitter={{this.voorzitter}}
+            @secretaris={{this.secretaris}}
+            @bestuursorgaan={{this.bestuursorgaan}}
+            @possibleParticipants={{this.possibleParticipants}}
+            @aanwezigenBijStart={{this.aanwezigenBijStart}}
+            @onSave={{this.saveParticipationList}}
+          />
 
-      {{#if this.zitting.bestuursorgaan}}
-
-        <AuHeading id="sectionTwo" @level="2" @skin="3" class="au-c-onboarding-wrapper">
-          {{t "meetingForm.secondSectionTitle"}}
-          <span class="au-c-onboarding">
-            <AuIcon @icon="info-circle"/>
-            {{t "meetingForm.secondSectionNotFilledWarning"}}
-          </span>
-        </AuHeading>
-        <ParticipationList
-          @zitting={{@zitting}}
-          @onSave={{this.saveParticipationList}}
-        />
-
-        <AuHeading id="sectionThree" @level="2" @skin="3" class="au-c-onboarding-wrapper">
-          {{t "meetingForm.thirdSectionTitle"}}
-          <span class="au-c-onboarding">
-            <AuIcon @icon="info-circle"/>
-            {{t "meetingForm.thirdSectionNotFilledWarning"}}
-          </span>
-        </AuHeading>
-        <ManageAgendaZitting @zitting={{@zitting}} @onChange={{perform this.fetchTreatments}}> </ManageAgendaZitting>
-        <AuHeading id="sectionFour" @level="2" @skin="3" class="au-c-onboarding-wrapper">
-          {{t "meetingForm.fourthSectionTitle"}}
-          <span class="au-c-onboarding">
-            <AuIcon @icon="info-circle"/>
-            {{t "meetingForm.fourthSectionNotFilledWarning"}}
-          </span>
-        </AuHeading>
-        {{#if this.fetchTreatments.isRunning}}
-          <p class="loader"><span class="u-visually-hidden">{{t "participationList.loadingLoader"}}</span></p>
-        {{/if}}
-        {{#if this.fetchTreatments.lastSuccessful}}
-          {{#each this.behandelingen as |behandeling|}}
-            <div>
-              <BehandelingVanAgendapunt @aanwezigenBijStart={{this.aanwezigenBijStart}} @behandeling={{behandeling}} @bestuursorgaan={{this.zitting.bestuursorgaan}}/>
-            </div>
-          {{/each}}
+          <AuHeading id="sectionThree" @level="2" @skin="3" class="au-c-onboarding-wrapper">
+            {{t "meetingForm.thirdSectionTitle"}}
+            <span class="au-c-onboarding">
+              <AuIcon @icon="info-circle"/>
+              {{t "meetingForm.thirdSectionNotFilledWarning"}}
+            </span>
+          </AuHeading>
+          <ManageAgendaZitting @zitting={{@zitting}} @onChange={{perform this.fetchTreatments}}> </ManageAgendaZitting>
+          <AuHeading id="sectionFour" @level="2" @skin="3" class="au-c-onboarding-wrapper">
+            {{t "meetingForm.fourthSectionTitle"}}
+            <span class="au-c-onboarding">
+              <AuIcon @icon="info-circle"/>
+              {{t "meetingForm.fourthSectionNotFilledWarning"}}
+            </span>
+          </AuHeading>
+          {{#if this.fetchTreatments.isRunning}}
+            <p class="loader"><span class="u-visually-hidden">{{t "participationList.loadingLoader"}}</span></p>
+          {{/if}}
+          {{#if this.fetchTreatments.lastSuccessful}}
+            {{#each this.behandelingen as |behandeling|}}
+              <div>
+                <BehandelingVanAgendapunt @possibleParticipants={{this.possibleParticipants}} @behandeling={{behandeling}} @bestuursorgaan={{this.zitting.bestuursorgaan}}/>
+              </div>
+            {{/each}}
+          {{/if}}
         {{/if}}
       {{else}}
         <AuHelpText @skin="secondary">

--- a/app/components/participation-list.hbs
+++ b/app/components/participation-list.hbs
@@ -1,13 +1,8 @@
-{{#if this.bestuursorgaan}}
-  <div class="au-c-meeting-chrome-card">
-    {{#if this.dataLoading}}
-      <p>{{t "participationList.loadingTitle"}}</p>
-      <p class="loader"><span class="u-visually-hidden">{{t "participationList.loadingLoader"}}</span></p>
-    {{else}}
-      {{#if hasParticipationInfo}}
+<div class="au-c-meeting-chrome-card">
+    {{#if hasParticipationInfo}}
       <ul class="au-c-list-divider">
-          <li class="au-c-list-divider__item">
-            {{t "participationList.voorzitterLabel"}} <strong>{{this.voorzitter.isBestuurlijkeAliasVan.fullName}}</strong>
+        <li class="au-c-list-divider__item">
+          {{t "participationList.voorzitterLabel"}} <strong>{{this.voorzitter.isBestuurlijkeAliasVan.fullName}}</strong>
           </li>
 
           <li class="au-c-list-divider__item">
@@ -30,7 +25,7 @@
               <strong>{{mandataris.isBestuurlijkeAliasVan.fullName}}</strong>,
             {{/each}}
           </li>
-        </ul>
+      </ul>
       {{/if}}
       <AuButton
         @width="block"
@@ -44,14 +39,12 @@
       </AuButton>
 
       <ParticipationList::Modal
-        @bestuursorgaan={{this.bestuursorgaan}}
         @voorzitter={{this.voorzitter}}
         @secretaris={{this.secretaris}}
         @show={{this.popup}}
         @togglePopup={{this.togglePopup}}
-        @onSave={{this.onSave}}
+        @onSave={{@onSave}}
         @aanwezigenBijStart={{this.aanwezigenBijStart}}
+        @possibleParticipants={{this.possibleParticipants}}
       />
-    {{/if}}
-  </div>
-{{/if}}
+</div>

--- a/app/components/participation-list.js
+++ b/app/components/participation-list.js
@@ -4,61 +4,40 @@ import { action } from "@ember/object";
 import { inject as service } from '@ember/service';
 import { task } from 'ember-concurrency-decorators';
 import { get } from '@ember/object';
+import { isEmpty } from '@ember/utils';
 
 export default class ParticipationListComponent extends Component {
   @tracked popup = false;
   @tracked info;
-  @tracked mandataris;
   @tracked voorzitter;
   @tracked secretaris;
   @tracked aanwezigenBijStart;
-  @tracked bestuursorgaan;
-  @tracked mandatees;
+  @tracked possibleParticipants;
 
   @service store;
 
   constructor() {
     super(...arguments);
-    this.voorzitter = this.args.zitting.voorzitter;
-    this.secretaris = this.args.zitting.secretaris;
-    this.aanwezigenBijStart = this.args.zitting.aanwezigenBijStart;
-    this.bestuursorgaan = this.args.zitting.bestuursorgaan;
-    this.loadData.perform();
-  }
-
-  get dataLoading() {
-    return this.loadData.isRunning || get(this.voorzitter, 'isLoading') || get(this.secretaris,'isLoading') || get(this.aanwezigenBijStart, 'isLoading') || get(this.bestuursorgaan, 'isLoading');
-  }
-
-  @task
-  *loadData() {
-    yield this.fetchMandatees();
-  }
-
-  async fetchMandatees() {
-    const bestuursorgaanUri = this.bestuursorgaan && this.bestuursorgaan.get('uri');
-    const today=(new Date).toISOString().split('T')[0];
-    let queryParams = {
-      'filter[bekleedt][bevat-in][:uri:]': bestuursorgaanUri,
-      include: 'is-bestuurlijke-alias-van',
-     'filter[:gt:einde]': today,
-      page: { size: 100 } //arbitrary number, later we will make sure there is previous last. (also like this in the plugin)
-    };
-    this.mandatees = await this.store.query('mandataris', queryParams);
+    this.voorzitter = this.args.voorzitter;
+    this.secretaris = this.args.secretaris;
+    console.log(this.args.aanwezigenBijStart);
+    this.aanwezigenBijStart = this.args.aanwezigenBijStart ? this.args.aanwezigenBijStart : new Array();
+    this.possibleParticipants = this.args.possibleParticipants ? this.args.possibleParticipants : new Array();;
   }
 
   // this is only called after loading has finished
   get hasParticipationInfo() {
-    return Boolean(this.aanwezigenBijStart.length > 0 || this.voorzitter.id || this.secretaris.id);
+    return Boolean(this.aanwezigenBijStart.length > 0 || this.voorzitter || this.secretaris);
   }
+
   get mandateesPresent(){
     const sorted=this.aanwezigenBijStart.sortBy('isBestuurlijkeAliasVan.achternaam');
     return sorted;
   }
   get mandateesNotPresent() {
-    if(this.aanwezigenBijStart && this.mandatees) {
+    if(this.aanwezigenBijStart.length > 0 && this.possibleParticipants) {
       const aanwezigenUris = this.aanwezigenBijStart.map((mandataris) => mandataris.uri);
-      const notPresent = this.mandatees.filter((mandataris) => !aanwezigenUris.includes(mandataris.uri));
+      const notPresent = this.possibleParticipants.filter((mandataris) => !aanwezigenUris.includes(mandataris.uri));
       const sorted=notPresent.sortBy('isBestuurlijkeAliasVan.achternaam');
       return sorted;
     }
@@ -71,10 +50,5 @@ export default class ParticipationListComponent extends Component {
       e.preventDefault();
     }
     this.popup = !this.popup;
-  }
-
-  @action
-  onSave(info) {
-    this.args.onSave(info);
   }
 }

--- a/app/components/participation-list.js
+++ b/app/components/participation-list.js
@@ -11,8 +11,6 @@ export default class ParticipationListComponent extends Component {
   @tracked info;
   @tracked voorzitter;
   @tracked secretaris;
-  @tracked aanwezigenBijStart;
-  @tracked possibleParticipants;
 
   @service store;
 
@@ -20,9 +18,12 @@ export default class ParticipationListComponent extends Component {
     super(...arguments);
     this.voorzitter = this.args.voorzitter;
     this.secretaris = this.args.secretaris;
-    console.log(this.args.aanwezigenBijStart);
-    this.aanwezigenBijStart = this.args.aanwezigenBijStart ? this.args.aanwezigenBijStart : new Array();
-    this.possibleParticipants = this.args.possibleParticipants ? this.args.possibleParticipants : new Array();;
+  }
+  get aanwezigenBijStart() {
+    return this.args.aanwezigenBijStart ?? [];
+  }
+  get possibleParticipants() {
+    return this.args.possibleParticipants ?? [];
   }
 
   // this is only called after loading has finished

--- a/app/components/participation-list/mandatarissen-table.hbs
+++ b/app/components/participation-list/mandatarissen-table.hbs
@@ -14,7 +14,7 @@
     </tr>
   </thead>
   <tbody>
-    {{#each @mandataris as |mandataris|}}
+    {{#each @possibleParticipants as |mandataris|}}
       <ParticipationList::MandatarisRow
         @mandataris={{mandataris}}
         @selectedMandatees={{this.selectedMandatees}}

--- a/app/components/participation-list/mandatarissen-table.js
+++ b/app/components/participation-list/mandatarissen-table.js
@@ -7,14 +7,14 @@ export default class ParticipationListMandatariesTableComponent extends Componen
     super(...arguments);
     this.generateSelected();
   }
-  @action 
+  @action
   generateSelected() {
     if(this.args.selected && this.args.selected.length) {
       this.args.selected.forEach((mandataris) => {
         this.selectedMandatees[mandataris.uri] = mandataris;
       });
     } else {
-      this.args.mandataris.forEach((mandataris) => {
+      this.args.possibleParticipants.forEach((mandataris) => {
         this.selectedMandatees[mandataris.uri] = mandataris;
       });
     }

--- a/app/components/participation-list/modal.hbs
+++ b/app/components/participation-list/modal.hbs
@@ -1,5 +1,5 @@
 {{#if @show}}
-  <div {{did-insert (perform this.fetchData)}}>
+  <div>
     {{#wu-modal
       title="Beheer aanwezigen"
       dialog-class="modal-dialog--wide modal-dialog--sectioned"
@@ -32,7 +32,7 @@
             <div>
               <AuLabel>{{t "participationListModal.presentLabel"}}</AuLabel>
               <ParticipationList::MandatarissenTable
-                @mandataris={{this.mandataris}}
+                @possibleParticipants={{@possibleParticipants}}
                 @selected={{@aanwezigenBijStart}}
                 @onChange={{this.updateMandatarisTable}}
               />

--- a/app/components/participation-list/modal.js
+++ b/app/components/participation-list/modal.js
@@ -13,37 +13,16 @@ export default class ParticipationListModalComponent extends Component {
 
   constructor() {
     super(...arguments);
-    this.initializeState();
-  }
-  initializeState() {
     this.voorzitter = this.args.voorzitter;
     this.secretaris = this.args.secretaris;
-
   }
 
-  @task
-  *fetchData() {
-    //kinda wierd depends on pc date can be spoofed
-    //not 100% sure this works
-    const today=(new Date).toISOString().split('T')[0]
-
-    let queryParams = {
-      sort: 'is-bestuurlijke-alias-van.achternaam',
-      'filter[bekleedt][bevat-in][:uri:]': this.args.bestuursorgaan.get('uri'),
-      'filter[:gt:einde]': today,
-      page: { size: 100 } //arbitrary number, later we will make sure there is previous last. (also like this in the plugin)
-    };
-    const mandataris = yield this.store.query('mandataris', queryParams);
-
-    this.mandataris = mandataris;
-  }
 
   @action
   togglePopup(e) {
     if(e) {
       e.preventDefault();
     }
-    this.initializeState();
     this.args.togglePopup(e);
   }
   @action

--- a/app/components/treatment/participation.hbs
+++ b/app/components/treatment/participation.hbs
@@ -1,8 +1,8 @@
 <div class="au-c-meeting-chrome-card">
   <ParticipationList::Modal
     @show={{this.showParticipationModal}}
-    @aanwezigenBijStart={{this.behandeling.aanwezigen}}
-    @bestuursorgaan={{@bestuursorgaan}}
+    @aanwezigenBijStart={{@aanwezigen}}
+    @possibleParticipants={{@possibleParticipants}}
     @onSave={{this.saveParticipants}}
     @togglePopup={{this.toggleModal}}
     @voorzitter={{this.behandeling.voorzitter}}

--- a/app/components/zitting/manage-zittingsdata.js
+++ b/app/components/zitting/manage-zittingsdata.js
@@ -78,6 +78,7 @@ export default class ZittingManageZittingsdataComponent extends Component {
       await this.zitting.save();
       this.showModal = !this.showModal;
     }
+    this.args.onChange(this.zitting);
   }
 
   @action

--- a/app/models/mandataris.js
+++ b/app/models/mandataris.js
@@ -12,6 +12,8 @@ export default Model.extend({
   tijdelijkeVervangingen: hasMany('mandataris', {inverse: null }),
   datumEedaflegging: attr('datetime'),
   datumMinistrieelBesluit: attr('datetime'),
+  aanwezigBijBehandeling: hasMany('behandeling-van-agendapunt'),
+  aanwezigBijZitting: hasMany('zitting'),
 
   rdfaBindings: { // eslint-disable-line ember/avoid-leaking-state-in-ember-objects
     class: "http://data.vlaanderen.be/ns/mandaat#Mandataris",

--- a/app/routes/meetings/edit.js
+++ b/app/routes/meetings/edit.js
@@ -4,9 +4,8 @@ export default class MeetingsEditRoute extends Route {
   async model(params) {
     const zitting = await this.store.findRecord("zitting", params.id, {
       include:
-        "aanwezigen-bij-start,agendapunten.behandeling,secretaris,voorzitter",
+        "bestuursorgaan,secretaris,voorzitter",
     });
-    zitting.agendapunten = (await zitting.agendapunten).sortBy("position");
     return zitting;
   }
 }


### PR DESCRIPTION
keep a store of potential participants on the top meeting-form component and
pass that down to where it's needed. I realized later this could also have been
a service, but I still think the approach works.

while doing this optimization I also refactored the loading of participants to
the treatment of an agendapoint, as this previously did not take pagination into
account. It now fetches the first 100 participants, which should suffice.