### PR TITLE
Bugfix/error publishing notulen

### DIFF
--- a/app/controllers/meetings/publish/notulen.js
+++ b/app/controllers/meetings/publish/notulen.js
@@ -78,7 +78,7 @@ export default class MeetingsPublishNotulenController extends Controller {
   * createSignedResource() {
     const id = this.model.id;
     yield fetch(`/signing/notulen/sign/${id}`, { method: 'POST' });
-    setTimeout(() => this.reloadNotulen.perform(), 500);
+    setTimeout(() => this.reloadNotulen.perform(), 1);
   }
 
   @task
@@ -92,7 +92,7 @@ export default class MeetingsPublishNotulenController extends Controller {
                   }),
                   method: 'POST'
                 });
-    setTimeout(() => this.reloadNotulen.perform(), 500);
+    setTimeout(() => this.reloadNotulen.perform(), 1);
   }
 
   get zittingWrapper() {

--- a/app/controllers/meetings/publish/notulen.js
+++ b/app/controllers/meetings/publish/notulen.js
@@ -78,7 +78,7 @@ export default class MeetingsPublishNotulenController extends Controller {
   * createSignedResource() {
     const id = this.model.id;
     yield fetch(`/signing/notulen/sign/${id}`, { method: 'POST' });
-    yield this.reloadNotulen.perform();
+    setTimeout(() => this.reloadNotulen.perform(), 500);
   }
 
   @task
@@ -92,8 +92,7 @@ export default class MeetingsPublishNotulenController extends Controller {
                   }),
                   method: 'POST'
                 });
-    yield this.reloadNotulen.perform();
-
+    setTimeout(() => this.reloadNotulen.perform(), 500);
   }
 
   get zittingWrapper() {

--- a/app/templates/meetings/publish/notulen.hbs
+++ b/app/templates/meetings/publish/notulen.hbs
@@ -1,5 +1,5 @@
 <div class="au-o-box">
-  {{#if this.initializeNotulen.isIdle}}
+  {{#if (and this.initializeNotulen.isIdle this.reloadNotulen.isIdle)}}
   <ul>
     <Signatures::Notulen::TimelineStep
       @name="notulen"


### PR DESCRIPTION
I want some feedback on this, I know the solution is kinda tricky but not sure how to solve it in a "good way".
Basically the problem I have is that if I reload the notulen without reloading the UI I get an error
```
runtime.js:4147 Uncaught (in promise) DOMException: Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.
```

I solved this reloading the UI when the function that reloads the notulen is running, but then I ran into the second bug, If I do that in a syncronous way I get the old notulen back, the one that's not yet published, but if I execute it asynchronous with a timeout the problem is solved, the timeout can be as low as one ms.