### PR TITLE
Changing last successful by is idle should solve all the problems

### DIFF
--- a/app/controllers/meetings/publish/agenda.js
+++ b/app/controllers/meetings/publish/agenda.js
@@ -44,6 +44,14 @@ export default class MeetingsPublishAgendaController extends Controller {
     this.spoedeisendeAgenda = yield this.initializeAgenda.perform("spoedeisendeagenda");
   }
 
+  @task
+  * reloadAgendas() {
+    this.ontwerpAgenda = yield this.initializeAgenda.perform("ontwerpagenda");
+    this.aanvullendeAgenda = yield this.initializeAgenda.perform("aanvullendeagenda");
+    this.spoedeisendeAgenda = yield this.initializeAgenda.perform("spoedeisendeagenda");
+  }
+
+
   /**
    * @this {MeetingsPublishAgendaController}
    * @param {string} type
@@ -89,7 +97,7 @@ export default class MeetingsPublishAgendaController extends Controller {
 
     const id = this.model.id;
     yield fetch(`/signing/agenda/sign/${agendaType}/${id}`, { method: 'POST'});
-    yield this.initializeAgendas.perform();
+    yield this.reloadAgendas.perform();
   }
 
   /**
@@ -100,6 +108,6 @@ export default class MeetingsPublishAgendaController extends Controller {
   * createPublishedResource(agendaType) {
     const id = this.model.id;
     yield fetch(`/signing/agenda/publish/${agendaType}/${id}`, { method: 'POST'});
-    yield this.initializeAgendas.perform();
+    yield this.reloadAgendas.perform();
   }
 }

--- a/app/controllers/meetings/publish/besluitenlijst.js
+++ b/app/controllers/meetings/publish/besluitenlijst.js
@@ -41,6 +41,15 @@ export default class MeetingsPublishBesluitenlijstController extends Controller 
     }
   }
 
+  @task
+  * reloadBesluitenLijst() {
+    const behandelings = yield this.store.query('versioned-besluiten-lijst',{
+      'filter[zitting][:id:]': this.model.id,
+      include: 'signed-resources,published-resource'
+    });
+    this.besluitenlijst = behandelings.firstObject;
+  }
+
 
   @task
   *createPrePublishedResource() {
@@ -54,13 +63,13 @@ export default class MeetingsPublishBesluitenlijstController extends Controller 
   * createSignedResource() {
     const id = this.model.id;
     yield fetch(`/signing/besluitenlijst/sign/${id}`, { method: 'POST' });
-    yield this.initializeBesluitenLijst.perform();
+    yield this.reloadBesluitenLijst.perform();
   }
 
   @task
   * createPublishedResource() {
     const id = this.model.id;
     yield fetch(`/signing/besluitenlijst/publish/${id}`, { method: 'POST' });
-    yield this.initializeBesluitenLijst.perform();
+    yield this.reloadBesluitenLijst.perform();
   }
 }

--- a/app/controllers/meetings/publish/notulen.js
+++ b/app/controllers/meetings/publish/notulen.js
@@ -42,6 +42,18 @@ export default class MeetingsPublishNotulenController extends Controller {
     this.behandelings = behandelings;
   }
 
+  @task
+  *reloadNotulen() {
+    const notulen = yield this.store.query('versioned-notulen',{
+      'filter[zitting][:id:]': this.model.id,
+      include: 'signed-resources,published-resource'
+    });
+    this.notulen = notulen.firstObject;
+    this.publicBehandelingUris = notulen.firstObject.publicBehandelingen;
+    const behandelings = yield this.fetchBehandelings.perform();
+    this.behandelings = behandelings;
+  }
+
 
   @task
   *createPrePublishedResource() {
@@ -63,7 +75,7 @@ export default class MeetingsPublishNotulenController extends Controller {
   * createSignedResource() {
     const id = this.model.id;
     yield fetch(`/signing/notulen/sign/${id}`, { method: 'POST' });
-    yield this.initializeNotulen.perform();
+    yield this.reloadNotulen.perform();
   }
 
   @task
@@ -77,7 +89,7 @@ export default class MeetingsPublishNotulenController extends Controller {
                   }),
                   method: 'POST'
                 });
-    yield this.initializeNotulen.perform();
+    yield this.reloadNotulen.perform();
 
   }
 

--- a/app/templates/meetings/publish/agenda.hbs
+++ b/app/templates/meetings/publish/agenda.hbs
@@ -1,5 +1,5 @@
 <div class="au-o-box">
-  {{#if this.initializeAgendas.lastSuccessful}}
+  {{#if this.initializeAgendas.isIdle}}
   <ul>
     <Signatures::Agenda::TimelineStep
       @name="ontwerpagenda"

--- a/app/templates/meetings/publish/besluitenlijst.hbs
+++ b/app/templates/meetings/publish/besluitenlijst.hbs
@@ -1,5 +1,5 @@
 <div class="au-o-box">
-  {{#if this.initializeBesluitenLijst.lastSuccessful}}
+  {{#if this.initializeBesluitenLijst.isIdle}}
   <ul>
     <Signatures::Besluitenlijst::TimelineStep
       @name="besluitenlijst"

--- a/app/templates/meetings/publish/notulen.hbs
+++ b/app/templates/meetings/publish/notulen.hbs
@@ -1,5 +1,5 @@
 <div class="au-o-box">
-  {{#if this.initializeNotulen.lastSuccessful}}
+  {{#if this.initializeNotulen.isIdle}}
   <ul>
     <Signatures::Notulen::TimelineStep
       @name="notulen"

--- a/app/templates/meetings/publish/uittreksels.hbs
+++ b/app/templates/meetings/publish/uittreksels.hbs
@@ -1,5 +1,5 @@
 <div class="au-o-box">
-  {{#if this.initializeUittreksels.lastSuccessful}}
+  {{#if this.initializeUittreksels.isIdle}}
   <ul>
     {{#each this.uittreksels as |uittreksel|}}
       <Signatures::Behandeling::TimelineStep


### PR DESCRIPTION
When changing to the publication page with a slow connection it shows the last published document for a few seconds (depends on how much time it takes to load the new prepublish document), if we try to publish this document errors happen.
By changing the .lastSuccessful attribute by .isIdle we solve this problem as we place the loading screen as soon as the user enters the screen