### PR TITLE
<DateTimePicker> usability improvements

### DIFF
--- a/app/components/date-time-picker.hbs
+++ b/app/components/date-time-picker.hbs
@@ -13,13 +13,29 @@
   <div class="au-o-grid__item au-u-2-6 au-u-1-6@medium">
     {{#let (unique-id) as |id|}}
       <AuLabel for={{id}}>Uur</AuLabel>
-      <Input class="au-c-input au-c-input--block" type='number' @input={{fn this.onChangeTime 'hours'}} @value={{this.hours}} max={{24}} id={{id}} />
+      <input
+        class="au-c-input au-c-input--block"
+        type='number'
+        value={{this.hours}}
+        min={{-1}}
+        max={{24}}
+        id={{id}}
+        {{on "input" (fn this.onChangeTime 'hours')}}
+      />
     {{/let}}
   </div>
   <div class="au-o-grid__item au-u-2-6 au-u-1-6@medium">
     {{#let (unique-id) as |id|}}
       <AuLabel for={{id}}>Minuten</AuLabel>
-      <Input class="au-c-input au-c-input--block" type='number' @input={{fn this.onChangeTime 'minutes'}} @value={{this.minutes}} max={{60}} id={{id}} />
+      <input
+        class="au-c-input au-c-input--block"
+        type='number'
+        value={{this.minutes}}
+        min={{-1}}
+        max={{60}}
+        id={{id}}
+        {{on "input" (fn this.onChangeTime 'minutes')}}
+      />
     {{/let}}
   </div>
 </div>

--- a/app/components/date-time-picker.js
+++ b/app/components/date-time-picker.js
@@ -1,20 +1,27 @@
 import Component from '@glimmer/component';
 import { action } from "@ember/object";
 import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 
 export default class DateTimePicker extends Component{
   @service intl;
-  date;
-  hours;
-  minutes;
+  @tracked date;
 
   constructor() {
     super(...arguments);
     if(this.args.value) {
       this.date = new Date(this.args.value);
-      this.hours = this.date.getHours();
-      this.minutes = this.date.getMinutes();
+    } else {
+      this.date = new Date();
     }
+  }
+
+  get hours() {
+    return this.date.getHours();
+  }
+
+  get minutes() {
+    return this.date.getMinutes();
   }
 
   get datePickerLocalization() {
@@ -38,12 +45,13 @@ export default class DateTimePicker extends Component{
   onChangeDate(isoDate, date) {
     let wasDateInputCleared = !date;
     if (!wasDateInputCleared) {
-      if(!this.date) {
-        this.date = new Date();
-      }
-      this.date.setDate(date.getDate());
-      this.date.setMonth(date.getMonth());
-      this.date.setFullYear(date.getFullYear());
+      let newDate = new Date(this.date.getTime());
+
+      newDate.setDate(date.getDate());
+      newDate.setMonth(date.getMonth());
+      newDate.setFullYear(date.getFullYear());
+
+      this.date = newDate;
       this.args.onChange(this.date);
     }
   }
@@ -51,16 +59,15 @@ export default class DateTimePicker extends Component{
   @action
   onChangeTime(type, event) {
     const value = event.target.value;
-    if(!this.date) {
-      this.date = new Date();
-    }
+    let newDate = new Date(this.date.getTime());
+
     if(type === 'hours') {
-      if(value < 0 || value > 24) return;
-      this.date.setHours(value);
+      newDate.setHours(value);
     } else {
-      if(value < 0 || value > 60) return;
-      this.date.setMinutes(value);
+      newDate.setMinutes(value);
     }
+
+    this.date = newDate;
     this.args.onChange(this.date);
   }
 }


### PR DESCRIPTION
This makes it possible for the time picker to "wrap around" when certain
values are reached.

For example when the user types in 60 in the minutes field, the hour
field will be incremented by 1.