### PR TITLE
Feature/update appuniversum and design fixes

### DIFF
--- a/app/components/besluit-document-container.hbs
+++ b/app/components/besluit-document-container.hbs
@@ -1,17 +1,21 @@
 {{#if @saving}}
-  <div class="editor-container container-flex--scroll">
-    <div class="editor">
-      <div class="grid grid--align-center">
-        <div class="col--7-12">
-          <div class="au-c-rdfa-scanner say-content rdfa-annotations scanner">
-            <div class="scanner__text">
-              <div class="badge badge--l badge--initials">
-                <span class="loader"><span class="u-visually-hidden">Aan het verwerken</span></span>
-              </div>
-              <h3 class="h3">Bezig met opslaan</h3>
+  <div class="container-flex--contain">
+    <div class="au-c-rdfa-editor">
+      <div class="say-container say-container--sidebar-left">
+        <div class="say-container__main">
+          <div class="au-c-scanner">
+            <div class="au-c-scanner__text">
+              <AuLoader @size="small" />
+              <AuHelpText @size="large">Bezig met opslaan</AuHelpText>
             </div>
-            <span class="scanner__bar"></span>
-            {{html-safe @editor.htmlContent}}
+            <span class="au-c-scanner__bar"></span>
+          </div>
+          <div class="say-editor rdfa-annotations rdfa-annotations-highlight rdfa-annotations-hover">
+            <div class="say-editor__paper">
+              <div class="say-editor__inner say-content">
+                {{html-safe @editor.htmlContent}}
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/app/components/signatures/notulen/behandelingen-list.hbs
+++ b/app/components/signatures/notulen/behandelingen-list.hbs
@@ -10,7 +10,8 @@
           <p class="au-c-help-text au-c-help-text--normal">De titel en de openbaarheid van de behandeling worden wel gepubliceerd. Voor besluiten worden ook de titel van het besluit en de korte omschrijving gepubliceerd.</p>
         {{/if}}
       {{else}}
-        <WuSwitch @label=" Maak inhoud agendapunt publiek" @checked={{contains preview.behandeling @publicBehandelingUris}} @onClick={{action @toggle preview}} @class="checkbox--switch__wrapper" />
+        <AuToggleSwitch @label="Maak inhoud agendapunt publiek" @checked={{contains preview.behandeling @publicBehandelingUris}} @onChange={{action @toggle preview}} />
+        <AuHr />
         {{#if (contains preview.behandeling @publicBehandelingUris)}}
           <p><strong>Inhoud wordt gepubliceerd</strong></p>
           <p class="au-c-help-text au-c-help-text--normal">Alle informatie uit de behandeling van het agendapunt wordt gepubliceerd.</p>

--- a/app/styles/_deprecated.scss
+++ b/app/styles/_deprecated.scss
@@ -1,0 +1,113 @@
+/* ==========================================================================
+   #DEPRECATED
+   Styles that are flagged to be removed
+   ========================================================================== */
+
+/* spans in link lists replacing data */
+li.link-list__item > span {
+  display: block;
+  padding: 1rem 1.5rem;
+}
+
+li.link-list__item > button.button {
+  padding: 1rem 1.5rem;
+  background-color: transparent;
+  color: $primary-blue;
+  border: none;
+  height: auto;
+  display: block;
+  width: 100%;
+  text-align: left;
+  white-space: initial;
+  line-height: 1.4;
+
+  &:hover {
+    background-color: $blue-gray-lightest;
+  }
+
+  &.button--disabled {
+    color: $gray;
+    pointer-events: none;
+  }
+}
+
+/* ember data table red color override */
+.data-table-menu {
+  color: $gray-dark;
+}
+
+.badge--xs {
+  width: 2rem;
+  height: 2rem;
+  line-height: 0.9;
+  padding: 0.25rem 0.4rem;
+  text-align: center;
+  position: relative;
+  top: 0.6rem;
+
+  .vi {
+    font-size: 0.9rem;
+  }
+}
+
+.pill {
+  .badge--xs {
+    position: relative;
+    top: 0.3rem;
+    margin-right: 0.5rem;
+    line-height: 1.1;
+    width: 1.6rem;
+    height: 1.6rem;
+    padding: 0 0.35rem;
+  }
+}
+
+.data-table--white tr {
+  background-color: white !important;
+}
+
+.data-table--bordered {
+  border-left: 1px solid $gray-lighter;
+  border-right: 1px solid $gray-lighter;
+}
+
+/* temporary styling for import-export demo */
+.preview-list__image {
+  width: 16rem;
+  height: 20rem;
+  display: block;
+  box-shadow: 0 0 6px 0 #CBD2DA;
+  overflow: hidden;
+  margin-bottom: 1rem;
+}
+
+.preview-list__name {
+  line-height: 1;
+  margin-bottom: 2rem;
+}
+
+.description-data__value--placeholder {
+  font-style: italic;
+  // color: $gray;
+  font-weight: 300;
+  font-size: 1.4rem;
+}
+
+/* temporary fix for besluittypes dropdown */
+
+.ember-basic-dropdown-content.ember-power-select-dropdown.ember-basic-dropdown-content--below {
+  z-index: 9999;
+}
+
+/* temporary demo fixes for fracties */
+input.input-field {
+  padding-right: 0;
+}
+
+.data-table th .button {
+  font-weight: normal;
+}
+
+.modal-dialog.modal-dialog--sectioned .modal-dialog__content {
+  max-height: 75vh;
+}

--- a/app/styles/_deprecated.scss
+++ b/app/styles/_deprecated.scss
@@ -12,7 +12,7 @@ li.link-list__item > span {
 li.link-list__item > button.button {
   padding: 1rem 1.5rem;
   background-color: transparent;
-  color: $primary-blue;
+  color: $au-blue-700;
   border: none;
   height: auto;
   display: block;
@@ -22,18 +22,18 @@ li.link-list__item > button.button {
   line-height: 1.4;
 
   &:hover {
-    background-color: $blue-gray-lightest;
+    background-color: $au-gray-100;
   }
 
   &.button--disabled {
-    color: $gray;
+    color: $au-gray-600;
     pointer-events: none;
   }
 }
 
 /* ember data table red color override */
 .data-table-menu {
-  color: $gray-dark;
+  color: $au-gray-700;
 }
 
 .badge--xs {
@@ -67,8 +67,8 @@ li.link-list__item > button.button {
 }
 
 .data-table--bordered {
-  border-left: 1px solid $gray-lighter;
-  border-right: 1px solid $gray-lighter;
+  border-left: 1px solid $au-gray-200;
+  border-right: 1px solid $au-gray-200;
 }
 
 /* temporary styling for import-export demo */

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -4,162 +4,11 @@
    Some parts will be reused, but most of them will not.
    ========================================================================== */
 
-/* side nav problem remove once webuniversum updated*/
-
-.side-navigation__item a {
-  word-break: initial;
-}
-
-/* step styling override remove once webuniversum updated*/
-.step__header > .grid {
-  width: 100%;
-}
-
-.step__content p + p {
-  margin-top: 0;
-}
-
-/* spans in link lists replacing data */
-li.link-list__item > span {
-  display: block;
-  padding: 1rem 1.5rem;
-}
-
-li.link-list__item > button.button {
-  padding: 1rem 1.5rem;
-  background-color: transparent;
-  color: $primary-blue;
-  border: none;
-  height: auto;
-  display: block;
-  width: 100%;
-  text-align: left;
-  white-space: initial;
-  line-height: 1.4;
-
-  &:hover {
-    background-color: $blue-gray-lightest;
-  }
-
-  &.button--disabled {
-    color: $gray;
-    pointer-events: none;
-  }
-}
-
-/* ember data table red color override */
-.data-table-menu {
-  color: $gray-dark;
-}
-
-.badge--xs {
-  width: 2rem;
-  height: 2rem;
-  line-height: 0.9;
-  padding: 0.25rem 0.4rem;
-  text-align: center;
-  position: relative;
-  top: 0.6rem;
-
-  .vi {
-    font-size: 0.9rem;
-  }
-}
-
-.pill {
-  .badge--xs {
-    position: relative;
-    top: 0.3rem;
-    margin-right: 0.5rem;
-    line-height: 1.1;
-    width: 1.6rem;
-    height: 1.6rem;
-    padding: 0 0.35rem;
-  }
-}
-
-/** Collapsable document structure */
-.editor-container {
-  background-color: $blue-gray-lightest;
-
-  .grid {
-
-    .sidebar-wrapper {
-      position: relative;
-      transition: 0.5s;
-      left: 0;
-
-      &.col--3-12.col--collapsed {
-        left: calc(-25% + 50px);
-      }
-
-      .sidebar {
-        background-color: white;
-
-        .sidebar__header i {
-          cursor: pointer;
-        }
-      }
-    }
-  }
-}
-
-/* temporary fix for besluittypes dropdown */
-
-.ember-basic-dropdown-content.ember-power-select-dropdown.ember-basic-dropdown-content--below {
-  z-index: 9999;
-}
-
-/* temporary demo fixes for fracties */
-input.input-field {
-  padding-right: 0;
-}
-
-.data-table th .button {
-  font-weight: normal;
-}
-
-.modal-dialog.modal-dialog--sectioned .modal-dialog__content {
-  max-height: 75vh;
-}
-
-.data-table--white tr {
-  background-color: white !important;
-}
-
-.data-table--bordered {
-  border-left: 1px solid $gray-lighter;
-  border-right: 1px solid $gray-lighter;
-}
-
-
 // Temporary focus overrides for focus area's
 // @TODO: discuss where to put this or how to fix this focus style.
 #main:focus,
 #content:focus {
   outline: 0;
-}
-
-/* temporary styling for import-export demo */
-.preview-list__image {
-  width: 16rem;
-  height: 20rem;
-  display: block;
-  box-shadow: 0 0 6px 0 #CBD2DA;
-  overflow: hidden;
-  margin-bottom: 1rem;
-}
-
-.preview-list__name {
-  line-height: 1;
-  margin-bottom: 2rem;
-}
-
-.description-data__value--placeholder {
-  font-style: italic;
-  // color: $gray;
-  font-weight: 300;
-  font-size: 1.4rem;
 }
 
 // Fix ACMIDM login alerts/loading in header
@@ -209,16 +58,6 @@ input.input-field {
   }
 }
 
-.au-c-toolbar__group--column {
-  flex-direction: column;
-  align-items: flex-start !important;
-
-  > * + * {
-    margin-left: 0;
-    margin-top: $au-unit-tiny;
-  }
-}
-
 // Fix visited state on links acting as buttons
 // @TODO: port to ember-appuniversum component or convert link to button
 .au-c-button-link {
@@ -261,18 +100,6 @@ input.input-field {
   &:active {
     background-color: $au-button-contrast-active-color;
   }
-}
-
-// Ember a11y refocus
-#ember-a11y-refocus-nav-message {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
 }
 
 // Data table quick fix
@@ -398,41 +225,6 @@ input.input-field {
   .datepicker {
     display: block;
     width: 100%;
-  }
-}
-
-// Flow object @TODO: remove after appuniversum update
-.au-o-flow {
-  > * {
-    margin-bottom: 0;
-  }
-
-  > * + * {
-    margin-top: $au-unit;
-  }
-}
-
-.au-o-flow--tiny {
-  > * + * {
-    margin-top: $au-unit-tiny;
-  }
-}
-
-.au-o-flow--small {
-  > * + * {
-    margin-top: $au-unit-small;
-  }
-}
-
-.au-o-flow--large {
-  > * + * {
-    margin-top: $au-unit-large;
-  }
-}
-
-.au-o-flow--huge {
-  > * + * {
-    margin-top: $au-unit-huge;
   }
 }
 

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -11,7 +11,6 @@
 }
 
 /* step styling override remove once webuniversum updated*/
-
 .step__header > .grid {
   width: 100%;
 }
@@ -21,7 +20,6 @@
 }
 
 /* spans in link lists replacing data */
-
 li.link-list__item > span {
   display: block;
   padding: 1rem 1.5rem;
@@ -50,7 +48,6 @@ li.link-list__item > button.button {
 }
 
 /* ember data table red color override */
-
 .data-table-menu {
   color: $gray-dark;
 }
@@ -114,7 +111,6 @@ li.link-list__item > button.button {
 }
 
 /* temporary demo fixes for fracties */
-
 input.input-field {
   padding-right: 0;
 }
@@ -145,7 +141,6 @@ input.input-field {
 }
 
 /* temporary styling for import-export demo */
-
 .preview-list__image {
   width: 16rem;
   height: 20rem;
@@ -280,7 +275,6 @@ input.input-field {
   border: 0;
 }
 
-
 // Data table quick fix
 // @TODO port to appuniversum
 .au-c-data-table__header th {
@@ -398,9 +392,6 @@ input.input-field {
     margin-right: $au-unit-tiny;
   }
 }
-
-
-
 
 .au-c-datepicker {
   input,

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -370,3 +370,24 @@
     margin-right: $au-unit-small;
   }
 }
+
+// Temp fix for data table search component
+.input-field-icon-container--block.input-field-icon-container--left {
+  @extend .au-c-input-wrapper;
+
+  .input-field.input-field--block {
+    @extend .au-c-input;
+    @extend .au-c-input--block;
+  }
+
+  .input-field__icon {
+    position: absolute;
+    left: $au-unit-small;
+    top: $au-unit-tiny - .1rem;
+  }
+}
+
+// Fix missing u-hidden
+.u-hidden {
+  @extend .au-u-hidden-visually;
+}

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -145,4 +145,5 @@
 
 
 // TEMPORARY HACKS AND QUICKFIXES
+@import 'deprecated';
 @import 'shame';

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -19,9 +19,6 @@
  * SHAME: Temporary hacks and quickfixes
  */
 
-// WU VARIABLES (DEPRECATED)
-@import 'deprecated/colors';
-
 
 // VARIABLES
 @import "appuniversum/s-colors.scss";
@@ -58,15 +55,16 @@
 
 
 // WU COMPONENTS (DEPRECATED)
-@import 'ember-vo-webuniversum-data-table';
 @import 'ember-vo-webuniversum';
+@import 'ember-vo-webuniversum-data-table';
 @import 'ember-power-select';
 
 
+
 // COMPONENTS (DEPRECATED)
+@import 'deprecated/tasklist';
 @import 'deprecated/scrollto';
 @import 'deprecated/loading-events';
-@import 'deprecated/tasklist';
 @import 'deprecated/wizard';
 
 

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -114,11 +114,13 @@
 @import "ember-appuniversum/c-textarea";
 @import "ember-appuniversum/c-timepicker";
 @import "ember-appuniversum/c-toolbar";
-
+@import "ember-appuniversum/c-toggle-switch";
 
 
 // PLUGINS
 @import "ember-rdfa-editor";
+@import "ember-appuniversum/p-ember-power-select";
+@import "ember-appuniversum/p-duet-datepicker";
 @import "project/p-annotations";
 @import "project/p-annotations-content-nl";
 @import "project/p-annotations-content-en";
@@ -127,6 +129,7 @@
 
 // UTILITIES
 @import "appuniversum/u-align-text";
+@import "appuniversum/u-break-word";
 @import "appuniversum/u-headings";
 @import "appuniversum/u-hide";
 @import "appuniversum/u-font-family";

--- a/app/styles/deprecated/loading-events.scss
+++ b/app/styles/deprecated/loading-events.scss
@@ -7,6 +7,6 @@
   margin-top: 2rem;
 
   i.vi.vi-check {
-    color: $primary-blue;
+    color: $au-blue-700;
   }
 }

--- a/app/styles/deprecated/scrollto.scss
+++ b/app/styles/deprecated/scrollto.scss
@@ -9,15 +9,15 @@
 
 @keyframes bg{
   0%{
-    background: rgba($primary-yellow, 1);
+    background: rgba($au-yellow-300, 1);
   }
   20%{
-        background: rgba($primary-yellow, 0.8);
+        background: rgba($au-yellow-300, 0.8);
   }
   50%{
-        background: rgba($primary-yellow, 0.5);
+        background: rgba($au-yellow-300, 0.5);
   }
   100%{
-    background: rgba($primary-yellow, 0);
+    background: rgba($au-yellow-300, 0);
   }
 }

--- a/app/styles/deprecated/tasklist.scss
+++ b/app/styles/deprecated/tasklist.scss
@@ -8,12 +8,12 @@
   left: -50rem;
   top: 44px;
   bottom: 0;
-  background: $white;
+  background: $au-white;
   min-width: $au-unit-huge*3 + $au-unit;
   max-width: $au-unit-huge*3 + $au-unit;
   display: block;
   z-index: 9;
-  border-right: 1px solid $blue-gray-lighter;
+  border-right: 1px solid $au-gray-200;
   box-shadow: 0 1px 3px rgba($au-gray-900, .1), 0 4px 20px rgba($au-gray-900, .035), 0 1px 1px rgba($au-gray-900, .025);
   display: flex;
   flex-direction: column;

--- a/app/styles/project/_c-editor-preview.scss
+++ b/app/styles/project/_c-editor-preview.scss
@@ -279,7 +279,7 @@
     &:after {
       color: $au-blue-900;
       content: "Publieke informatie";
-      border-right: 4px solid $primary-blue;
+      border-right: 4px solid $au-blue-700;
     }
   }
 }
@@ -312,12 +312,12 @@
   div[property^="ext:insert"],
   [data-flagged-remove="complete"],
   [data-flagged-remove="complete"] {
-    background-color: $primary-yellow;
-    color: $black;
+    background-color: $au-yellow-300;
+    color: $au-gray-1000;
 
     &:after {
       content: "Informatie ontbreekt";
-      border-right: 4px solid $primary-yellow;
+      border-right: 4px solid $au-yellow-300;
     }
   }
 }
