### PR TITLE
Remove the ember-simple-auth mixins

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,11 +9,11 @@ steps:
     repo: lblod/frontend-gelinkt-notuleren
     dry_run: true
     purge: true
-- name: test
+- name: lint
   image: danlynn/ember-cli:3.20.0
   commands:
   - npm install
-  - npm test
+  - npm run lint
 trigger:
   event:
     - pull_request
@@ -34,6 +34,9 @@ steps:
 trigger:
   branch:
     - development
+  event:
+    exclude:
+    - pull_request
 ---
 kind: pipeline
 type: docker

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,8 +25,8 @@ module.exports = {
   },
   rules: {
     'ember/no-jquery': 'error',
-    "semi": "warn",
-    "ember/no-mixins": "warn"
+    "ember/no-mixins": "warn",
+    "semi": "error",
   },
   overrides: [
     // node files

--- a/app/routes/agendapoints.js
+++ b/app/routes/agendapoints.js
@@ -1,5 +1,10 @@
 import Route from '@ember/routing/route';
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import { inject as service } from '@ember/service';
 
-export default Route.extend(AuthenticatedRouteMixin, {
-});
+export default class AgendapointsRoute extends Route {
+  @service session;
+
+  beforeModel(transition) {
+    this.session.requireAuthentication(transition, 'login');
+  }
+}

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,15 +1,12 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
-import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mixin';
 import ENV from 'frontend-gelinkt-notuleren/config/environment';
 
 const featureFlagRegex = /^feature\[(.+)\]$/;
 
-export default Route.extend(ApplicationRouteMixin, {
-  moment: service(),
-  currentSession: service(),
-  features: service(),
-  intl: service(),
+export default class ApplicationRoute extends Route {
+  @service currentSession;
+  @service features;
 
   beforeModel(transition) {
     this.updateFeatureFlags(transition.to.queryParams);
@@ -17,21 +14,11 @@ export default Route.extend(ApplicationRouteMixin, {
       document.title = `Gelinkt Notuleren - ${ENV.environmentName}`;
     }
     return this.loadCurrentSession();
-  },
-
-  sessionAuthenticated() {
-    this._super(...arguments);
-    this.loadCurrentSession();
-  },
-
-  sessionInvalidated() {
-    const logoutUrl = ENV['torii']['providers']['acmidm-oauth2']['logoutUrl'];
-    window.location.replace(logoutUrl);
-  },
+  }
 
   loadCurrentSession() {
     return this.currentSession.load().catch(() => this.session.invalidate());
-  },
+  }
 
   updateFeatureFlags(queryParams) {
     const keys = Object.keys(queryParams);
@@ -48,4 +35,4 @@ export default Route.extend(ApplicationRouteMixin, {
       }
     }
   }
-});
+}

--- a/app/routes/import.js
+++ b/app/routes/import.js
@@ -1,24 +1,16 @@
 import Route from '@ember/routing/route';
-import { computed } from '@ember/object';
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import { inject as service } from '@ember/service';
 
-export default Route.extend(AuthenticatedRouteMixin, {
-  queryParams: {
+export default class ImportRoute extends Route {
+  @service session;
+
+  queryParams = {
     mock: { refreshModel: true },
-    source: { refreshModel: true }
-  },
+    source: { refreshModel: true },
+  };
 
   beforeModel(transition) {
-    this.set('mock', transition.to.queryParams.mock);
-    this._super(...arguments);
-  },
-
-  authenticationRoute: computed('mock', function() {
-    if (this.mock) {
-      return 'mock-login';
-    }
-    else {
-      return 'login'; // TODO read from configuration
-    }
-  })
-});
+    let loginRoute = transition.to.queryParams.mock ? 'mock-login' : 'login';
+    this.session.requireAuthentication(transition, loginRoute);
+  }
+}

--- a/app/routes/inbox.js
+++ b/app/routes/inbox.js
@@ -1,5 +1,10 @@
 import Route from '@ember/routing/route';
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import { inject as service } from '@ember/service';
 
-export default Route.extend(AuthenticatedRouteMixin, {
-});
+export default class InboxRoute extends Route {
+  @service session;
+
+  beforeModel(transition) {
+    this.session.requireAuthentication(transition, 'login');
+  }
+}

--- a/app/routes/login.js
+++ b/app/routes/login.js
@@ -1,4 +1,10 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
-export default Route.extend({
-});
+export default class LoginRoute extends Route {
+  @service session;
+
+  beforeModel() {
+    this.session.prohibitAuthentication('index');
+  }
+}

--- a/app/routes/meetings.js
+++ b/app/routes/meetings.js
@@ -1,5 +1,10 @@
 import Route from '@ember/routing/route';
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import { inject as service } from '@ember/service';
 
-export default Route.extend(AuthenticatedRouteMixin, {
-});
+export default class MeetingsRoute extends Route {
+  @service session;
+
+  beforeModel(transition) {
+    this.session.requireAuthentication(transition, 'login');
+  }
+}

--- a/app/routes/mock-login.js
+++ b/app/routes/mock-login.js
@@ -1,17 +1,20 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
-export default Route.extend({
-  queryParams: {
+
+export default class MockLoginRoute extends Route {
+  @service session;
+  @service store;
+
+  queryParams = {
     page: {
       refreshModel: true
     }
-  },
-  session: service(),
-  store: service(),
+  };
+
   beforeModel() {
-    if (this.session.isAuthenticated)
-      this.transitionTo('index');
-  },
+    this.session.prohibitAuthentication('index');
+  }
+
   model(params) {
     const filter = { provider: 'https://github.com/lblod/mock-login-service' };
     if (params.gemeente)
@@ -21,6 +24,6 @@ export default Route.extend({
       filter: filter,
       page: { size: 10, number: params.page },
       sort: 'gebruiker.achternaam'
-    }); 
+    });
   }
-});
+}

--- a/app/routes/print.js
+++ b/app/routes/print.js
@@ -1,5 +1,10 @@
 import Route from '@ember/routing/route';
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import { inject as service } from '@ember/service';
 
-export default Route.extend(AuthenticatedRouteMixin, {
-});
+export default class PrintRoute extends Route {
+  @service session;
+
+  beforeModel(transition) {
+    this.session.requireAuthentication(transition, 'login');
+  }
+}

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -1,0 +1,17 @@
+import { inject as service } from '@ember/service';
+import BaseSessionService from 'ember-simple-auth/services/session';
+import ENV from 'frontend-gelinkt-notuleren/config/environment';
+
+export default class SessionService extends BaseSessionService {
+  @service currentSession;
+
+  handleAuthentication(routeAfterAuthentication) {
+    super.handleAuthentication(routeAfterAuthentication);
+    this.currentSession.load();
+  }
+
+  handleInvalidation() {
+    const logoutUrl = ENV['torii']['providers']['acmidm-oauth2']['logoutUrl'];
+    super.handleInvalidation(logoutUrl);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "ember-promise-helpers": "^1.0.9",
     "ember-qunit": "^4.6.0",
     "ember-resolver": "^8.0.0",
+    "ember-simple-auth": "^3.1.0",
     "ember-source": "~3.20.2",
     "ember-template-lint": "^2.9.1",
     "ember-truth-helpers": "^3.0.0",


### PR DESCRIPTION
This replaces the ember-simple-auth mixins with session service based alternatives.