### PR TITLE
Meeting creation flow changes

### DIFF
--- a/app/components/administrative-body-select.hbs
+++ b/app/components/administrative-body-select.hbs
@@ -1,0 +1,18 @@
+<div class={{if @error "ember-power-select--error"}}>
+  <PowerSelect
+    @placeholder={{t "manageZittingsData.selectPlaceholder"}}
+    @selected={{@selected}}
+    @options={{this.administrativeBodyOptions}}
+    @onChange={{@onChange}}
+    @triggerId={{@id}}
+    as |administrativeBody|
+  >
+    {{administrativeBody.isTijdsspecialisatieVan.naam}}
+    (periode: {{moment-format administrativeBody.bindingStart "MM/DD/YYYY"}} -
+    {{#if administrativeBody.bindingEinde~}}
+      {{moment-format administrativeBody.bindingEinde "MM/DD/YYYY"}}
+    {{~else~}}
+      nvt.
+    {{~/if}})
+  </PowerSelect>
+</div>

--- a/app/components/administrative-body-select.js
+++ b/app/components/administrative-body-select.js
@@ -1,0 +1,53 @@
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { task } from 'ember-concurrency';
+
+const VALID_ADMINISTRATIVE_BODY_CLASSIFICATIONS = [
+  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000005", //	"Gemeenteraad"
+  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000007", //	"Raad voor Maatschappelijk Welzijn"
+  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000009", //	"Bijzonder Comité voor de Sociale Dienst"
+  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000a", //	"Districtsraad"
+  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000c", //	"Provincieraad"
+  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/53c0d8cd-f3a2-411d-bece-4bd83ae2bbc9", //	"Voorzitter van het Bijzonder Comité voor de Sociale Dienst"
+  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/9314533e-891f-4d84-a492-0338af104065", //	"Districtsburgemeester"
+  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000b", //	"Districtscollege"
+  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/180a2fba-6ca9-4766-9b94-82006bb9c709", //	"Gouverneur"
+  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/e14fe683-e061-44a2-b7c8-e10cab4e6ed9", //	"Voorzitter van de Raad voor Maatschappelijk Welzijn"
+  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000006", //	"College van Burgemeester en Schepenen"
+  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/4c38734d-2cc1-4d33-b792-0bd493ae9fc2", //	"Voorzitter van de Gemeenteraad"
+  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000d", //	"Deputatie"
+  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/4955bd72cd0e4eb895fdbfab08da0284", //	"Burgemeester"
+  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000008" //	"Vast Bureau"
+];
+
+export default class AdministrativeBodySelectComponent extends Component {
+  @service currentSession;
+  @service store;
+  @tracked administrativeBodyOptions = [];
+
+  constructor() {
+    super(...arguments);
+
+    this.fetchAdministrativeBodies.perform();
+  }
+
+  @task
+  * fetchAdministrativeBodies() {
+    let currentAdministrativeUnitId = this.currentSession.group.id;
+
+    let administrativeBodiesInTime = yield this.store.query('bestuursorgaan', {
+      'filter[is-tijdsspecialisatie-van][bestuurseenheid][id]': currentAdministrativeUnitId,
+      'include': [
+        'is-tijdsspecialisatie-van.bestuurseenheid',
+        'is-tijdsspecialisatie-van.classificatie',
+      ].join(),
+      'sort': '-binding-start'
+    });
+
+    this.administrativeBodyOptions = administrativeBodiesInTime.filter((administrativeBodyInTime) => {
+      let classificationUrl = administrativeBodyInTime.get('isTijdsspecialisatieVan.classificatie.uri');
+      return VALID_ADMINISTRATIVE_BODY_CLASSIFICATIONS.includes(classificationUrl);
+    });
+  }
+}

--- a/app/components/meeting-form.hbs
+++ b/app/components/meeting-form.hbs
@@ -105,7 +105,6 @@
       </AuHeading>
       <Zitting::ManageZittingsdata
         @zitting={{@zitting}}
-        @onCreate={{@onCreateMeeting}}
         @onChange={{this.meetingInfoUpdate}}
         @readOnly={{this.readOnly}}
       />

--- a/app/components/meeting-form.hbs
+++ b/app/components/meeting-form.hbs
@@ -92,7 +92,10 @@
   <div class="au-c-meeting-chrome">
     <div class="au-c-meeting-chrome__paper">
       {{!-- Meeting title --}}
-      <AuHeading>{{t "meetingForm.meetingHeadingPartOne"}} <span class="au-c-meeting-chrome__highlight">{{@zitting.bestuursorgaan.isTijdsspecialisatieVan.naam}}</span>, {{t "meetingForm.meetingHeadingPartTwo"}} <span class="au-c-meeting-chrome__highlight">{{moment-format  @zitting.geplandeStart "DD/MM/YYYY HH:mm"}}</span></AuHeading>
+      <AuHeading>
+        {{t "meetingForm.meetingHeadingPartOne"}} <span class="au-c-meeting-chrome__highlight">{{@zitting.bestuursorgaan.isTijdsspecialisatieVan.naam}},</span>
+        {{t "meetingForm.meetingHeadingPartTwo"}} <span class="au-c-meeting-chrome__highlight">{{moment-format  @zitting.geplandeStart "DD/MM/YYYY HH:mm"}}</span>
+      </AuHeading>
       <AuHr @size="large"/>
 
       {{!-- General Information --}}
@@ -159,7 +162,7 @@
             </span>
           </AuHeading>
           <ZittingTextDocumentContainer @zitting={{@zitting}} @readOnly={{this.readOnly}} @type="ext:intro"/>
-  
+
           {{!-- Treatment of agenda --}}
           <AuHeading id="sectionFive" @level="2" @skin="3" class="au-c-onboarding-wrapper au-u-margin-top-huge">
             {{t "meetingForm.fifthSectionTitle"}}

--- a/app/components/required-field.hbs
+++ b/app/components/required-field.hbs
@@ -1,0 +1,1 @@
+<AuPill ...attributes>{{t "requiredField.required"}}</AuPill>

--- a/app/components/zitting/manage-zittingsdata.hbs
+++ b/app/components/zitting/manage-zittingsdata.hbs
@@ -1,29 +1,27 @@
-<div {{did-insert this.fetchBestuursorgaan}}>
-  <div class="au-c-meeting-chrome-card au-u-margin-bottom-large">
-    <ul class="au-c-list-divider">
-      <li class="au-c-list-divider__item">
-        {{t "manageZittingsData.bestuursorganLabel"}} <strong>{{this.bestuursorgaan.isTijdsspecialisatieVan.naam}}</strong>
-      </li>
-      <li class="au-c-list-divider__item">
-        {{t "manageZittingsData.geplandeStartLabel"}} <strong>{{moment-format  this.geplandeStart "DD/MM/YYYY HH:mm"}}</strong>
-      </li>
-      <li class="au-c-list-divider__item">
-        {{t "manageZittingsData.opLocatieLabel"}} <strong>{{this.opLocatie}}</strong>
-      </li>
-      <li class="au-c-list-divider__item">
-        {{t "manageZittingsData.gestartOpTijdstipLabel"}} <strong>{{moment-format this.gestartOpTijdstip "DD/MM/YYYY HH:mm"}}</strong>
-      </li>
-      <li class="au-c-list-divider__item">
-        {{t "manageZittingsData.geeindigdOpTijdstipLabel"}} <strong>{{moment-format this.geeindigdOpTijdstip "DD/MM/YYYY HH:mm"}}</strong>
-      </li>
-    </ul>
-    {{#unless @readOnly}}
-      <AuButton {{on "click" this.toggleModal}} @skin="secondary" @width="block" @icon="pencil" @iconAlignment="left">{{t "manageZittingsData.openModalButton"}}</AuButton>
-    {{/unless}}
-  </div>
+<div class="au-c-meeting-chrome-card au-u-margin-bottom-large">
+  <ul class="au-c-list-divider">
+    <li class="au-c-list-divider__item">
+      {{t "manageZittingsData.bestuursorganLabel"}} <strong>{{this.bestuursorgaan.isTijdsspecialisatieVan.naam}}</strong>
+    </li>
+    <li class="au-c-list-divider__item">
+      {{t "manageZittingsData.geplandeStartLabel"}} <strong>{{moment-format  this.geplandeStart "DD/MM/YYYY HH:mm"}}</strong>
+    </li>
+    <li class="au-c-list-divider__item">
+      {{t "manageZittingsData.opLocatieLabel"}} <strong>{{this.opLocatie}}</strong>
+    </li>
+    <li class="au-c-list-divider__item">
+      {{t "manageZittingsData.gestartOpTijdstipLabel"}} <strong>{{moment-format this.gestartOpTijdstip "DD/MM/YYYY HH:mm"}}</strong>
+    </li>
+    <li class="au-c-list-divider__item">
+      {{t "manageZittingsData.geeindigdOpTijdstipLabel"}} <strong>{{moment-format this.geeindigdOpTijdstip "DD/MM/YYYY HH:mm"}}</strong>
+    </li>
+  </ul>
+  {{#unless @readOnly}}
+    <AuButton {{on "click" this.toggleModal}} @skin="secondary" @width="block" @icon="pencil" @iconAlignment="left">{{t "manageZittingsData.openModalButton"}}</AuButton>
+  {{/unless}}
 </div>
 
-  {{#if this.showModal}}
+{{#if this.showModal}}
   <AuModal
     @modalTitle={{t "manageZittingsData.modalTitle"}}
     @modalOpen={{this.showModal}}
@@ -32,24 +30,19 @@
       <div class="au-o-flow">
         <div>
           <AuLabel>{{t "manageZittingsData.bestuursorganLabel"}}</AuLabel>
-          <PowerSelect
-            @placeholder={{t "manageZittingsData.selectPlaceholder"}}
-            @selected={{this.bestuursorgaan}}
-            @options={{this.bestuursorgaanOptions}}
-            @onChange={{this.changeSelect}}
-            as |bestuursorgaan|>
-              {{bestuursorgaan.isTijdsspecialisatieVan.naam}}
-              (periode: {{moment-format bestuursorgaan.bindingStart "MM/DD/YYYY"}} -
-              {{#if bestuursorgaan.bindingEinde}}{{moment-format bestuursorgaan.bindingEinde "MM/DD/YYYY"}}{{else}}nvt.{{/if}})
-          </PowerSelect>
+          {{this.bestuursorgaan.isTijdsspecialisatieVan.naam}}
+          (periode: {{moment-format this.bestuursorgaan.bindingStart "MM/DD/YYYY"}} -
+          {{#if this.bestuursorgaan.bindingEinde}}{{moment-format this.bestuursorgaan.bindingEinde "MM/DD/YYYY"}}{{else}}nvt.{{/if}})
+        </div>
+        <div>
+          {{#let (unique-id) as |id|}}
+            <AuLabel for={{id}}>{{t "manageZittingsData.opLocatieLabel"}}</AuLabel>
+            <AuInput type='text' @value={{mut this.opLocatie}} @width="block" id={{id}} />
+          {{/let}}
         </div>
         <div>
           <AuLabel>{{t "manageZittingsData.geplandeStartLabel"}}</AuLabel>
           <DateTimePicker @onChange={{fn this.changeDate 'geplandeStart'}} @value={{this.geplandeStart}}/>
-        </div>
-        <div>
-          <AuLabel>{{t "manageZittingsData.opLocatieLabel"}}</AuLabel>
-          <AuInput type='text' @value={{mut this.opLocatie}} />
         </div>
         <div>
           <AuLabel>{{t "manageZittingsData.gestartOpTijdstipLabel"}}</AuLabel>
@@ -72,4 +65,4 @@
       </AuButtonGroup>
     </Modal.Footer>
   </AuModal>
-  {{/if}}
+{{/if}}

--- a/app/components/zitting/manage-zittingsdata.hbs
+++ b/app/components/zitting/manage-zittingsdata.hbs
@@ -1,4 +1,28 @@
 <div {{did-insert this.fetchBestuursorgaan}}>
+  <div class="au-c-meeting-chrome-card au-u-margin-bottom-large">
+    <ul class="au-c-list-divider">
+      <li class="au-c-list-divider__item">
+        {{t "manageZittingsData.bestuursorganLabel"}} <strong>{{this.bestuursorgaan.isTijdsspecialisatieVan.naam}}</strong>
+      </li>
+      <li class="au-c-list-divider__item">
+        {{t "manageZittingsData.geplandeStartLabel"}} <strong>{{moment-format  this.geplandeStart "DD/MM/YYYY HH:mm"}}</strong>
+      </li>
+      <li class="au-c-list-divider__item">
+        {{t "manageZittingsData.opLocatieLabel"}} <strong>{{this.opLocatie}}</strong>
+      </li>
+      <li class="au-c-list-divider__item">
+        {{t "manageZittingsData.gestartOpTijdstipLabel"}} <strong>{{moment-format this.gestartOpTijdstip "DD/MM/YYYY HH:mm"}}</strong>
+      </li>
+      <li class="au-c-list-divider__item">
+        {{t "manageZittingsData.geeindigdOpTijdstipLabel"}} <strong>{{moment-format this.geeindigdOpTijdstip "DD/MM/YYYY HH:mm"}}</strong>
+      </li>
+    </ul>
+    {{#unless @readOnly}}
+      <AuButton {{on "click" this.toggleModal}} @skin="secondary" @width="block" @icon="pencil" @iconAlignment="left">{{t "manageZittingsData.openModalButton"}}</AuButton>
+    {{/unless}}
+  </div>
+</div>
+
   {{#if this.showModal}}
   <AuModal
     @modalTitle={{t "manageZittingsData.modalTitle"}}
@@ -48,28 +72,4 @@
       </AuButtonGroup>
     </Modal.Footer>
   </AuModal>
-  {{else}}
-  <div class="au-c-meeting-chrome-card au-u-margin-bottom-large">
-    <ul class="au-c-list-divider">
-      <li class="au-c-list-divider__item">
-        {{t "manageZittingsData.bestuursorganLabel"}} <strong>{{this.bestuursorgaan.isTijdsspecialisatieVan.naam}}</strong>
-      </li>
-      <li class="au-c-list-divider__item">
-        {{t "manageZittingsData.geplandeStartLabel"}} <strong>{{moment-format  this.geplandeStart "DD/MM/YYYY HH:mm"}}</strong>
-      </li>
-      <li class="au-c-list-divider__item">
-        {{t "manageZittingsData.opLocatieLabel"}} <strong>{{this.opLocatie}}</strong>
-      </li>
-      <li class="au-c-list-divider__item">
-        {{t "manageZittingsData.gestartOpTijdstipLabel"}} <strong>{{moment-format this.gestartOpTijdstip "DD/MM/YYYY HH:mm"}}</strong>
-      </li>
-      <li class="au-c-list-divider__item">
-        {{t "manageZittingsData.geeindigdOpTijdstipLabel"}} <strong>{{moment-format this.geeindigdOpTijdstip "DD/MM/YYYY HH:mm"}}</strong>
-      </li>
-    </ul>
-    {{#unless @readOnly}}
-      <AuButton {{on "click" this.toggleModal}} @skin="secondary" @width="block" @icon="pencil" @iconAlignment="left">{{t "manageZittingsData.openModalButton"}}</AuButton>
-    {{/unless}}
-  </div>
   {{/if}}
-</div>

--- a/app/components/zitting/manage-zittingsdata.js
+++ b/app/components/zitting/manage-zittingsdata.js
@@ -1,7 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from "@ember/object";
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
 
 export default class ZittingManageZittingsdataComponent extends Component {
   @tracked showModal = false;
@@ -11,28 +10,6 @@ export default class ZittingManageZittingsdataComponent extends Component {
   @tracked geeindigdOpTijdstip;
   @tracked opLocatie;
   @tracked bestuursorgaan;
-  @tracked bestuursorgaanOptions;
-
-  @service store;
-  @service currentSession;
-
-  allowedBestuursorgaanClassifications = [
-    "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000005", //	"Gemeenteraad"
-    "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000007", //	"Raad voor Maatschappelijk Welzijn"
-    "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000009", //	"Bijzonder Comité voor de Sociale Dienst"
-    "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000a", //	"Districtsraad"
-    "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000c", //	"Provincieraad"
-    "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/53c0d8cd-f3a2-411d-bece-4bd83ae2bbc9", //	"Voorzitter van het Bijzonder Comité voor de Sociale Dienst"
-    "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/9314533e-891f-4d84-a492-0338af104065", //	"Districtsburgemeester"
-    "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000b", //	"Districtscollege"
-    "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/180a2fba-6ca9-4766-9b94-82006bb9c709", //	"Gouverneur"
-    "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/e14fe683-e061-44a2-b7c8-e10cab4e6ed9", //	"Voorzitter van de Raad voor Maatschappelijk Welzijn"
-    "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000006", //	"College van Burgemeester en Schepenen"
-    "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/4c38734d-2cc1-4d33-b792-0bd493ae9fc2", //	"Voorzitter van de Gemeenteraad"
-    "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000d", //	"Deputatie"
-    "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/4955bd72cd0e4eb895fdbfab08da0284", //	"Burgemeester"
-    "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000008" //	"Vast Bureau"
-  ];
 
   constructor() {
     super(...arguments);
@@ -49,20 +26,6 @@ export default class ZittingManageZittingsdataComponent extends Component {
   }
 
   @action
-  async fetchBestuursorgaan() {
-    // TODO: Move select Bestuursorgaan to component
-    const currentBestuurseenheid = this.currentSession.group;
-    let query = {
-      'filter[is-tijdsspecialisatie-van][bestuurseenheid][id]': currentBestuurseenheid.id,
-      'include':'is-tijdsspecialisatie-van,is-tijdsspecialisatie-van.bestuurseenheid,is-tijdsspecialisatie-van.classificatie',
-      'sort': '-binding-start'
-    };
-    let bestuursorganenInTijd = await this.store.query('bestuursorgaan', query);
-    bestuursorganenInTijd = bestuursorganenInTijd.filter(b => this.allowedBestuursorgaanClassifications.includes(b.get('isTijdsspecialisatieVan.classificatie.uri')));
-    this.bestuursorgaanOptions = bestuursorganenInTijd;
-  }
-
-  @action
   async saveZittingsData(){
     this.zitting.geplandeStart = this.geplandeStart;
     this.zitting.gestartOpTijdstip = this.gestartOpTijdstip;
@@ -70,23 +33,9 @@ export default class ZittingManageZittingsdataComponent extends Component {
     this.zitting.opLocatie = this.opLocatie;
     this.zitting.bestuursorgaan = this.bestuursorgaan;
 
-    if(!this.zitting.id){
-      await this.zitting.save();
-      this.args.onCreate(this.zitting);
-    }
-    else {
-      await this.zitting.save();
-      this.showModal = !this.showModal;
-      this.args.onChange(this.zitting);
-    }
-  }
-
-  @action
-  async changeSelect(bestuursorgaan) {
-    this.bestuursorgaan = bestuursorgaan;
-    this.zitting.voorzitter = undefined;
-    this.zitting.secretaris = undefined;
-    this.zitting.aanwezigenBijStart = [];
+    await this.zitting.save();
+    this.toggleModal();
+    this.args.onChange(this.zitting);
   }
 
   @action

--- a/app/controllers/inbox/meetings.js
+++ b/app/controllers/inbox/meetings.js
@@ -1,17 +1,12 @@
 import { inject as service } from '@ember/service';
 import Controller from '@ember/controller';
 import DefaultQueryParamsMixin from 'ember-data-table/mixins/default-query-params';
-import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
 export default class InboxMeetingsController extends Controller.extend(DefaultQueryParamsMixin) {
   @service currentSession;
   @tracked sort = '-geplande-start';
 
-  @action
-  openNewDocument() {
-    this.transitionToRoute('meetings.new');
-  }
   get readOnly(){
     return !this.currentSession.canWrite && this.currentSession.canRead;
   }

--- a/app/controllers/inbox/meetings/new.js
+++ b/app/controllers/inbox/meetings/new.js
@@ -1,0 +1,43 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { dropTask } from 'ember-concurrency';
+import { inject as service } from '@ember/service';
+
+export default class InboxMeetingsNewController extends Controller {
+  @service router;
+
+  get meeting() {
+    return this.model;
+  }
+
+  @dropTask
+  * saveMeetingTask(event) {
+    event.preventDefault();
+
+    let bestuursorgaan = yield this.meeting.bestuursorgaan;
+    if (!bestuursorgaan) {
+      this.meeting.errors.add('bestuursorgaan', 'inbox.meetings.new.meeting.errors.administrativeBody.required');
+    }
+
+    if (this.meeting.isValid) {
+      yield this.meeting.save();
+      this.router.replaceWith('meetings.edit', this.meeting.id);
+    }
+  }
+
+  @action
+  updateAdministrativeBody(administrativeBody) {
+    this.meeting.bestuursorgaan = administrativeBody;
+    this.meeting.errors.remove('bestuursorgaan');
+  }
+
+  @action
+  cancelMeetingCreation() {
+    this.meeting.destroyRecord();
+
+    // Ember has a bug where using the router service here, reruns the parent's model hooks.
+    // More info: https://github.com/emberjs/ember.js/issues/19497
+    // TODO use the router service once the bug is fixed
+    this.replaceRoute('inbox.meetings');
+  }
+}

--- a/app/controllers/meetings/new.js
+++ b/app/controllers/meetings/new.js
@@ -1,9 +1,0 @@
-import Controller from '@ember/controller';
-import { action } from "@ember/object";
-
-export default class MeetingsNewController extends Controller {
-  @action
-  async goToEditRoute(zitting) {
-    this.transitionToRoute('meetings.edit', zitting.id);
-  }
-}

--- a/app/router.js
+++ b/app/router.js
@@ -10,7 +10,9 @@ Router.map(function() {
   this.route('inbox', function() {
     this.route('trash');
     this.route('agendapoints');
-    this.route('meetings');
+    this.route('meetings', function() {
+      this.route('new');
+    });
   });
   this.route('mock-login');
   this.route('login');
@@ -41,7 +43,6 @@ Router.map(function() {
   });
 
   this.route('meetings', function() {
-    this.route('new');
     this.route('edit', { path: '/:id/edit' });
     this.route('publish',{path: '/:id/publish'}, function() {
       this.route('agenda');

--- a/app/routes/inbox/meetings/new.js
+++ b/app/routes/inbox/meetings/new.js
@@ -1,16 +1,19 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
-export default class MeetingsNewRoute extends Route {
+export default class InboxMeetingsNewRoute extends Route {
   @service currentSession;
+  @service router;
+  @service store;
+
   beforeModel() {
-    if(!this.currentSession.canWrite) {
-      this.transitionTo('inbox.meetings');
+    if (!this.currentSession.canWrite) {
+      this.router.replaceWith('inbox.meetings');
     }
   }
 
-  model(){
-    const now = new Date();
+  model() {
+    let now = new Date();
     return this.store.createRecord('zitting', {
       geplandeStart: now,
       gestartOpTijdstip: now,

--- a/app/templates/inbox/meetings.hbs
+++ b/app/templates/inbox/meetings.hbs
@@ -1,5 +1,5 @@
-<AuDataTable @content={{this.model}} @isLoading={{this.isLoadingModel}} @noDataMessage="Geen zittingen" @sort={{this.sort}} @page={{this.page}} @size={{this.size}} @class="container-flex--contain" as |t|>
-  <t.menu as |menu|>
+<AuDataTable @content={{this.model}} @isLoading={{this.isLoadingModel}} @noDataMessage="Geen zittingen" @sort={{this.sort}} @page={{this.page}} @size={{this.size}} @class="container-flex--contain" as |table|>
+  <table.menu as |menu|>
     <menu.general>
       <AuToolbar @size="large">
         <AuToolbarGroup>
@@ -9,15 +9,15 @@
         </AuToolbarGroup>
         <AuToolbarGroup class="au-c-toolbar__group--search">
           {{#unless this.readOnly}}
-            <AuButton {{on "click" this.openNewDocument}}>
-              Nieuwe zitting
-            </AuButton>
+            <LinkTo @route="inbox.meetings.new" class="au-c-button">
+              {{t "inbox.meetings.newMeeting"}}
+            </LinkTo>
           {{/unless}}
         </AuToolbarGroup>
       </AuToolbar>
     </menu.general>
-  </t.menu>
-  <t.content as |c|>
+  </table.menu>
+  <table.content as |c|>
     <c.header>
       <th><span class="au-c-data-table__header-title au-c-data-table__header-title--sortable">Zitting</span></th>
       <AuDataTableThSortable @field="bestuursorgaan.isTijdsspecialisatieVan.naam" @currentSorting={{this.sort}} @label="Bestuursorgaan" />
@@ -34,7 +34,7 @@
         {{meeting.opLocatie}}
       </td>
     </c.body>
-  </t.content>
+  </table.content>
 </AuDataTable>
 
 {{outlet}}

--- a/app/templates/inbox/meetings/new.hbs
+++ b/app/templates/inbox/meetings/new.hbs
@@ -1,0 +1,61 @@
+{{page-title (t "inbox.meetings.new.title")}}
+
+<AuModal
+  @modalTitle={{t "inbox.meetings.new.title"}}
+  @modalOpen={{true}}
+  @closeModal={{this.cancelMeetingCreation}}
+  as |Modal|
+>
+  <Modal.Body>
+    <form class="au-o-flow" id="create-meeting-form" {{on "submit" (perform this.saveMeetingTask)}}>
+      <div>
+        {{#let (unique-id) this.meeting.errors.bestuursorgaan as |id errors|}}
+          <AuLabel
+            @error={{if errors true false}}
+            for={{id}}
+          >
+            {{t "inbox.meetings.new.meeting.administrativeBody"}} <RequiredField />
+          </AuLabel>
+          <AdministrativeBodySelect
+            @id={{id}}
+            @selected={{this.meeting.bestuursorgaan}}
+            @onChange={{this.updateAdministrativeBody}}
+            @error={{if errors true false}}
+          />
+          {{#each errors as |error|}}
+            <AuHelpText @error={{true}}>
+              {{t error.message}}
+            </AuHelpText>
+          {{/each}}
+        {{/let}}
+      </div>
+      <div>
+        {{#let (unique-id) as |id|}}
+          <AuLabel for={{id}}>{{t "inbox.meetings.new.meeting.location"}}</AuLabel>
+          <AuInput @value={{this.meeting.opLocatie}} @width="block" id={{id}} type="text" />
+        {{/let}}
+      </div>
+      <div>
+        <AuLabel>{{t "inbox.meetings.new.meeting.plannedStart"}}</AuLabel>
+        <DateTimePicker @onChange={{fn (mut this.meeting.geplandeStart)}} @value={{this.meeting.geplandeStart}}/>
+      </div>
+    </form>
+  </Modal.Body>
+  <Modal.Footer>
+    <AuButtonGroup>
+      {{!-- Due to a bug in Ember overriding the type of a button component with splattributes isn't possible --}}
+      {{!-- More information: https://github.com/emberjs/ember.js/issues/18232 --}}
+      {{!-- TODO: Replace this with the AuButton component once the app is updated to 3.25+ or the fix is backported to 3.24 LTS --}}
+      <button
+        class="au-c-button {{if this.saveMeetingTask.isRunning "is-loading"}}"
+        form="create-meeting-form"
+        type="submit"
+      >
+        {{t "inbox.meetings.new.save"}}
+      </button>
+      <AuButton {{on "click" this.cancelMeetingCreation}} @skin="secondary">
+        {{t "inbox.meetings.new.cancel"}}
+      </AuButton>
+    </AuButtonGroup>
+  </Modal.Footer>
+</AuModal>

--- a/app/templates/meetings/new.hbs
+++ b/app/templates/meetings/new.hbs
@@ -1,2 +1,0 @@
-
-<MeetingForm @zitting={{@model}} @onCreateMeeting={{this.goToEditRoute}} />

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@appuniversum/appuniversum": "0.0.15",
-    "@appuniversum/ember-appuniversum": "0.4.0",
+    "@appuniversum/ember-appuniversum": "0.4.4",
     "@ember/optional-features": "^2.0.0",
     "@ember/render-modifiers": "^1.0.2",
     "@ember/test-helpers": "^2.1.4",

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -287,3 +287,5 @@ manageIntermissions:
   checkboxLabel: I understand that the intermission will be irreversibly removed.
   retainButton: Retain intermission
   deleteButton: Delete intermission
+requiredField:
+  required: Required

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -4,6 +4,19 @@ inbox:
     agendapoints: Agenda points
     trash: Recycle bin
     manual: View manual
+  meetings:
+    newMeeting: New meeting
+    new:
+      title: Create a new meeting
+      meeting:
+        administrativeBody: Held by
+        location: On location
+        plannedStart: Scheduled start
+        errors:
+          administrativeBody:
+            required: Please select an administrative body
+      save: Create meeting
+      cancel: Back
   agendapoints:
     pageTitle: Agendapoints
     searchPlaceholder: Type the title of a agendapoint

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -286,3 +286,5 @@ manageIntermissions:
   checkboxLabel: Ik begrijp dat deze onderbreking onomkeerbaar verwijderd gaat worden.
   deleteButton: Verwijder onderbreking
   retainButton: Behoud onderbreking
+requiredField:
+  required: Verplicht

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -4,6 +4,19 @@ inbox:
     agendapoints: Agendapunten
     trash: Prullenmand
     manual: Bekijk handleiding
+  meetings:
+    newMeeting: Nieuwe zitting
+    new:
+      title: Nieuwe zitting aanmaken
+      meeting:
+        administrativeBody: Gehouden door
+        location: Op locatie
+        plannedStart: Geplande start
+        errors:
+          administrativeBody:
+            required: Gelieve een bestuursorgaan te selecteren
+      save: Zitting aanmaken
+      cancel: Terug
   agendapoints:
     pageTitle: Agendapunten
     searchPlaceholder: Zoek titel agendapunt


### PR DESCRIPTION
This changes the meeting creation flow. Instead of showing a "faux" edit page on which the user needs to click a button to open a modal, it now opens a modal directly. It also validates that an administrative body is selected before a meeting is created. On the edit page the administrative body is now readonly (GN-2651).