### PR TITLE
show mark-highlight-manual on print view

### DIFF
--- a/app/styles/project/_u-print.scss
+++ b/app/styles/project/_u-print.scss
@@ -159,10 +159,6 @@
     border-bottom: 0 !important;
   }
 
-  .mark-highlight-manual {
-    display: none !important;
-  }
-
   // [property="ext:hiddenBesluitType"] {
   //   display: block !important;
   // }


### PR DESCRIPTION
Fixes the issue when the div with the mark-highlight-manual class is not printed.