### PR TITLE
Alway revert "meeting"  data changes when closing

### DIFF
--- a/app/components/zitting/manage-zittingsdata.hbs
+++ b/app/components/zitting/manage-zittingsdata.hbs
@@ -25,7 +25,7 @@
   <AuModal
     @modalTitle={{t "manageZittingsData.modalTitle"}}
     @modalOpen={{this.showModal}}
-    @closeModal={{fn (mut this.showModal) false}} as |Modal| >
+    @closeModal={{this.cancel}} as |Modal| >
     <Modal.Body>
       <div class="au-o-flow">
         <div>


### PR DESCRIPTION
This makes sure changes to the meeting data are reverted when closing the modal by pressing escape or clicking outside of it.