### PR TITLE
Remove the @class argument from <PowerSelect>

### DIFF
--- a/app/components/agenda-manager/agenda-item-form/select-draft.hbs
+++ b/app/components/agenda-manager/agenda-item-form/select-draft.hbs
@@ -3,7 +3,6 @@
     {{yield}}
   </AuLabel>
   <PowerSelect
-    @class="select select--block u-spacer--tiny"
     @renderInPlace={{true}}
     @placeholder={{@placeholder}}
     @options={{this.options}}

--- a/app/components/agenda-manager/agenda-item-form/select-location.hbs
+++ b/app/components/agenda-manager/agenda-item-form/select-location.hbs
@@ -5,7 +5,6 @@
   <div class="au-o-grid au-o-grid--tiny">
     <div class="au-o-grid__item au-u-1-2">
       <PowerSelect
-        @class="select select--block"
         @renderInPlace={{true}}
         @placeholder={{t "manageAgendaZittingModalMove.positionSelectPlaceholder"}}
         @options={{this.locationOptions}}
@@ -20,7 +19,6 @@
     {{#if this.showAfterItemOptions}}
       <div class="au-o-grid__item au-u-1-2">
         <PowerSelect
-          @class="js-select"
           @renderInPlace={{true}}
           @placeholder={{t "manageAgendaZittingModalMove.agendapuntSelectPlaceholder"}}
           @searchEnabled={{true}}


### PR DESCRIPTION
This argument did not actually do anything without setting a tagName and that isn't possible anymore since it uses Glimmer components now. The classes aren't neither either since appuniversum uses the power-select classes directly.