### PR TITLE
Bugfix/aanwezigen filter

### DIFF
--- a/app/components/behandeling-van-agendapunt.hbs
+++ b/app/components/behandeling-van-agendapunt.hbs
@@ -18,6 +18,7 @@
       @onSave={{this.saveParticipants}}
       @bestuursorgaan={{this.bestuursorgaan}}
       @modalTitle={{t "behandelingVanAgendapunten.participationListButton"}}
+      @meeting={{@meeting}}
    />
   {{/if}}
   <div class="au-u-padding-bottom-large">

--- a/app/components/meeting-form.hbs
+++ b/app/components/meeting-form.hbs
@@ -148,7 +148,12 @@
           {{#if this.fetchTreatments.lastSuccessful}}
             {{#each this.behandelingen as |behandeling|}}
               <div>
-                <BehandelingVanAgendapunt @possibleParticipants={{this.possibleParticipants}} @behandeling={{behandeling}} @bestuursorgaan={{this.zitting.bestuursorgaan}}/>
+                <BehandelingVanAgendapunt
+                  @possibleParticipants={{this.possibleParticipants}}
+                  @behandeling={{behandeling}}
+                  @bestuursorgaan={{this.zitting.bestuursorgaan}}
+                  @meeting={{this.zitting}}
+                />
               </div>
             {{/each}}
           {{/if}}

--- a/app/components/meeting-form.hbs
+++ b/app/components/meeting-form.hbs
@@ -123,6 +123,7 @@
             @aanwezigenBijStart={{this.aanwezigenBijStart}}
             @onSave={{this.saveParticipationList}}
             @bestuursorgaan={{this.bestuursorgaan}}
+            @meeting={{this.zitting}}
             @modalTitle={{t "participationList.openModalButton"}}
           />
 

--- a/app/components/meeting-form.js
+++ b/app/components/meeting-form.js
@@ -69,9 +69,7 @@ export default class MeetingForm extends Component {
       page: { size: 100 } //arbitrary number, later we will make sure there is previous last. (also like this in the plugin)
     };
     const mandatees = yield this.store.query('mandataris', queryParams);
-    this.aanwezigenBijStart = Array.from(
-      mandatees.filter( (mandatee) => this.isValidMandateeForMeeting(mandatee) )
-    );
+    this.aanwezigenBijStart = mandatees;
   }
 
   @task

--- a/app/components/meeting-form.js
+++ b/app/components/meeting-form.js
@@ -28,8 +28,22 @@ export default class MeetingForm extends Component {
     this.zitting = this.args.zitting;
     this.loadData.perform();
   }
+
   get isComplete() {
     return this.loadData.lastSuccessful;
+  }
+
+  /**
+   * checks whether a mandatee can be a member of the meeting
+   * this means the meeting date should be between the mandatee's start and end
+   * the mandatee needs to have a "acting" (waarnemend) or "effective" (effectief) status
+   */
+  isValidMandateeForMeeting(mandatee) {
+    const startOfMeeting = this.zitting.gestartOpTijdstip ? this.zitting.gestartOpTijdstip : this.zitting.geplandeStart;
+    const hasValidStartDate = mandatee.start <= startOfMeeting;
+    const hasValidEndDate = isEmpty(mandatee.einde) || mandatee.einde > startOfMeeting;
+    const hasValidStatus = [statusEffectief, statusWaarnemend].includes(mandatee.get("status.id"));
+    return hasValidStartDate && hasValidEndDate && hasValidStatus;
   }
 
   @task
@@ -56,8 +70,7 @@ export default class MeetingForm extends Component {
     };
     const mandatees = yield this.store.query('mandataris', queryParams);
     this.aanwezigenBijStart = Array.from(
-      // TODO: should this not filter on meeting date?
-      mandatees.filter( (mandatee) => (isEmpty(mandatee.einde) || mandatee.einde > new Date()) && [statusEffectief, statusWaarnemend].includes(mandatee.get("status.id")))
+      mandatees.filter( (mandatee) => this.isValidMandateeForMeeting(mandatee) )
     );
   }
 
@@ -74,8 +87,7 @@ export default class MeetingForm extends Component {
     };
     const mandatees = yield this.store.query('mandataris', queryParams);
     this.possibleParticipants = Array.from(
-      // TODO: should this not filter on meeting date?
-      mandatees.filter( (mandatee) => (isEmpty(mandatee.einde) || mandatee.einde > new Date()) && [statusEffectief, statusWaarnemend].includes(mandatee.get("status.id")))
+      mandatees.filter( (mandatee) => this.isValidMandateeForMeeting(mandatee) )
     );
   }
 

--- a/app/components/meeting-form.js
+++ b/app/components/meeting-form.js
@@ -3,10 +3,7 @@ import { action } from "@ember/object";
 import { tracked } from "@glimmer/tracking";
 import { task } from "ember-concurrency-decorators";
 import { inject as service } from "@ember/service";
-import { isEmpty } from '@ember/utils';
-
-const statusEffectief = '21063a5b-912c-4241-841c-cc7fb3c73e75';
-const statusWaarnemend = 'e1ca6edd-55e1-4288-92a5-53f4cf71946a';
+import isValidMandateeForMeeting from 'frontend-gelinkt-notuleren/utils/is-valid-mandatee-for-meeting';
 
 /** @typedef {import("../models/agendapunt").default[]} Agendapunt */
 
@@ -31,19 +28,6 @@ export default class MeetingForm extends Component {
 
   get isComplete() {
     return this.loadData.lastSuccessful;
-  }
-
-  /**
-   * checks whether a mandatee can be a member of the meeting
-   * this means the meeting date should be between the mandatee's start and end
-   * the mandatee needs to have a "acting" (waarnemend) or "effective" (effectief) status
-   */
-  isValidMandateeForMeeting(mandatee) {
-    const startOfMeeting = this.zitting.gestartOpTijdstip ? this.zitting.gestartOpTijdstip : this.zitting.geplandeStart;
-    const hasValidStartDate = mandatee.start <= startOfMeeting;
-    const hasValidEndDate = isEmpty(mandatee.einde) || mandatee.einde > startOfMeeting;
-    const hasValidStatus = [statusEffectief, statusWaarnemend].includes(mandatee.get("status.id"));
-    return hasValidStartDate && hasValidEndDate && hasValidStatus;
   }
 
   @task
@@ -85,7 +69,7 @@ export default class MeetingForm extends Component {
     };
     const mandatees = yield this.store.query('mandataris', queryParams);
     this.possibleParticipants = Array.from(
-      mandatees.filter( (mandatee) => this.isValidMandateeForMeeting(mandatee) )
+      mandatees.filter( (mandatee) => isValidMandateeForMeeting(mandatee, this.zitting) )
     );
   }
 

--- a/app/components/participation-list.hbs
+++ b/app/components/participation-list.hbs
@@ -47,5 +47,6 @@
         @bestuursorgaan={{@bestuursorgaan}}
         @aanwezigenBijStart={{this.aanwezigenBijStart}}
         @possibleParticipants={{this.possibleParticipants}}
+        @meeting={{@meeting}}
       />
 </div>

--- a/app/components/participation-list/mandataris-selector.js
+++ b/app/components/participation-list/mandataris-selector.js
@@ -3,6 +3,7 @@ import { action } from "@ember/object";
 import { timeout } from 'ember-concurrency';
 import {task} from 'ember-concurrency-decorators';
 import { inject as service } from '@ember/service';
+import isValidMandateeForMeeting from 'frontend-gelinkt-notuleren/utils/is-valid-mandatee-for-meeting';
 
 export default class ParticipationListMandatarisSelectorComponent extends Component {
   @service store;
@@ -19,6 +20,7 @@ export default class ParticipationListMandatarisSelectorComponent extends Compon
       'filter[is-bestuurlijke-alias-van][achternaam]': searchData,
       page: { size: 100 }
     };
-    return yield this.store.query('mandataris', queryParams);
+    const mandatees = yield this.store.query('mandataris', queryParams);
+    return mandatees.filter((mandatee) => isValidMandateeForMeeting(mandatee, this.args.meeting));
   }
 }

