### PR TITLE
Fix print view overflow issue when &nbsp is used in text

### DIFF
--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -416,3 +416,10 @@
     flex-wrap: nowrap !important;
   }
 }
+
+// FIX NBSP ISSUE
+.say-content,
+.au-c-editor-preview {
+  overflow-wrap: break-word;
+  word-break: break-word;
+}


### PR DESCRIPTION
The use of &nbsp; in text means that this is handled as one long word and won't break with the width of the container.

Added:
- Quick fix with CSS overriding the behaviour of &nbsp in long text. 

Possible better solution in the future:
- remove &nbsp; when a user copies text in the editor