### PR TITLE
Improve wording around notification

### DIFF
--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -243,7 +243,7 @@ timelineStep:
   previewInfo: "The document will be published as seen in the preview above to "
   previewInfoEnd: ", and will be publicly available to anyone, without authentication."
   notifyConsequences: Consequences notification
-  notifyInfo: "A notification will be sent for this document to the authoritative government and will be visible in the "
+  notifyInfo: "If applicable, a notification will be sent for this document to the authoritative government and will be visible in the "
   localLoket: "Loket voor Lokale Besturen"
   publishWarning: "Complete the missing information to publish"
 publicationConfirmation:
@@ -255,7 +255,7 @@ publicationConfirmation:
   publicationTitle: Publication
   publicationSubtitle: "The document and its content are made public on the publication page, freely accessible to citizens:"
   reportingTitle: Reporting
-  reportingSubtitle: The document will be automatically reported to the supervising authority, and will be visible in the
+  reportingSubtitle: If applicable, document will be automatically reported to the supervising authority, and will be visible in the
   reportingLink: Loket voor Lokale Besturen
   metadataTitle: Publishing metadata
   publisherLabel: Publisher

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -231,7 +231,7 @@ timelineStep:
   printInfo: "Anyone with access to the meeting minutes can make a print (or PDF) after they have been signed"
   secondPrintInfo: "Printing is only possible after the document has been signed. This print will not be made available externally."
   publishButtonLabel: "Publish {name}"
-  publishNotifyButtonLabel: "Publish and notify {name}"
+  publishNotifyButtonLabel: "Publish (and notify) {name}"
   publishRestrictionInfo: "Publishing is only possible by persons with the "
   publishRestrictionRole: "publisher"
   publishRestrictionEnd: " role."

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -230,7 +230,7 @@ timelineStep:
   printInfo: "Een print (of PDF) maken kan op elk moment, door iedereen die toegang heeft tot de notulen; nadat het document ondertekend werd."
   secondPrintInfo: "Printen kan enkel nadat het document ondertekend werd. Deze print wordt niet extern beschikbaar gemaakt."
   publishButtonLabel: "Publiceer {name}"
-  publishNotifyButtonLabel: "Publiceer en meld {name}"
+  publishNotifyButtonLabel: "Publiceer (en meld) {name}"
   publishRestrictionInfo: "Publiceren kan enkel door personen met de rol "
   publishRestrictionRole: "publiceerder"
   publishRestrictionEnd: "."

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -242,7 +242,7 @@ timelineStep:
   previewInfo: "Het document wordt gepubliceerd zoals bovenaan in de voorvertoning naar "
   previewInfoEnd: ", en zal publiek beschikbaar zijn voor iedereen, zonder authenticatie."
   notifyConsequences: Gevolgen melding
-  notifyInfo: "Het document wordt automatisch gemeld aan de toezichthoudende overheid, en zal zichtbaar zijn in het "
+  notifyInfo: "Het document wordt, indien van toepassing, automatisch gemeld aan de toezichthoudende overheid, en zal zichtbaar zijn in het "
   localLoket: "Loket voor Lokale Besturen"
   publishWarning: "Vul de ontbrekende informatie aan om te publiceren"
 publicationConfirmation:
@@ -254,7 +254,7 @@ publicationConfirmation:
   publicationTitle: Publicatie
   publicationSubtitle: "Het document en diens inhoud worden publiek gemaakt op de publicatiepagina, vrij toegankelijk voor burgers:"
   reportingTitle: Melding
-  reportingSubtitle: Het document wordt automatisch gemeld aan de toezichthoudende overheid, en zal zichtbaar zijn in het
+  reportingSubtitle: Het document wordt, indien van toepassing, automatisch gemeld aan de toezichthoudende overheid, en zal zichtbaar zijn in het
   reportingLink: Loket voor Lokale Besturen
   metadataTitle: Metagegevens bij publiceren
   publisherLabel: Publiceerder


### PR DESCRIPTION
Not all publications lead to notification (melding). The wording we had did not reflect that.