### PR TITLE
Lint ember dependencies during CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -11,6 +11,11 @@ steps:
   image: danlynn/ember-cli:3.20.0
   commands:
   - npm run lint
+- name: dependency-lint
+  image: danlynn/ember-cli:3.20.0
+  failure: ignore
+  commands:
+  - ember dependency-lint
 - name: test
   image: danlynn/ember-cli:3.20.0
   failure: ignore

--- a/config/dependency-lint.js
+++ b/config/dependency-lint.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  generateTests: false
+};

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "ember-cli-autoprefixer": "^1.0.0",
     "ember-cli-babel": "^7.23.0",
     "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-dependency-lint": "^2.0.0",
     "ember-cli-deploy": "^1.0.2",
     "ember-cli-deploy-build": "^2.0.0",
     "ember-cli-deploy-display-revisions": "^2.1.2",


### PR DESCRIPTION
This adds a pipeline step that runs ember-cli-dependency-lint but is ignored when failed.
Multiple versions of the same Ember addons should be avoided since that can lead to weird bugs and behavior.