### PR TITLE
fix layout of publication preview (based on the work dieter did on the publication frontend)

### DIFF
--- a/app/styles/project/_c-template.scss
+++ b/app/styles/project/_c-template.scss
@@ -208,6 +208,13 @@
 
 .au-c-template--notes,
 .au-c-rdfa-publication .notulen {
+  h2 {
+    @include au-font-size($au-heading-3);
+    font-family: $au-font-secondary;
+    font-weight: $au-medium;
+    color: $au-gray-900;
+  }
+
   * + h2 {
     margin-top: $au-unit;
   }
@@ -237,27 +244,6 @@
   [typeof="besluit:Artikel"] {
     [property="eli:number"] {
       display: block;
-    }
-  }
-
-  // Mandatees: present -> Deprecated, present for old data
-  [property="ext:aanwezigenTable"] {
-    span {
-      display: inline-block;
-    }
-
-    [property="besluit:heeftAanwezige"] {
-      display: inline-block;
-    }
-
-    [property="besluit:heeftAanwezige"] + [property="besluit:heeftAanwezige"]:before,
-    p > span + span:before {
-      content: ",";
-    }
-
-    [property="besluit:heeftAanwezige"]:before,
-    p > span:before {
-      margin-left: -.4ex;
     }
   }
 }
@@ -300,16 +286,24 @@
 }
 
 .au-c-template-list-inline__item {
-  display: inline;
+  display: inline !important;
   margin-right: $au-unit-tiny;
 
   &:after {
     content: ",";
-    margin-left: -.2em;
+    // margin-left: -.1em;
   }
 
   &:last-child:after {
     content: ""
+  }
+
+  [property="mandaat:isBestuurlijkeAliasVan"]:before {
+    display: none !important;
+  }
+
+  &[property="besluit:heeftAanwezige"] {
+    margin-right: $au-unit-tiny !important;
   }
 }
 
@@ -319,7 +313,9 @@
 
 // Public and private labels
 .au-c-template-public,
-.au-c-template-private {
+.au-c-template-private,
+[property="besluit:geplandOpenbaar"],
+[property="besluit:openbaar"] {
   @include au-font-size($au-h6);
   color: $au-gray-600;
   text-transform: initial;
@@ -339,13 +335,26 @@
   }
 }
 
