### PR TITLE
Feature/publish service

### DIFF
--- a/app/components/extracts/print-view.hbs
+++ b/app/components/extracts/print-view.hbs
@@ -1,7 +1,7 @@
 <PrintView as |Print|>
   <Print.Header as |Header|>
     {{#if @backLinkRoute}}
-      <Header.BackLink @linkRoute={{@backLinkRoute}} @model={{@model}} @models={{@models}}>
+      <Header.BackLink @linkRoute={{@backLinkRoute}} @model={{@linkModel}} @models={{@linkModels}}>
         Terug naar ondertekenen & publiceren
       </Header.BackLink>
     {{/if}}

--- a/app/components/signatures/behandeling/timeline-step.hbs
+++ b/app/components/signatures/behandeling/timeline-step.hbs
@@ -1,10 +1,10 @@
 <Signatures::TimelineStep
   @name={{@name}}
-  @document={{@behandeling}}
-  @errors={{@errors}}
+  @document={{@extract.document}}
+  @errors={{@extract.errors}}
   @signing={{@signing}}
   @publish={{@publish}}
   @mockDocument={{this.mockBehandeling}}
   @isOpen={{this.isOpen}}
-  @print={{@print}}
+  @print={{fn @print @extract}}
 />

--- a/app/components/signatures/behandeling/timeline-step.hbs
+++ b/app/components/signatures/behandeling/timeline-step.hbs
@@ -6,5 +6,5 @@
   @publish={{@publish}}
   @mockDocument={{this.mockBehandeling}}
   @isOpen={{this.isOpen}}
-  @print={{fn @print @extract}}
+  @print={{@print}}
 />

--- a/app/components/signatures/behandeling/timeline-step.js
+++ b/app/components/signatures/behandeling/timeline-step.js
@@ -3,8 +3,8 @@ import Component from '@glimmer/component';
 export default class SignaturesBesluitenlijstTimelineStep extends Component {
   get mockBehandeling() {
     return {
-      body: this.args.behandeling.content,
-      signedId: this.args.behandeling.zitting.get('id')
+      body: this.args.extract.document.content,
+      signedId: this.args.extract.document.zitting.get('id')
     };
   }
 }

--- a/app/components/signatures/timeline-step.hbs
+++ b/app/components/signatures/timeline-step.hbs
@@ -152,7 +152,7 @@
           </AuToolbarGroup>
         </AuToolbar>
         <div class="au-u-margin-top-none au-u-margin-bottom-large">
-          <AuButton {{ on 'click' (fn @print @document)}} >
+          <AuButton {{ on 'click' @print }} >
             {{t "timelineStep.printButtonLabel" name=@name}}
           </AuButton>
         </div>

--- a/app/controllers/meetings/publish/uittreksels.js
+++ b/app/controllers/meetings/publish/uittreksels.js
@@ -1,106 +1,72 @@
 import Controller from '@ember/controller';
-import {task} from "ember-concurrency";
-import {tracked} from "@glimmer/tracking";
+import { task } from 'ember-concurrency';
+import { tracked } from '@glimmer/tracking';
 import { fetch } from 'fetch';
 import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 export default class MeetingsPublishUittrekselsController extends Controller {
-  @tracked uittreksels;
+  @service publish;
   @tracked documentToPrint;
   @tracked showPrintModal;
 
   @tracked errors;
 
-
   initialize() {
-    this.uittreksels = [];
     this.documentToPrint = null;
     this.showPrintModal = false;
-    this.initializeUittreksels.perform();
+    this.loadExtractsTask.perform();
   }
 
   get meeting() {
     return this.model;
   }
 
-  @task
-  * initializeUittreksels() {
-    const uittreksels = [];
-    const previews = yield this.fetchExtractPreviews.perform();
-    for(const uittreksel of previews) {
-      const existingUittreksels = yield this.store.query('versioned-behandeling',{
-        'filter[behandeling][:id:]': uittreksel.data.attributes.uuid,
-        include: 'signed-resources,published-resource,behandeling'
-      });
-      if(existingUittreksels.length) {
-        uittreksels.push({document: existingUittreksels.firstObject});
-      } else {
-        const behandeling = yield this.store.findRecord('behandeling-van-agendapunt', uittreksel.data.attributes.uuid);
-        const rslt = yield this.store.createRecord("versioned-behandeling", {
-          zitting: this.meeting,
-          content: uittreksel.data.attributes.content,
-          behandeling,
-        });
-        uittreksels.push({document: rslt, errors: uittreksel.data.attributes.errors});
-      }
-    }
-    this.uittreksels = uittreksels;
+  get uittreksels() {
+    return this.publish.treatmentExtracts;
+  }
+
+  get isLoading() {
+    return this.loadExtractsTask.isRunning;
   }
 
   @task
-  * reloadUittreksels() {
-    const uittreksels = [];
-    const previews = yield this.fetchExtractPreviews.perform();
-    for(const uittreksel of previews) {
-      const existingUittreksels = yield this.store.query('versioned-behandeling',{
-        'filter[behandeling][:id:]': uittreksel.data.attributes.uuid,
-        include: 'signed-resources,published-resource'
-      });
-      if(existingUittreksels.length) {
-        uittreksels.push(existingUittreksels.firstObject);
-      } else {
-        const behandeling = yield this.store.findRecord('behandeling-van-agendapunt', uittreksel.data.attributes.uuid);
-        const rslt = yield this.store.createRecord("versioned-behandeling", {
-          zitting: this.model,
-          content: uittreksel.data.attributes.content,
-          behandeling,
-        });
-        uittreksels.push(rslt);
-      }
-    }
-    this.uittreksels = uittreksels;
+  *loadExtractsTask() {
+    yield this.publish.loadExtractsTask.perform(this.meeting.id);
   }
 
+  get createSignedResourceTask() {
+    return this._createSignedResourceTask.unlinked();
+  }
 
-  @task
-  *fetchExtractPreviews() {
-    const response = yield fetch(`/prepublish/behandelingen/${this.meeting.id}`);
-    const json = yield response.json();
-    return json;
+  get createPublishedResourceTask() {
+    return this._createPublishedResourceTask.unlinked();
   }
 
   @task
-  * createSignedResource(behandeling) {
+  *_createSignedResourceTask(behandeling) {
     const id = this.model.id;
-    yield fetch(`/signing/behandeling/sign/${id}/${behandeling.get('id')}`, { method: 'POST'});
-    yield this.reloadUittreksels.perform();
+    yield fetch(`/signing/behandeling/sign/${id}/${behandeling.get('id')}`, {
+      method: 'POST',
+    });
+    yield this.loadExtractsTask.perform();
   }
 
   @task
-  * createPublishedResource(behandeling) {
+  *_createPublishedResourceTask(behandeling) {
     const id = this.model.id;
-    yield fetch(`/signing/behandeling/publish/${id}/${behandeling.get('id')}`, { method: 'POST' });
-    yield this.reloadUittreksels.perform();
-
+    yield fetch(`/signing/behandeling/publish/${id}/${behandeling.get('id')}`, {
+      method: 'POST',
+    });
+    yield this.loadExtractsTask.perform();
   }
 
   @action
-  print(versionedTreatment) {
-    if(versionedTreatment.isNew) {
-      this.transitionToRoute('print.uittreksel', versionedTreatment);
-    } else {
-      this.transitionToRoute('print.uittreksel', versionedTreatment.id);
-
-    }
+  print(extract) {
+    this.transitionToRoute(
+      'print.uittreksel',
+      this.meeting.id,
+      extract.treatmentId
+    );
   }
 }

--- a/app/controllers/meetings/publish/uittreksels.js
+++ b/app/controllers/meetings/publish/uittreksels.js
@@ -22,12 +22,15 @@ export default class MeetingsPublishUittrekselsController extends Controller {
     return this.model;
   }
 
-  get uittreksels() {
+  get extracts() {
     return this.publish.treatmentExtracts;
   }
 
   get isLoading() {
     return this.loadExtractsTask.isRunning;
+  }
+  get isEmpty() {
+    return !this.extracts?.length;
   }
 
   @task

--- a/app/models/zitting.js
+++ b/app/models/zitting.js
@@ -18,5 +18,6 @@ export default class ZittingModel extends Model {
   @hasMany('mandataris', { inverse: null }) aanwezigenBijStart;
   @hasMany('mandataris', { inverse: null }) afwezigenBijStart;
   @hasMany('intermission', { inverse: 'zitting' }) intermissions;
+  @hasMany('versioned-behandeling', {inverse: 'zitting'}) versionedBehandelingen;
 }
-  
+

--- a/app/router.js
+++ b/app/router.js
@@ -24,7 +24,7 @@ Router.map(function() {
   });
   this.route('contact');
   this.route('print', function() {
-    this.route('uittreksel', { path: '/uittreksel/:id' });
+    this.route('uittreksel', { path: 'uittreksel/:meeting_id/:treatment_id' });
   });
   this.route('route-not-found', {
     path: '/*wildcard'

--- a/app/routes/print/uittreksel.js
+++ b/app/routes/print/uittreksel.js
@@ -1,9 +1,21 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class PrintUittrekselRoute extends Route {
+  @service publish;
+
   async model(params) {
-    return this.store.findRecord('versioned-behandeling', params.id, {
-      include: 'zitting.bestuursorgaan.is-tijdsspecialisatie-van,signed-resources.gebruiker'
-    });
+    const { treatment_id: treatmentId, meeting_id: meetingId } = params;
+    const extract = this.publish.treatmentExtractsMap.get(treatmentId);
+
+    if (extract) {
+      return { document: extract.document, meetingId };
+    } else {
+      await this.publish.loadExtractsTask.perform(meetingId);
+      return {
+        document: this.publish.treatmentExtractsMap.get(treatmentId)?.document,
+        meetingId,
+      };
+    }
   }
 }

--- a/app/services/publish.js
+++ b/app/services/publish.js
@@ -16,6 +16,15 @@ export class Extract {
   }
 }
 
+/**
+ * WIP service to abstract away the api calls need for the publication flow
+ *
+ * Expects the developer to manage when to update the treatment extracts.
+ *
+ * TODO: build out the rest of the api
+ * TODO: consider getting rid of the state altogether
+ *
+ */
 export default class PublishService extends Service {
   @tracked treatmentExtractsMap;
   @service store;
@@ -34,12 +43,14 @@ export default class PublishService extends Service {
   }
 
   get loadExtractsTask() {
+    // for background, see https://github.com/machty/ember-concurrency/issues/161
     return this._loadExtractsTask.unlinked();
   }
 
   /**
    * Combine saved extracts with newly created ones and expose them as one map keyed by the
    * id of the treatment
+   * TODO: proper pagination
    * @param meetingId
    * @return {Generator<*, void, *>}
    */
@@ -51,10 +62,12 @@ export default class PublishService extends Service {
       this.store.query('behandeling-van-agendapunt', {
         'filter[onderwerp][zitting][:id:]': meetingId,
         include: 'onderwerp',
+        page: { size: 1000 },
       }),
       this.store.query('versioned-behandeling', {
         'filter[zitting][:id:]': meetingId,
         include: 'behandeling.onderwerp,signed-resources,published-resource',
+        page: { size: 1000 },
       }),
     ]);
 

--- a/app/services/publish.js
+++ b/app/services/publish.js
@@ -1,0 +1,106 @@
+import Service, { inject as service } from '@ember/service';
+import { task, all } from 'ember-concurrency';
+import { tracked } from '@glimmer/tracking';
+
+export class Extract {
+  @tracked treatmentId;
+  @tracked position;
+  @tracked document;
+  @tracked errors;
+
+  constructor(treatmentId, position, document, errors) {
+    this.treatmentId = treatmentId;
+    this.position = position;
+    this.document = document;
+    this.errors = errors;
+  }
+}
+
+export default class PublishService extends Service {
+  @tracked treatmentExtractsMap;
+  @service store;
+
+  constructor(...args) {
+    super(...args);
+    this.treatmentExtractsMap = new Map();
+  }
+
+  get treatmentExtracts() {
+    return [...this.treatmentExtractsMap.values()].sortBy('position');
+  }
+
+  get isIdle() {
+    return this.loadExtractsTask.isIdle;
+  }
+
+  get loadExtractsTask() {
+    return this._loadExtractsTask.unlinked();
+  }
+
+  /**
+   * Combine saved extracts with newly created ones and expose them as one map keyed by the
+   * id of the treatment
+   * @param meetingId
+   * @return {Generator<*, void, *>}
+   */
+  @task
+  *_loadExtractsTask(meetingId) {
+    const [newExtracts, meeting, treatments, versionedTreatments] = yield all([
+      fetch(`/prepublish/behandelingen/${meetingId}`).then((res) => res.json()),
+      this.store.findRecord('zitting', meetingId),
+      this.store.query('behandeling-van-agendapunt', {
+        'filter[onderwerp][zitting][:id:]': meetingId,
+        include: 'onderwerp',
+      }),
+      this.store.query('versioned-behandeling', {
+        'filter[zitting][:id:]': meetingId,
+        include: 'behandeling.onderwerp,signed-resources,published-resource',
+      }),
+    ]);
+
+    // map all treatments to their ids for later retrieval
+    const treatmentMap = new Map();
+    treatments.forEach((treatment) =>
+      treatmentMap.set(treatment.id, treatment)
+    );
+
+    // map all existing extracts to their behandeling id
+    const extractMap = new Map();
+    versionedTreatments.forEach((versionedTreatment) => {
+      extractMap.set(
+        versionedTreatment.behandeling.get('id'),
+        new Extract(
+          versionedTreatment.behandeling.get('id'),
+          versionedTreatment.get('behandeling.onderwerp.position'),
+          versionedTreatment
+        )
+      );
+    });
+
+    // loop over new extracts and create a VersionedBehandeling if it doesn't exist yet
+    for (const extract of newExtracts) {
+      const treatmentId = extract.data.attributes.uuid;
+      if (!extractMap.has(treatmentId)) {
+        const treatment = treatmentMap.get(treatmentId);
+        const versionedTreatment = this.store.createRecord(
+          'versioned-behandeling',
+          {
+            zitting: meeting,
+            content: extract.data.attributes.content,
+            behandeling: treatment,
+          }
+        );
+        extractMap.set(
+          treatmentId,
+          new Extract(
+            treatmentId,
+            treatment.get('onderwerp.position'),
+            versionedTreatment,
+            extract.data.attributes.errors
+          )
+        );
+      }
+    }
+    this.treatmentExtractsMap = extractMap;
+  }
+}

--- a/app/templates/meetings/publish/uittreksels.hbs
+++ b/app/templates/meetings/publish/uittreksels.hbs
@@ -10,7 +10,7 @@
                 @extract={{extract}}
                 @signing={{perform this.createSignedResourceTask extract.document.behandeling}}
                 @publish={{perform this.createPublishedResourceTask extract.document.behandeling}}
-                @print={{this.print}}
+                @print={{fn this.print extract}}
         />
       {{else}}
         <AuAlert @alertIcon="alert-triangle" @alertskin="warning" @alertsize="small">

--- a/app/templates/meetings/publish/uittreksels.hbs
+++ b/app/templates/meetings/publish/uittreksels.hbs
@@ -1,23 +1,22 @@
 <div class="au-o-box">
-  {{#if this.initializeUittreksels.isIdle}}
-  <ul>
-    {{#each this.uittreksels as |uittreksel|}}
-      <Signatures::Behandeling::TimelineStep
-        @name={{uittreksel.document.behandeling.onderwerp.titel}}
-        @behandeling={{uittreksel.document}}
-        @errors={{uittreksel.errors}}
-        @signing={{perform this.createSignedResource uittreksel.document.behandeling}}
-        @publish={{perform this.createPublishedResource uittreksel.document.behandeling}}
-        @print={{this.print}}
-      />
-    {{else}}
-    <AuAlert @alertIcon="alert-triangle" @alertskin="warning" @alertsize="small">
-      {{t "publish.excerptsErrorMessage"}}
-    </AuAlert>
-    {{/each}}
-  </ul>
-  {{else}}
+  {{#if this.isLoading}}
     <AuHelpText @size="large">{{t "publish.loadingMessage"}}</AuHelpText>
-    <AuLoader @padding="small" />
+    <AuLoader @padding="small"/>
+  {{else}}
+    <ul>
+      {{#each this.uittreksels as |uittreksel|}}
+        <Signatures::Behandeling::TimelineStep
+                @name={{uittreksel.document.behandeling.onderwerp.titel}}
+                @extract={{uittreksel}}
+                @signing={{perform this.createSignedResourceTask uittreksel.document.behandeling}}
+                @publish={{perform this.createPublishedResourceTask uittreksel.document.behandeling}}
+                @print={{this.print}}
+        />
+      {{else}}
+        <AuAlert @alertIcon="alert-triangle" @alertskin="warning" @alertsize="small">
+          {{t "publish.excerptsErrorMessage"}}
+        </AuAlert>
+      {{/each}}
+    </ul>
   {{/if}}
 </div>

--- a/app/templates/meetings/publish/uittreksels.hbs
+++ b/app/templates/meetings/publish/uittreksels.hbs
@@ -1,22 +1,23 @@
 <div class="au-o-box">
   {{#if this.isLoading}}
-    <AuHelpText @size="large">{{t "publish.loadingMessage"}}</AuHelpText>
+    <AuHelpText @size="large">{{t (if this.isEmpty "publish.loadingMessage" "publish.updatingMessage")}}</AuHelpText>
     <AuLoader @padding="small"/>
-  {{else}}
-    <ul>
-      {{#each this.uittreksels as |uittreksel|}}
-        <Signatures::Behandeling::TimelineStep
-                @name={{uittreksel.document.behandeling.onderwerp.titel}}
-                @extract={{uittreksel}}
-                @signing={{perform this.createSignedResourceTask uittreksel.document.behandeling}}
-                @publish={{perform this.createPublishedResourceTask uittreksel.document.behandeling}}
-                @print={{this.print}}
-        />
-      {{else}}
+  {{/if}}
+  <ul>
+    {{#each this.extracts as |extract|}}
+      <Signatures::Behandeling::TimelineStep
+              @name={{extract.document.behandeling.onderwerp.titel}}
+              @extract={{extract}}
+              @signing={{perform this.createSignedResourceTask extract.document.behandeling}}
+              @publish={{perform this.createPublishedResourceTask extract.document.behandeling}}
+              @print={{this.print}}
+      />
+    {{else}}
+      {{#unless this.isLoading }}
         <AuAlert @alertIcon="alert-triangle" @alertskin="warning" @alertsize="small">
           {{t "publish.excerptsErrorMessage"}}
         </AuAlert>
-      {{/each}}
-    </ul>
-  {{/if}}
+      {{/unless}}
+    {{/each}}
+  </ul>
 </div>

--- a/app/templates/meetings/publish/uittreksels.hbs
+++ b/app/templates/meetings/publish/uittreksels.hbs
@@ -2,22 +2,21 @@
   {{#if this.isLoading}}
     <AuHelpText @size="large">{{t (if this.isEmpty "publish.loadingMessage" "publish.updatingMessage")}}</AuHelpText>
     <AuLoader @padding="small"/>
-  {{/if}}
-  <ul>
-    {{#each this.extracts as |extract|}}
-      <Signatures::Behandeling::TimelineStep
-              @name={{extract.document.behandeling.onderwerp.titel}}
-              @extract={{extract}}
-              @signing={{perform this.createSignedResourceTask extract.document.behandeling}}
-              @publish={{perform this.createPublishedResourceTask extract.document.behandeling}}
-              @print={{this.print}}
-      />
-    {{else}}
-      {{#unless this.isLoading }}
+  {{else}}
+    <ul>
+      {{#each this.extracts as |extract|}}
+        <Signatures::Behandeling::TimelineStep
+                @name={{extract.document.behandeling.onderwerp.titel}}
+                @extract={{extract}}
+                @signing={{perform this.createSignedResourceTask extract.document.behandeling}}
+                @publish={{perform this.createPublishedResourceTask extract.document.behandeling}}
+                @print={{this.print}}
+        />
+      {{else}}
         <AuAlert @alertIcon="alert-triangle" @alertskin="warning" @alertsize="small">
           {{t "publish.excerptsErrorMessage"}}
         </AuAlert>
-      {{/unless}}
-    {{/each}}
-  </ul>
+      {{/each}}
+    </ul>
+  {{/if}}
 </div>

--- a/app/templates/print/uittreksel.hbs
+++ b/app/templates/print/uittreksel.hbs
@@ -1,5 +1,5 @@
 <Extracts::PrintView
-        @versionedTreatment={{this.model}}
+        @versionedTreatment={{@model.document}}
         @backLinkRoute="meetings.publish.uittreksels"
-        @model={{this.model.zitting.id}}
+        @linkModel={{@model.meetingId}}
 />

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -32,6 +32,7 @@ publish:
   backToMeeting: Back to meeting
   headingPartOne: Meeting on
   loadingMessage: Loading...
+  updatingMessage: Updating...
   excerptsErrorMessage: There are no excerpts available
 behandelingVanAgendapunten:
   documentLink: "document link"

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -32,6 +32,7 @@ publish:
   backToMeeting: Terug naar zitting
   headingPartOne: Zitting van
   loadingMessage: Bezig met laden...
+  updatingMessage: Bezig met bijwerken...
   excerptsErrorMessage: Er zijn geen uittreksels beschikbaar
 behandelingVanAgendapunten:
   documentLink: "document link"


### PR DESCRIPTION
Blood, sweat and mostly tears as usual.

I think it's a decent implementation now? I honestly can't tell anymore.
Basically the service acts as a domain-specific store without implicit reloading. So we get a merged map of "real (aka persisted)" versionedBehandeling objects and "previews", keyed by the id of the treatment they represent. In the print route we then fetch the extract by the id of the treatment, and we don't care whether this is a persisted one or a preview (well we care in the sense that we can handle both in the template). If the lookup fails, we do a reload and try again (this handles refreshing the page for example). Actually now that I write this down, we could do that more elegantly by only fetching the specific preview we care about, and creating it if it doesn't exist. 

Issues can probably appear since this is basically doing ad-hoc caching, depending on the developer to reload the cache. I don't know if this is a good pattern or not. It seems to be in the spirit of what ember-storefront proposes, but I might be wrong about that.