### PR TITLE
Fix `<EditorDocumentTitle>` exception

### DIFF
--- a/app/components/editor-document-title.hbs
+++ b/app/components/editor-document-title.hbs
@@ -5,7 +5,7 @@
 {{else}}
   {{#if this.active}}
     <div class="au-c-app-chrome__title-group {{if this.error "au-c-input--error"}}">
-      <Input class="au-c-app-chrome__title-input" placeholder="Naamloos document" @type="text" @value={{this.title}} {{on "input" this.setTitle}} @autofocus="autofocus"  />
+      <input class="au-c-app-chrome__title-input" placeholder="Naamloos document" type="text" value={{this.title}} {{on "input" this.setTitle}} />
       <AuButton class="au-c-app-chrome__title-button" {{on "click" this.toggleActive}} @skin="secondary" @icon="check" @hideText={{true}}>Titel aanpassen</AuButton>
     </div>
   {{else}}

--- a/app/components/editor-document-title.js
+++ b/app/components/editor-document-title.js
@@ -4,7 +4,6 @@ import { tracked } from '@glimmer/tracking';
 
 export default class EditorDocumentTitleComponent extends Component {
   @tracked active = false;
-  @tracked _title;
   @tracked error = false;
 
   constructor() {
@@ -13,24 +12,16 @@ export default class EditorDocumentTitleComponent extends Component {
   }
 
   get title() {
-    if (this._title) {
-      return this._title;
-    }
-    else if (this.args.title) {
-      return this.args.title;
-    }
-    else {
-      return "";
-    }
+    return this.args.title || '';
   }
 
   @action
   setTitle(event) {
-    this._title = event.target.value;
-    if (this.args.onChange) {
-      this.args.onChange(this._title);
-    }
-    if (this._title) {
+    let title = event.target.value;
+
+    this.args.onChange?.(title);
+
+    if (title) {
       this.error = false;
     }
   }


### PR DESCRIPTION
I noticed that typing in a title showed an exception in the console.

Did a little refactoring while I was at it :smile:.