### PR TITLE
Agendapoint record cleanup

### DIFF
--- a/app/components/agenda-manager/agenda-context.hbs
+++ b/app/components/agenda-manager/agenda-context.hbs
@@ -4,6 +4,6 @@
   deleteItemTask=this.deleteItemTask
   onSort=(perform this.onSortTask)
   saveItemTask=this.saveItemTask
-  createItemTask=this.createItemTask
+  createAgendaItem=this.createAgendaItem
   onCancel=(perform this.resetItemTask)
 )}}

--- a/app/components/agenda-manager/agenda-context.hbs
+++ b/app/components/agenda-manager/agenda-context.hbs
@@ -1,8 +1,9 @@
 {{yield (hash
-                items=this.items
-                loadItemsTask=this.loadItemsTask
-                deleteItemTask=this.deleteItemTask
-                onSort=(perform this.onSortTask)
-                saveItemTask=this.saveItemTask
-                createItemTask=this.createItemTask
-        )}}
+  items=this.items
+  loadItemsTask=this.loadItemsTask
+  deleteItemTask=this.deleteItemTask
+  onSort=(perform this.onSortTask)
+  saveItemTask=this.saveItemTask
+  createItemTask=this.createItemTask
+  onCancel=(perform this.resetItemTask)
+)}}

--- a/app/components/agenda-manager/agenda-context.js
+++ b/app/components/agenda-manager/agenda-context.js
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import {task} from "ember-concurrency-decorators";
+import {action} from '@ember/object';
 import {inject as service} from '@ember/service';
 import {tracked} from 'tracked-built-ins';
 import {DRAFT_STATUS_ID, PUBLISHED_STATUS_ID, SCHEDULED_STATUS_ID} from "../../utils/constants";
@@ -81,32 +82,24 @@ export default class AgendaManagerAgendaContextComponent extends Component {
     }
   }
 
-
   /**
    * Create a new agenda item
    * @return {Agendapunt} the newly created item
    */
