### PR TITLE
Remove "Artikel" model

### DIFF
--- a/app/models/artikel.js
+++ b/app/models/artikel.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor-citaten-plugin/models/artikel';


### PR DESCRIPTION
`@lblod/ember-rdfa-editor-citaten-plugin` doesn't export this model class anymore.