### PR TITLE
Fix a bug where agenda items would have incorrect links to previous agenda items

### DIFF
--- a/app/components/agenda-manager/agenda-context.hbs
+++ b/app/components/agenda-manager/agenda-context.hbs
@@ -3,7 +3,7 @@
   loadItemsTask=this.loadItemsTask
   deleteItemTask=this.deleteItemTask
   onSort=(perform this.onSortTask)
-  saveItemTask=this.saveItemTask
+  saveItemTask=this.updateItemTask
   createAgendaItem=this.createAgendaItem
   onCancel=(perform this.resetItemTask)
 )}}


### PR DESCRIPTION
Fixes the cause of https://binnenland.atlassian.net/browse/GN-2883

Also improves performance of adding & reordering agenda-items. Now only the minimum required network requests are sent, instead of always patching every item. 
The amount of network requests is now (n = amount of items):
swapping: constant in n
appending: constant in n
inserting/deleting: linear in n (with an average of n/2)

(this is not time complexity, all operations are still O(n) in that regard)