### PR TITLE
fix editor scrolling issue

### DIFF
--- a/app/styles/_deprecated.scss
+++ b/app/styles/_deprecated.scss
@@ -111,3 +111,14 @@ input.input-field {
 .modal-dialog.modal-dialog--sectioned .modal-dialog__content {
   max-height: 75vh;
 }
+
+
+.container-flex--contain {
+  position: relative;
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  flex-direction: column;
+  overflow: hidden;
+  height: 100%;
+}


### PR DESCRIPTION
Scrolling behaviour in the editor was broken with the removal of webuniversum.
Added back the container-flex--contain class to revert to the correct scrolling behaviour.