### PR TITLE
Update to ember-power-select 4.1.4

### DIFF
--- a/app/components/agenda-manager/agenda-item-form/select-draft.hbs
+++ b/app/components/agenda-manager/agenda-item-form/select-draft.hbs
@@ -3,17 +3,17 @@
     {{yield}}
   </AuLabel>
   <PowerSelect
-          @class="select select--block u-spacer--tiny"
-          @renderInPlace={{true}}
-          @placeholder={{@placeholder}}
-          @options={{this.options}}
-          @verticalPosition="below"
-          @searchEnabled={{true}}
-          @selected={{this.selected}}
-          @allowClear={{true}}
-          @search={{perform this.getDrafts}}
-          @onchange={{this.select}}
-          as |option|>
+    @class="select select--block u-spacer--tiny"
+    @renderInPlace={{true}}
+    @placeholder={{@placeholder}}
+    @options={{this.options}}
+    @verticalPosition="below"
+    @searchEnabled={{true}}
+    @selected={{this.selected}}
+    @allowClear={{true}}
+    @search={{perform this.getDrafts}}
+    @onChange={{this.select}}
+    as |option|>
     {{option.currentVersion.title}}
   </PowerSelect>
 </div>

--- a/app/components/agenda-manager/agenda-item-form/select-location.hbs
+++ b/app/components/agenda-manager/agenda-item-form/select-location.hbs
@@ -5,32 +5,32 @@
   <div class="au-o-grid au-o-grid--tiny">
     <div class="au-o-grid__item au-u-1-2">
       <PowerSelect
-              @class="select select--block"
-              @renderInPlace={{true}}
-              @placeholder={{t "manageAgendaZittingModalMove.positionSelectPlaceholder"}}
-              @options={{this.locationOptions}}
-              @verticalPosition="above"
-              @searchEnabled={{false}}
-              @selected={{this.selectedLocation}}
-              @allowClear={{true}}
-              @onchange={{this.selectLocation}}
-              as |location|>
+        @class="select select--block"
+        @renderInPlace={{true}}
+        @placeholder={{t "manageAgendaZittingModalMove.positionSelectPlaceholder"}}
+        @options={{this.locationOptions}}
+        @verticalPosition="above"
+        @selected={{this.selectedLocation}}
+        @allowClear={{true}}
+        @onChange={{this.selectLocation}}
+        as |location|>
         {{location.name}}
       </PowerSelect>
     </div>
     {{#if this.showAfterItemOptions}}
       <div class="au-o-grid__item au-u-1-2">
         <PowerSelect
-                @class="js-select"
-                @renderInPlace={{true}}
-                @placeholder={{t "manageAgendaZittingModalMove.agendapuntSelectPlaceholder"}}
-                @searchPlaceholder={{t "manageAgendaZittingModalMove.searchPlaceholder"}}
-                @verticalPosition="above"
-                @options={{this.afterItemOptions}}
-                @searchField="titel"
-                @selected={{this.selectedAfterItem}}
-                @onchange={{this.selectAfterItem}}
-                as |a|>
+          @class="js-select"
+          @renderInPlace={{true}}
+          @placeholder={{t "manageAgendaZittingModalMove.agendapuntSelectPlaceholder"}}
+          @searchEnabled={{true}}
+          @searchPlaceholder={{t "manageAgendaZittingModalMove.searchPlaceholder"}}
+          @verticalPosition="above"
+          @options={{this.afterItemOptions}}
+          @searchField="titel"
+          @selected={{this.selectedAfterItem}}
+          @onChange={{this.selectAfterItem}}
+          as |a|>
           {{a.titel}}
         </PowerSelect>
       </div>

--- a/app/components/language-select.hbs
+++ b/app/components/language-select.hbs
@@ -1,7 +1,7 @@
 <PowerSelect
-  @searchEnabled={{false}}
   @options={{this.options}}
   @selected={{this.selected}}
-  @onchange={{this.selectLanguage}} as |option|>
+  @onChange={{this.selectLanguage}}
+  as |option|>
   {{option.label}}
 </PowerSelect>

--- a/app/components/participation-list/functionaris-selector.hbs
+++ b/app/components/participation-list/functionaris-selector.hbs
@@ -4,7 +4,7 @@
 <PowerSelect
   @options={{this.options}}
   @selected={{@functionaris}}
-  @onchange={{@onSelect}}
+  @onChange={{@onSelect}}
   as |functionaris| >
   {{functionaris.isBestuurlijkeAliasVan.gebruikteVoornaam}} {{functionaris.isBestuurlijkeAliasVan.achternaam}},
   {{functionaris.bekleedt.rol.label}} (periode {{moment-format functionaris.start "MM/DD/YYYY"}}  - {{moment-format functionaris.einde "MM/DD/YYYY"}})

--- a/app/components/participation-list/mandataris-selector.hbs
+++ b/app/components/participation-list/mandataris-selector.hbs
@@ -1,14 +1,15 @@
 <PowerSelect
   @loadingMessage={{t "participationListModalSelector.loadingMessage"}}
   @noMatchesMessage={{t "participationListModalSelector.noMatchesMessage"}}
+  @searchEnabled={{true}}
   @searchMessage={{t "participationListModalSelector.searchMessage"}}
   @renderInPlace={{true}}
   @placeholder={{t "participationListModalSelector.placeholder"}}
   @allowClear={{true}}
   @search={{perform this.searchByName}}
   @selected={{@mandataris}}
-  @onchange={{this.select}}
+  @onChange={{this.select}}
   as |mandataris|>
-  {{mandataris.isBestuurlijkeAliasVan.gebruikteVoornaam}} {{mandataris.isBestuurlijkeAliasVan.achternaam}}, 
+  {{mandataris.isBestuurlijkeAliasVan.gebruikteVoornaam}} {{mandataris.isBestuurlijkeAliasVan.achternaam}},
   {{mandataris.bekleedt.bestuursfunctie.label}}
 </PowerSelect>

--- a/app/components/zitting/manage-zittingsdata.hbs
+++ b/app/components/zitting/manage-zittingsdata.hbs
@@ -10,9 +10,10 @@
           <AuLabel>{{t "manageZittingsData.bestuursorganLabel"}}</AuLabel>
           <PowerSelect
             @placeholder={{t "manageZittingsData.selectPlaceholder"}}
-                          @selected={{this.bestuursorgaan}}
+            @selected={{this.bestuursorgaan}}
             @options={{this.bestuursorgaanOptions}}
-                          @onchange={{this.changeSelect}} as |bestuursorgaan|>
+            @onChange={{this.changeSelect}}
+            as |bestuursorgaan|>
               {{bestuursorgaan.isTijdsspecialisatieVan.naam}}
               (periode: {{moment-format bestuursorgaan.bindingStart "MM/DD/YYYY"}} -
               {{#if bestuursorgaan.bindingEinde}}{{moment-format bestuursorgaan.bindingEinde "MM/DD/YYYY"}}{{else}}nvt.{{/if}})

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "ember-modifier": "^1.0.3",
     "ember-moment": "^7.6.0",
     "ember-page-title": "^6.0.3",
-    "ember-power-select": "^2.3.5",
+    "ember-power-select": "^4.1.4",
     "ember-promise-helpers": "^1.0.9",
     "ember-qunit": "^5.1.1",
     "ember-resolver": "^8.0.2",


### PR DESCRIPTION
This should also fix the deprecation warnings about `-in-element` when building the app. 

Ideally `@lblod/ember-rdfa-editor-besluit-type-plugin` should be updated as well because now there are still 2 versions of ember-power-select being installed. ember-cli-dependency-lint wouldn't like that :smile:.