### PR TITLE
Quickfix for mandatee lists

### DIFF
--- a/app/styles/project/_c-editor-preview.scss
+++ b/app/styles/project/_c-editor-preview.scss
@@ -183,6 +183,28 @@
   }
 }
 
+// Quickfix for mandatee lists
+.au-c-editor-preview {
+  .behandeling,
+  .notulen {
+    // Mandatees: present
+    [property="ext:aanwezigenTable"] {
+      span {
+        display: inline-block;
+      }
+
+      [property="besluit:heeftAanwezige"] {
+        display: inline-block;
+      }
+
+      [property="besluit:heeftAanwezige"] + [property="besluit:heeftAanwezige"]:before,
+      p > span + span:before {
+        content: ",";
+      }
+    }
+  }
+}
+
 
 /* Notulen treatment (public/private)
  ========================================================================== */

--- a/app/styles/project/_c-editor-preview.scss
+++ b/app/styles/project/_c-editor-preview.scss
@@ -201,6 +201,11 @@
       p > span + span:before {
         content: ",";
       }
+
+      [property="besluit:heeftAanwezige"]:before,
+      p > span:before {
+        margin-left: -.4ex;
+      }
     }
   }
 }


### PR DESCRIPTION
Add a more compact styling for mandatee lists on the "uittreksels" and "notulen" publish view.