@@ -331,7 +331,7 @@
 .steps [data-flagged-remove="complete"]:before {
   content: "Leeg veld";
   font-weight: 300;
-  color: $gray;
+  color: $au-gray-600;
 }
 
 /* Style publishing animation
@@ -354,7 +354,7 @@
     top: 0;
     bottom: 0;
     position: absolute;
-    background-color: rgba($white, 0.7);
+    background-color: rgba($au-white, 0.7);
   }
 
   .au-c-loader {
@@ -394,7 +394,7 @@
 @keyframes move {
   0% {
     width: 0;
-    background-color: rgba($white, .5);
+    background-color: rgba($au-white, .5);
   }
   100% {
     width: 100%;
@@ -409,11 +409,11 @@
 
   // [data-flagged-remove="complete"]:before,
   // div[property^="ext:insert"] {
-  //   background-color: $primary-yellow;
+  //   background-color: $au-yellow-300;
   // }
 
   // &.editor__paper span.mark-highlight-manual {
-  //   background-color: $white;
+  //   background-color: $au-white;
   // }
 
   // * {
@@ -463,7 +463,7 @@
 
 // .published-example {
 //   position: relative;
-//   background-color: $white;
+//   background-color: $au-white;
 //   padding: 4rem 4rem 4rem 6rem;
 //   box-shadow: 0 2px 6px 0 $blue-gray-light;
 //   margin-bottom: 4rem;
@@ -483,7 +483,7 @@
 //     left: 6rem;
 //     right: 4rem;
 //     font-size: 1.6rem;
-//     color: $gray;
+//     color: $au-gray-600;
 //     z-index: 1011;
 //   }
 
@@ -496,11 +496,11 @@
 //   > [typeof="besluit:Zitting"] {
 //     > [property="besluit:heeftAgenda"] {
 //       display: block !important;
-//       background-color: $white;
+//       background-color: $au-white;
 //       position: relative;
 
 //       [property="besluit:geplandOpenbaar"] {
-//         color: $gray;
+//         color: $au-gray-600;
 //         font-size: 1.4rem;
 //       }
 
@@ -514,7 +514,7 @@
 //       [property="besluit:geplandOpenbaar"]:after,
 //       [property="dc:subject"] {
 //         display: inline-block;
-//         // color: rgba($gray, 0.7);
+//         // color: rgba($au-gray-600, 0.7);
 //         font-size: 1.4rem;
 //         text-transform: uppercase;
 //         letter-spacing: 1px;
@@ -565,14 +565,14 @@
 //       }
 
 //       > [property="besluit:openbaar"] {
-//         color: $gray;
+//         color: $au-gray-600;
 //         font-size: 1.4rem;
 //       }
 
 //       > [property="besluit:openbaar"]:after,
 //       > [property="dc:subject"] {
 //         display: inline-block;
-//         // color: rgba($gray, 0.7);
+//         // color: rgba($au-gray-600, 0.7);
 //         font-size: 1.4rem;
 //         text-transform: uppercase;
 //         letter-spacing: 1px;
@@ -601,7 +601,7 @@
 //         display: block;
 //         padding-bottom: 2rem;
 //         margin-bottom: 3rem;
-//         border-bottom: 1px solid $blue-gray-lighter;
+//         border-bottom: 1px solid $au-gray-100;
 //       }
 //     }
 //   }
@@ -611,7 +611,7 @@
 
 //   [property="besluit:geplandOpenbaar"],
 //   [property="besluit:openbaar"] {
-//     color: $gray;
+//     color: $au-gray-600;
 //     font-size: 1.4rem;
 //   }
 
@@ -626,7 +626,7 @@
 //   [property="besluit:openbaar"]:after,
 //   [property="dc:subject"] {
 //     display: inline-block;
-//     // color: rgba($gray, 0.7);
+//     // color: rgba($au-gray-600, 0.7);
 //     font-size: 1.4rem;
 //     text-transform: uppercase;
 //     letter-spacing: 1px;

--- a/app/styles/project/_c-editor-preview.scss
+++ b/app/styles/project/_c-editor-preview.scss
@@ -289,6 +289,10 @@
   padding: $au-unit;
   border-bottom: .1rem solid $au-gray-300;
   background-color: $au-gray-200;
+
+  .au-c-toggle-switch__toggle {
+    background-color: $au-gray-300;
+  }
 }
 
 .au-c-editor-preview-treatment__info--private {

--- a/app/styles/project/_c-editor-preview.scss
+++ b/app/styles/project/_c-editor-preview.scss
@@ -299,13 +299,6 @@
   }
 }
 
-/* Style hr's — remove this style once new version of webuniversum is added
- ========================================================================== */
-
-.step__content .u-hr {
-  border-color: $blue-gray-lighter;
-}
-
 
 /* Behandeling overview
  ========================================================================== */