--- a/app/components/participation-list/mandataris-selector.js
+++ b/app/components/participation-list/mandataris-selector.js
@@ -16,6 +16,7 @@ export default class ParticipationListMandatarisSelectorComponent extends Compon
     yield timeout(300);
     let queryParams = {
       sort: 'is-bestuurlijke-alias-van.achternaam',
+      include: 'status',
       'filter[bekleedt][bevat-in][:uri:]': this.args.bestuursorgaan.get('uri'),
       'filter[is-bestuurlijke-alias-van][achternaam]': searchData,
       page: { size: 100 }

--- a/app/components/participation-list/modal.hbs
+++ b/app/components/participation-list/modal.hbs
@@ -17,6 +17,7 @@
               <ParticipationList::MandatarisSelector
                 @onSelect={{this.selectVoorzitter}}
                 @mandataris={{this.voorzitter}}
+                @meeting={{@meeting}}
                 @bestuursorgaan={{@bestuursorgaan}}
               />
             </div>

--- a/app/components/treatment/voting/modal.js
+++ b/app/components/treatment/voting/modal.js
@@ -63,10 +63,7 @@ export default class TreatmentVotingModalComponent extends Component {
         "filter[:id:]": this.args.behandeling.id,
         include: "aanwezigen.bekleedt.bestuursfunctie"
       });
