### PR TITLE
Don't link to the "meeting" page after removing the agenda item

### DIFF
--- a/app/components/zitting-link.js
+++ b/app/components/zitting-link.js
@@ -17,7 +17,10 @@ export default class ZittingLinkComponent extends Component {
   @restartableTask
   * getMeeting(){
     const result = yield this.store.query("zitting", {
-      'filter[agendapunten][behandeling][document-container][:id:]':this.args.documentContainer.id
+      'filter[agendapunten][behandeling][document-container][:id:]': this.args.documentContainer.id,
+      // Including the agendapunten relationship ensures the cache returns the proper response.
+      // TODO: This is a workaround for a mu-cache issue. Remove the include once that's resolved.
+      'include': 'agendapunten'
     });
     this.meeting = result.firstObject;
   }


### PR DESCRIPTION
Fixes GN-2639 with a workaround, as discussed.