--- a/app/styles/project/_c-editor-preview.scss
+++ b/app/styles/project/_c-editor-preview.scss
@@ -337,6 +337,74 @@
   color: $gray;
 }
 
+/* Style publishing animation
+ ========================================================================== */
+
+ .au-c-scanner {
+  position: absolute !important;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  backface-visibility: hidden;
+  pointer-events: none;
+
+  &:after {
+    content: "";
+    display: block;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    position: absolute;
+    background-color: rgba($white, 0.7);
+  }
+
+  .au-c-loader {
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .au-c-loader::before {
+    height: .4rem !important;
+  }
+}
+
+.au-c-scanner__text {
+  position: absolute;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  padding-top: $au-unit-huge;
+  text-align: center;
+  z-index: 10;
+}
+
+.au-c-scanner__bar {
+  position: absolute;
+  left: 0;
+  top: 0;
+  height: 100%;
+  background-color: $au-yellow-300;
+  z-index: 1;
+  animation: move 3s cubic-bezier(0.15, 0.44, 0.76, 0.64);
+  animation-iteration-count: infinite;
+  border-right: 1rem $au-yellow-300 solid;
+  margin-top: 0;
+}
+
+@keyframes move {
+  0% {
+    width: 0;
+    background-color: rgba($white, .5);
+  }
+  100% {
+    width: 100%;
+    background-color: rgba($au-yellow-300, .5);
+  }
+}
+
 /* Behandeling preview publicatie
  ========================================================================== */
 
@@ -572,75 +640,5 @@
 //   [property="besluit:openbaar"]:after {
 //     content: "Openbaar agendapunt:";
 //     margin-left: 0.7rem;
-//   }
-// }
-
-
-
-/* Style publishing animation (deprecated - delete after testing)
- ========================================================================== */
-
-// .scanner {
-//   backface-visibility: hidden;
-//   position: relative;
-//   pointer-events: none;
-
-//   .badge {
-//     margin-left: auto;
-//     margin-right: auto;
-//   }
-
-//   .loader:before {
-//     display: block;
-//   }
-
-//   &:after {
-//     content: "";
-//     display: block;
-//     left: 0;
-//     right: 0;
-//     top: 0;
-//     bottom: 0;
-//     position: absolute;
-//     background-color: rgba($white, 0.7);
-//   }
-
-//   .scanner__text {
-//     position: absolute;
-//     left: 0;
-//     top: 0;
-//     right: 0;
-//     bottom: 0;
-//     padding-top: 20rem;
-//     text-align: center;
-//     z-index: 10;
-
-//     h3 {
-//       margin-top: 0;
-//     }
-//   }
-
-//   .scanner__bar {
-//     position: absolute;
-//     left: 0;
-//     top: 0;
-//     height: 100%;
-//     background-color: rgba($primary-yellow, 1);
-//     z-index: 1;
-//     animation: move 3s cubic-bezier(0.15, 0.44, 0.76, 0.64);
-//     animation-iteration-count: infinite;
-//     border-right: 1rem $primary-yellow solid;
-//     margin-top: 0;
-//   }
-// }
-
-// @keyframes move {
-//   0% {
-//     width: 0;
-//     background-color: rgba($white, 0.5);
-//   }
-//   100% {
-//     width: 100%;
-//     background-color: rgba($primary-yellow, 0.5);
 //   }
 // }

--- a/app/styles/project/_c-rdfa-editor.scss
+++ b/app/styles/project/_c-rdfa-editor.scss
@@ -27,16 +27,6 @@
   }
 }
 
