### PR TITLE
Move the custom inflector rules file

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -2,7 +2,7 @@ import Application from '@ember/application';
 import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from 'frontend-gelinkt-notuleren/config/environment';
-import './models/custom-inflector-rules';
+import './config/custom-inflector-rules';
 
 export default class App extends Application {
   modulePrefix = config.modulePrefix;

--- a/app/config/custom-inflector-rules.js
+++ b/app/config/custom-inflector-rules.js
@@ -62,5 +62,3 @@ inflector.irregular('blockchain-status', 'blockchain-statuses');
 inflector.irregular('concept', 'concepts');
 inflector.irregular('concept-scheme', 'concept-schemes');
 inflector.uncountable('sync');
-// Meet Ember Inspector's expectation of an export
-export default {};


### PR DESCRIPTION
I noticed this was placed inside the models folder, and needed a default export "hack" as well. I think moving it to a config folder makes sense?