-  @task
-  * createItemTask() {
-    const item = this.store.createRecord("agendapunt", {
+  @action
+  createAgendaItem() {
+    const agendaItem = this.store.createRecord("agendapunt", {
       titel: "",
       beschrijving: "",
       geplandOpenbaar: true,
       position: this.items.length
     });
-    item.behandeling = yield this.createBehandelingTask.perform(item);
-    return item;
-  }
-
-  @task
-  * createBehandelingTask(agendapunt) {
-    const behandeling = this.store.createRecord("behandeling-van-agendapunt",
-      {
-        openbaar: agendapunt.geplandOpenbaar,
-        onderwerp: agendapunt,
+    agendaItem.behandeling = this.store.createRecord("behandeling-van-agendapunt", {
+      openbaar: agendaItem.geplandOpenbaar,
+      onderwerp: agendaItem,
       });
-    yield behandeling.initializeDocument();
-    return behandeling;
+
+    return agendaItem;
   }
 
   /**

--- a/app/components/agenda-manager/agenda-context.js
+++ b/app/components/agenda-manager/agenda-context.js
@@ -99,6 +99,7 @@ export default class AgendaManagerAgendaContextComponent extends Component {
       onderwerp: agendaItem,
       });
 
+    this.args.onCreate(agendaItem);
     return agendaItem;
   }
 

--- a/app/components/agenda-manager/agenda-context.js
+++ b/app/components/agenda-manager/agenda-context.js
@@ -132,6 +132,15 @@ export default class AgendaManagerAgendaContextComponent extends Component {
   }
 
   @task
+  * resetItemTask(agendaItem) {
+    let behandeling = yield agendaItem.behandeling;
+    behandeling.rollbackAttributes();
+    agendaItem.rollbackAttributes();
+
+    this.args.onCancel();
+  }
+
+  @task
   * onSortTask() {
     yield this.savePositionsTask.perform();
     yield this.args.onSave();

--- a/app/components/agenda-manager/edit.js
+++ b/app/components/agenda-manager/edit.js
@@ -17,7 +17,6 @@ export default class AgendaManagerEditComponent extends Component {
   @action
   cancel() {
     this.args.onCancel();
-    this.args.onClose();
   }
   @task
   * deleteTask(item) {

--- a/app/components/agenda-manager/index.hbs
+++ b/app/components/agenda-manager/index.hbs
@@ -1,5 +1,6 @@
 <AgendaManager::AgendaContext
   @zittingId={{@zittingId}}
+  @onCreate={{this.editItem}}
   @onSave={{@onSave}}
   @onCancel={{this.stopEditing}}
   as |agenda|
@@ -11,7 +12,7 @@
     {{else}}
       <AgendaManager::AgendaTable
               @onSort={{agenda.onSort}}
-              @onCreate={{fn this.createAgendaItem agenda.createAgendaItem}}
+              @onCreate={{agenda.createAgendaItem}}
               @items={{agenda.items}}
               @readOnly={{@readOnly}}
               as |Table|>

--- a/app/components/agenda-manager/index.hbs
+++ b/app/components/agenda-manager/index.hbs
@@ -1,4 +1,9 @@
-<AgendaManager::AgendaContext @zittingId={{@zittingId}} @onSave={{@onSave}} as |agenda|>
+<AgendaManager::AgendaContext
+  @zittingId={{@zittingId}}
+  @onSave={{@onSave}}
+  @onCancel={{this.cancelEdit}}
+  as |agenda|
+>
   <div class="au-c-meeting-chrome-card">
     {{#if agenda.loadItemsTask.isRunning}}
       <AuLoader />
@@ -24,15 +29,16 @@
       </AgendaManager::AgendaTable>
 
     {{/if}}
-
   </div>
-  <AgendaManager::Edit @visible={{this.editModalVisible}}
-                       @itemToEdit={{this.itemToEdit}}
-                       @saveTask={{agenda.saveItemTask}}
-                       @onClose={{this.closeModal}}
-                       @deleteTask={{agenda.deleteItemTask}}
-                       @onCancel={{this.closeModal}}
-                       @agendaItems={{agenda.items}}
+
+  <AgendaManager::Edit
+    @visible={{this.editModalVisible}}
+    @itemToEdit={{this.itemToEdit}}
+    @saveTask={{agenda.saveItemTask}}
+    @onClose={{this.closeModal}}
+    @deleteTask={{agenda.deleteItemTask}}
+    @onCancel={{fn agenda.onCancel this.itemToEdit}}
+    @agendaItems={{agenda.items}}
   />
 
 </AgendaManager::AgendaContext>

--- a/app/components/agenda-manager/index.hbs
+++ b/app/components/agenda-manager/index.hbs
@@ -1,7 +1,7 @@
 <AgendaManager::AgendaContext
   @zittingId={{@zittingId}}
   @onSave={{@onSave}}
-  @onCancel={{this.cancelEdit}}
+  @onCancel={{this.stopEditing}}
   as |agenda|
 >
   <div class="au-c-meeting-chrome-card">
@@ -31,14 +31,16 @@
     {{/if}}
   </div>
 
-  <AgendaManager::Edit
-    @visible={{this.editModalVisible}}
-    @itemToEdit={{this.itemToEdit}}
-    @saveTask={{agenda.saveItemTask}}
-    @onClose={{this.closeModal}}
-    @deleteTask={{agenda.deleteItemTask}}
-    @onCancel={{fn agenda.onCancel this.itemToEdit}}
-    @agendaItems={{agenda.items}}
-  />
+  {{#if this.editModalVisible}}
+    <AgendaManager::Edit
+      @visible={{this.editModalVisible}}
+      @itemToEdit={{this.itemToEdit}}
+      @saveTask={{agenda.saveItemTask}}
+      @onClose={{this.stopEditing}}
+      @deleteTask={{agenda.deleteItemTask}}
+      @onCancel={{fn agenda.onCancel this.itemToEdit}}
+      @agendaItems={{agenda.items}}
+    />
+  {{/if}}
 
 </AgendaManager::AgendaContext>

--- a/app/components/agenda-manager/index.hbs
+++ b/app/components/agenda-manager/index.hbs
@@ -11,7 +11,7 @@
     {{else}}
       <AgendaManager::AgendaTable
               @onSort={{agenda.onSort}}
-              @onCreate={{fn (perform this.createItemTask) agenda.createItemTask}}
+              @onCreate={{fn this.createAgendaItem agenda.createAgendaItem}}
               @items={{agenda.items}}
               @readOnly={{@readOnly}}
               as |Table|>

--- a/app/components/agenda-manager/index.js
+++ b/app/components/agenda-manager/index.js
@@ -3,8 +3,6 @@ import {tracked} from '@glimmer/tracking';
 import {action} from '@ember/object';
 import {task} from "ember-concurrency-decorators";
 
-/** @typedef {import("./AgendaData").default} AgendaData */
-
 /**
  * @typedef {Object} Args
  * @property {string} zittingId
@@ -13,7 +11,6 @@ import {task} from "ember-concurrency-decorators";
 
 /** @extends {Component<Args>} */
 export default class AgendaManagerIndexComponent extends Component {
-  /** @type AgendaData */
   @tracked popup = false;
   @tracked editModalVisible = false;
   @tracked itemToEdit = null;

--- a/app/components/agenda-manager/index.js
+++ b/app/components/agenda-manager/index.js
@@ -1,7 +1,6 @@
 import Component from '@glimmer/component';
 import {tracked} from '@glimmer/tracking';
 import {action} from '@ember/object';
-import {task} from "ember-concurrency-decorators";
 
 /**
  * @typedef {Object} Args
@@ -17,10 +16,10 @@ export default class AgendaManagerIndexComponent extends Component {
     return !!this.itemToEdit;
   }
 
-  @task
-  * createItemTask(newItemTask) {
-    const newItem = yield newItemTask.perform();
-    this.editItem(newItem);
+  @action
+  createAgendaItem(newAgendaItem) {
+    const agendaItem = newAgendaItem();
+    this.editItem(agendaItem);
   }
 
   @action

--- a/app/components/agenda-manager/index.js
+++ b/app/components/agenda-manager/index.js
@@ -11,23 +11,10 @@ import {task} from "ember-concurrency-decorators";
 
 /** @extends {Component<Args>} */
 export default class AgendaManagerIndexComponent extends Component {
-  @tracked editModalVisible = false;
   @tracked itemToEdit = null;
 
-  constructor(...args) {
-    super(...args);
-  }
-
-
-
-  @action
-  openModal() {
-    this.editModalVisible = true;
-  }
-
-  @action
-  closeModal() {
-    this.editModalVisible = false;
+  get editModalVisible() {
+    return !!this.itemToEdit;
   }
 
   @task
@@ -35,9 +22,9 @@ export default class AgendaManagerIndexComponent extends Component {
     const newItem = yield newItemTask.perform();
     this.editItem(newItem);
   }
+
   @action
-  cancelEdit() {
-    this.closeModal();
+  stopEditing() {
     this.itemToEdit = null;
   }
 
@@ -47,8 +34,5 @@ export default class AgendaManagerIndexComponent extends Component {
    */
   editItem(item) {
     this.itemToEdit = item;
-    this.openModal();
   }
-
-
 }

--- a/app/components/agenda-manager/index.js
+++ b/app/components/agenda-manager/index.js
@@ -17,12 +17,6 @@ export default class AgendaManagerIndexComponent extends Component {
   }
 
   @action
-  createAgendaItem(newAgendaItem) {
-    const agendaItem = newAgendaItem();
-    this.editItem(agendaItem);
-  }
-
-  @action
   stopEditing() {
     this.itemToEdit = null;
   }

--- a/app/components/agenda-manager/index.js
+++ b/app/components/agenda-manager/index.js
@@ -11,7 +11,6 @@ import {task} from "ember-concurrency-decorators";
 
 /** @extends {Component<Args>} */
 export default class AgendaManagerIndexComponent extends Component {
-  @tracked popup = false;
   @tracked editModalVisible = false;
   @tracked itemToEdit = null;
 

--- a/app/models/behandeling-van-agendapunt.js
+++ b/app/models/behandeling-van-agendapunt.js
@@ -34,11 +34,18 @@ export default class BehandelingVanAgendapunt extends Model {
     container.currentVersion = document;
     this.documentContainer = container;
   }
-  async saveAndPersistDocument(){
-    const agendaItem = await this.onderwerp;
-    const container = await this.documentContainer;
-    const document = await container.currentVersion;
 
+  async saveAndPersistDocument() {
+    const agendaItem = await this.onderwerp;
+    let container = await this.documentContainer;
+
+    // New treatments will not have a documentContainer unless the user selected a draft
+    if (!container) {
+      await this.initializeDocument();
+      container = await this.documentContainer;
+    }
+
+    const document = await container.currentVersion;
     document.title = agendaItem.titel;
 
     await document.save();


### PR DESCRIPTION
This rolls back the changes to the `Agendapunt` and `BehandelingVanAgendapunt` records when closing the modal without saving. This also means the newly created records are deleted.

This should fix both GN-2604 and GN-2605. 