### PR TITLE
Set the application title using `{{page-title}}`

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,6 +1,5 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
-import ENV from 'frontend-gelinkt-notuleren/config/environment';
 
 const featureFlagRegex = /^feature\[(.+)\]$/;
 
@@ -10,9 +9,7 @@ export default class ApplicationRoute extends Route {
 
   beforeModel(transition) {
     this.updateFeatureFlags(transition.to.queryParams);
-    if(ENV.environmentName) {
-      document.title = `Gelinkt Notuleren - ${ENV.environmentName}`;
-    }
+
     return this.loadCurrentSession();
   }
 

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,5 +1,12 @@
 <EmberLoadRemover />
 
+{{#let (config "environmentName") as |environmentName|}}
+  {{page-title (concat
+    "Gelinkt Notuleren"
+    (if environmentName (concat " - " environmentName))
+  )}}
+{{/let}}
+
 <div class="au-c-app-container">
   {{outlet}}
 


### PR DESCRIPTION
This sets the application title using the `{{page-title}}` helper. This allows other pages to also use the helper without overriding the base title.