-.au-c-rdfa-scanner {
-  padding: $au-unit;
-  margin: $au-unit;
-  box-shadow: 0 1px 3px rgba($au-gray-900, .1), 0 4px 20px rgba($au-gray-900, .035), 0 1px 1px rgba($au-gray-900, .025);
-
-  *:before {
-    display: none;
-  }
-}
-
 .au-c-rdfa-publication-holder {
   background-color: $au-gray-100;
   border-left: .1rem solid $au-gray-200;

--- a/app/styles/project/_u-print.scss
+++ b/app/styles/project/_u-print.scss
@@ -5,7 +5,7 @@
 
 .u-hide-on-print--show,
 .au-u-hide-on-print--show {
-  border-bottom: 3px dashed $blue-gray;
+  border-bottom: 3px dashed $au-gray-300;
   position: relative;
   margin-bottom: 6rem;
 
@@ -15,8 +15,8 @@
     position: absolute;
     left: 2rem;
     bottom: -1.6rem;
-    background-color: $blue-gray;
-    color: $white;
+    background-color: $au-gray-300;
+    color: $au-white;
     width: 3rem;
     height: 3rem;
     border-radius: 2rem;

--- a/app/styles/project/_u-print.scss
+++ b/app/styles/project/_u-print.scss
@@ -72,23 +72,6 @@
   //   }
   // }
 
-  .editor-container {
-
-    .grid--align-right {
-      justify-content: initial;
-    }
-
-    .col--2-12 {
-      display: none;
-    }
-
-    .col--8-12 {
-      width: 100%;
-      max-width: none;
-      flex-basis: 100%;
-    }
-  }
-
   .say-container {
     all: initial;
   }

--- a/app/templates/agendapoints/edit.hbs
+++ b/app/templates/agendapoints/edit.hbs
@@ -29,19 +29,23 @@
 {{/if}}
 
 {{#if this.saveTask.isRunning}}
-<div class="editor-container container-flex--scroll">
-  <div class="editor">
-    <div class="grid grid--align-center">
-      <div class="col--7-12">
-        <div class="au-c-rdfa-scanner say-content rdfa-annotations scanner">
-          <div class="scanner__text">
-            <div class="badge badge--l badge--initials">
-              <span class="loader"><span class="u-visually-hidden">Aan het verwerken</span></span>
+<div class="container-flex--contain">
+  <div class="au-c-rdfa-editor">
+    <div class="say-container say-container--sidebar-left">
+      <div class="say-container__main">
+        <div class="say-editor rdfa-annotations rdfa-annotations-highlight rdfa-annotations-hover">
+          <div class="say-editor__paper">
+            <div class="au-c-scanner">
+              <div class="au-c-scanner__text">
+                <AuLoader @size="small" />
+                <AuHelpText @size="large">Bezig met opslaan</AuHelpText>
+              </div>
+              <span class="au-c-scanner__bar"></span>
             </div>
-            <h3 class="h3">Bezig met opslaan</h3>
+            <div class="say-editor__inner say-content">
+              {{this.editorDocument.htmlSafeContent}}
+            </div>
           </div>
-          <span class="scanner__bar"></span>
-          {{this.editorDocument.htmlSafeContent}}
         </div>
       </div>
     </div>

--- a/app/templates/agendapoints/edit.hbs
+++ b/app/templates/agendapoints/edit.hbs
@@ -7,25 +7,32 @@
 />
 
 {{#if this.hasDocumentValidationErrors}}
-  <WuModal @title="Geef uw document een naam" @dialog-class="modal-dialog--wide modal-dialog--sectioned" @onClose={{this.closeValidationModal}} as |m|>
-    <m.content>
-      Klik op de titel om uw document een naam te geven.
-    </m.content>
-    <m.buttons as |b|>
-      <b.button @label="OK" @onClick={{this.closeValidationModal}} />
-    </m.buttons>
-  </WuModal>
+  <AuModal
+    @modalTitle="Geef uw document een naam"
+    @modalOpen={{true}}
+    @closeModal={{fn this.closeValidationModal}} as |Modal| >
+    <Modal.Body>
+      <p>Klik op de titel om uw document een naam te geven.</p>
+    </Modal.Body>
+    <Modal.Footer>
+      <AuButton {{on "click" this.closeValidationModal}}>OK</AuButton>
+    </Modal.Footer>
+  </AuModal>
 {{/if}}
 
 {{#if this.displayDeleteModal}}
-  <WuModal @title="Wilt u dit document naar de prullenmand verplaatsen?" @onClose={{this.toggleDeleteModal}} as |m|>
-    <div class="modal-dialog__buttons">
-      <m.buttons as |b|>
-        <b.button @label="Ja, verplaats naar prullenmand" @onClick={{this.deleteDocument}} />
-        <b.button @label="Annuleren" @onClick={{this.toggleDeleteModal}} @isLink={{true}} @icon="vi-cross" />
-      </m.buttons>
-    </div>
-  </WuModal>
+  <AuModal
+    @modalTitle="Wilt u dit document naar de prullenmand verplaatsen"
+    @modalOpen={{this.displayDeleteModal}}
+    @closeModal={{fn (mut this.displayDeleteModal) false}} as |Modal| >
+    <Modal.Body>
+      <p>U kan deze steeds herstellen vanuit de prullenmand.</p>
+    </Modal.Body>
+    <Modal.Footer>
+      <AuButton {{on "click" this.deleteDocument}}>Ja, verplaats naar prullenmand</AuButton>
+      <AuButton @skin="secondary" {{on "click" (fn (mut this.displayDeleteModal) false)}}>Annuleren</AuButton>
+    </Modal.Footer>
+  </AuModal>
 {{/if}}
 
 {{#if this.saveTask.isRunning}}

--- a/app/templates/agendapoints/new.hbs
+++ b/app/templates/agendapoints/new.hbs
@@ -5,31 +5,37 @@
 />
 
 {{#if this.hasDocumentValidationErrors}}
-  <WuModal @title="Er zijn fouten bij de validatie" @onClose={{this.closeValidationModal}} as |m|>
-    <m.content>
-      Gelieve een titel op te geven.
-    </m.content>
-    <m.buttons as |b|>
-      <b.button @label="OK" @onClick={{this.closeValidationModal}} />
-    </m.buttons>
-  </WuModal>
+  <AuModal
+    @modalTitle="Er zijn fouten bij de validatie."
+    @modalOpen={{true}}
+    @closeModal={{fn this.closeValidationModal}} as |Modal| >
+    <Modal.Body>
+      <p>Gelieve een titel op te geven</p>
+    </Modal.Body>
+    <Modal.Footer>
+      <AuButton {{on "click" this.closeValidationModal}}>OK</AuButton>
+    </Modal.Footer>
+  </AuModal>
 {{/if}}
 
 {{#if this.saveTask.isRunning}}
-  <div class="editor-container container-flex--scroll">
-    <div class="editor">
-      <div class="grid grid--align-center">
-        <div class="col--7-12">
-          <div class="au-c-rdfa-scanner say-content rdfa-annotations scanner">
-            <div class="scanner__text">
-              <div class="badge badge--l badge--initials">
-                <span class="loader"><span class="u-visually-hidden">Aan het verwerken</span></span>
+  <div class="container-flex--contain">
+    <div class="au-c-rdfa-editor">
+      <div class="say-container say-container--sidebar-left">
+        <div class="say-container__main">
+          <div class="say-editor rdfa-annotations rdfa-annotations-highlight rdfa-annotations-hover">
+            <div class="say-editor__paper">
+              <div class="au-c-scanner">
+                <div class="au-c-scanner__text">
+                  <AuLoader @size="small" />
+                  <AuHelpText @size="large">Bezig met opslaan</AuHelpText>
+                </div>
+                <span class="au-c-scanner__bar"></span>
               </div>
-              <h3 class="h3">Bezig met opslaan</h3>
+              <div class="say-editor__inner say-content">
+                {{html-safe this.editor.htmlContent}}
+              </div>
             </div>
-
-            <span class="scanner__bar"></span>
-            {{html-safe this.editor.htmlContent}}
           </div>
         </div>
       </div>

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -18,6 +18,9 @@ module.exports = function (defaults) {
         },
       },
     },
+    '@lblod/ember-vo-webuniversum': {
+      'shouldImportComponentCss': false,
+    },
     sassOptions: {
       sourceMapEmbed: true,
       includePaths: [

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@appuniversum/appuniversum": "0.0.15",
-    "@appuniversum/ember-appuniversum": "0.2.0",
+    "@appuniversum/ember-appuniversum": "0.3.3",
     "@ember/optional-features": "^1.3.0",
     "@ember/render-modifiers": "^1.0.2",
     "@glimmer/component": "^1.0.1",
@@ -42,7 +42,7 @@
     "@lblod/ember-rdfa-editor-import-snippet-plugin": "0.7.3",
     "@lblod/ember-rdfa-editor-roadsign-hint-plugin": "^0.5.0",
     "@lblod/ember-rdfa-editor-standard-template-plugin": "~0.7.5",
-    "@lblod/ember-vo-webuniversum": "^0.22.8",
+    "@lblod/ember-vo-webuniversum": "0.23.0",
     "@lblod/ember-vo-webuniversum-data-table": "^0.2.16",
     "@lblod/ember-vo-webuniversum-widget": "^0.1.2",
     "@lblod/marawa": "^0.6.0",


### PR DESCRIPTION
Update of appuniversum and webuniversum with the goal to remove webuniversum from the codebase:
- replaced WuSwitch
- seperated remaining webuniversum styles and provided fallbacks
- removed old color variables
- fixed missing saving animation
- provided an icon for clone functionality

Steps to take to finish the removal of webuniversum:
- replace WuDatepicker with AuDatePicker
- replace ember-vo-webuniversum-data-table with ember-au-data-table
- remove unused templates that still use webuniversum (eg. imported documents)