-.au-c-template-public {
+[property="besluit:geplandOpenbaar"] .au-c-template-public,
+[property="besluit:geplandOpenbaar"] .au-c-template-private,
+[property="besluit:openbaar"] .au-c-template-public,
+[property="besluit:openbaar"] .au-c-template-private {
+  &:before {
+    display: none !important;
+  }
+}
+
+.au-c-template-public,
+[property="besluit:geplandOpenbaar"][content="true"],
+[property="besluit:openbaar"][content="true"] {
   &:before {
     background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8cGF0aCBmaWxsPSIjNjk3MTdDIiBkPSJNMTIsNSBDMTUuOTA0LDUgMTkuNzM2LDcuMjM2IDIxLjg5NCwxMS41NTMgQzIyLjAzNDYyMTQsMTEuODM0NDEwOCAyMi4wMzQ2MjE0LDEyLjE2NTU4OTIgMjEuODk0LDEyLjQ0NyBDMTkuNzM2LDE2Ljc2NCAxNS45MDMsMTkgMTIsMTkgQzguMDk2LDE5IDQuMjY0LDE2Ljc2NCAyLjEwNiwxMi40NDcgQzEuOTY1Mzc4NjEsMTIuMTY1NTg5MiAxLjk2NTM3ODYxLDExLjgzNDQxMDggMi4xMDYsMTEuNTUzIEM0LjI2NCw3LjIzNiA4LjA5Nyw1IDEyLDUgWiBNMTIsNyBDOS4wMyw3IDUuOTk4LDguNjIgNC4xMywxMiBDNS45OTgsMTUuMzggOS4wMzEsMTcgMTIsMTcgQzE0Ljk2OSwxNyAxOC4wMDIsMTUuMzggMTkuODcsMTIgQzE4LjAwMiw4LjYyIDE0Ljk2OSw3IDEyLDcgWiBNMTIsOSBDMTMuNjU2ODU0Miw5IDE1LDEwLjM0MzE0NTggMTUsMTIgQzE1LDEzLjY1Njg1NDIgMTMuNjU2ODU0MiwxNSAxMiwxNSBDMTAuMzQzMTQ1OCwxNSA5LDEzLjY1Njg1NDIgOSwxMiBDOSwxMC4zNDMxNDU4IDEwLjM0MzE0NTgsOSAxMiw5IFoiLz4KPC9zdmc+Cg==");
   }
 }
 
-.au-c-template-private {
+.au-c-template-private,
+[property="besluit:geplandOpenbaar"][content="false"],
+[property="besluit:openbaar"][content="false"] {
   &:before {
     background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8cGF0aCBmaWxsPSIjNjk3MTdDIiBkPSJNNC43MDcsMy4yOTMgQzQuMzE0NjIxMTEsMi45MTQwMjc3OSAzLjY5MDkxNTIyLDIuOTE5NDQ3NjMgMy4zMDUxODE0MiwzLjMwNTE4MTQyIEMyLjkxOTQ0NzYzLDMuNjkwOTE1MjIgMi45MTQwMjc3OSw0LjMxNDYyMTExIDMuMjkzLDQuNzA3IEw1LjcxNyw3LjEzMSBDNC4yODcsOC4yMDcgMy4wMzksOS42ODUgMi4xMDYsMTEuNTUzIEMxLjk2NTM3ODYxLDExLjgzNDQxMDggMS45NjUzNzg2MSwxMi4xNjU1ODkyIDIuMTA2LDEyLjQ0NyBDNC4yNjQsMTYuNzY0IDguMDk2LDE5IDEyLDE5IEMxMy41NTUsMTkgMTUuMSwxOC42NDUgMTYuNTMsMTcuOTQ1IEwxOS4yOTMsMjAuNzA3IEMxOS42ODUzNzg5LDIxLjA4NTk3MjIgMjAuMzA5MDg0OCwyMS4wODA1NTI0IDIwLjY5NDgxODYsMjAuNjk0ODE4NiBDMjEuMDgwNTUyNCwyMC4zMDkwODQ4IDIxLjA4NTk3MjIsMTkuNjg1Mzc4OSAyMC43MDcsMTkuMjkzIEw0LjcwNywzLjI5MyBaIE0xNS4wMTQsMTYuNDI4IEMxNC4wMzQsMTYuODExIDEzLjAxNCwxNyAxMiwxNyBDOS4wMzEsMTcgNS45OTgsMTUuMzggNC4xMywxMiBDNC45NDcsMTAuNTIxIDUuOTg4LDkuMzggNy4xNDgsOC41NjMgTDkuMjkyLDEwLjcwNyBDOC43NDI5NDU1OCwxMS44NTQ1NDA3IDguOTc3MzQwMDUsMTMuMjIzNTk4OCA5Ljg3Njg3MDYzLDE0LjEyMzEyOTQgQzEwLjc3NjQwMTIsMTUuMDIyNjU5OSAxMi4xNDU0NTkzLDE1LjI1NzA1NDQgMTMuMjkzLDE0LjcwOCBMMTUuMDEzLDE2LjQyOCBMMTUuMDE0LDE2LjQyOCBaIE0xOC41NTIsMTMuODk2IEMxOS4wMzUsMTMuMzQgMTkuNDc4LDEyLjcwOSAxOS44NywxMiBDMTguMDAyLDguNjIgMTQuOTcsNyAxMiw3IEMxMS44ODgsNyAxMS43NzYsNy4wMDIgMTEuNjY0LDcuMDA3IEw5Ljg3OSw1LjIyMyBDMTAuNTc2MjgyNCw1LjA3NDg2NDI4IDExLjI4NzE1NTcsNS4wMDAxMjM3MSAxMiw1IEMxNS45MDMsNSAxOS43MzYsNy4yMzYgMjEuODk0LDExLjU1MyBDMjIuMDM0NjIxNCwxMS44MzQ0MTA4IDIyLjAzNDYyMTQsMTIuMTY1NTg5MiAyMS44OTQsMTIuNDQ3IEMyMS4zODE0NDU1LDEzLjQ4MjY4OTEgMjAuNzM0MTY2NywxNC40NDYwNDE2IDE5Ljk2OSwxNS4zMTIgTDE4LjU1MiwxMy44OTYgTDE4LjU1MiwxMy44OTYgWiIvPgo8L3N2Zz4K");
   }


### PR DESCRIPTION
inspired by https://github.com/lblod/frontend-gelinkt-notuleren-publicatie/pull/30

-     remove double comma's
-     fix incorrect margins
-     remove double icons
-     make print view typography smaller

![Screenshot from 2021-06-29 21-37-58](https://user-images.githubusercontent.com/878686/123857201-4f733d80-d922-11eb-96cf-d7e9df8cd1d5.png)
left hand side shows improvements