-      const participants = richTreatment.firstObject.aanwezigen.filter(
-        (mandatee) =>
-          mandatee.bekleedt.get("bestuursfunctie").get("uri") === COUNCIL_MEMBER_URI
-      );
+      const participants = richTreatment.firstObject.aanwezigen;
 
       const stemmingToEdit = this.store.createRecord("stemming", {
         onderwerp: "",

--- a/app/models/bestuursorgaan-classificatie-code.js
+++ b/app/models/bestuursorgaan-classificatie-code.js
@@ -11,5 +11,6 @@ export default Model.extend({
   label: attr(),
   scopeNote: attr(),
   standaardType: hasMany('bestuursfunctie-code', { inverse: 'standaardTypeVan' }),
+  isClassificatieVan: hasMany('bestuursorgaan', { inverse: null}),
   uri: attr()
 });

--- a/app/models/mandataris.js
+++ b/app/models/mandataris.js
@@ -14,6 +14,7 @@ export default Model.extend({
   datumMinistrieelBesluit: attr('datetime'),
   aanwezigBijBehandeling: hasMany('behandeling-van-agendapunt'),
   aanwezigBijZitting: hasMany('zitting'),
+  status: belongsTo('mandataris-status-code', {inverse: null}),
 
   rdfaBindings: { // eslint-disable-line ember/avoid-leaking-state-in-ember-objects
     class: "http://data.vlaanderen.be/ns/mandaat#Mandataris",

--- a/app/utils/is-valid-mandatee-for-meeting.js
+++ b/app/utils/is-valid-mandatee-for-meeting.js
@@ -1,0 +1,17 @@
+import { isEmpty } from '@ember/utils';
+const statusEffectief = '21063a5b-912c-4241-841c-cc7fb3c73e75';
+const statusWaarnemend = 'e1ca6edd-55e1-4288-92a5-53f4cf71946a';
+
+
+/**
+ * checks whether a mandatee can be a member of the meeting
+ * this means the meeting date should be between the mandatee's start and end
+ * the mandatee needs to have a "acting" (waarnemend) or "effective" (effectief) status
+ */
+export default function isValidMandateeForMeeting(mandatee, meeting) {
+  const startOfMeeting = meeting.gestartOpTijdstip ? meeting.gestartOpTijdstip : meeting.geplandeStart;
+  const hasValidStartDate = mandatee.start <= startOfMeeting;
+  const hasValidEndDate = isEmpty(mandatee.einde) || mandatee.einde > startOfMeeting;
+  const hasValidStatus = [statusEffectief, statusWaarnemend].includes(mandatee.get("status.id"));
+  return hasValidStartDate && hasValidEndDate && hasValidStatus;
+}

--- a/tests/unit/utils/is-valid-mandatee-for-meeting-test.js
+++ b/tests/unit/utils/is-valid-mandatee-for-meeting-test.js
@@ -1,0 +1,11 @@
+import isValidMandateeForMeeting from 'frontend-gelinkt-notuleren/utils/is-valid-mandatee-for-meeting';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | isValidMandateeForMeeting', function() {
+
+  // TODO: Replace this with your real tests.
+  test('it works', function(assert) {
+    let result = isValidMandateeForMeeting();
+    assert.ok(result);
+  });
+});


### PR DESCRIPTION
addresses https://binnenland.atlassian.net/browse/GN-2046 . 
It seems we already had the correct data to filter in our store and that was even used in the old "aanwezigen" plugin, but I guess somehow got lost during conversion to a regular ember component. 

This code assumes we have a <http://mu.semte.ch/vocabularies/ext/hasDefaultType> relationship on the "bestuursorgaan-classification-code" to specify which "bestuursfunctie-rol-code" should be used to filter for the "aanwezigen" relationship.

NOTE: The code needs to run against the latest development branch of app-gelinkt-notuleren as it relies on some inverse relationships that were added