### PR TITLE
Fix issue with double characters

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@lblod/ember-acmidm-login": "^1.2.0",
     "@lblod/ember-mock-login": "0.5.0",
     "@lblod/ember-rdfa-editor": "^0.47.0",
-    "@lblod/ember-rdfa-editor-besluit-type-plugin": "0.2.1",
+    "@lblod/ember-rdfa-editor-besluit-type-plugin": "0.4.0",
     "@lblod/ember-rdfa-editor-citaten-plugin": "0.13.2",
     "@lblod/ember-rdfa-editor-document-title-plugin": "0.2.0",
     "@lblod/ember-rdfa-editor-generic-model-plugin": "0.3.0",


### PR DESCRIPTION
As far as I can tell, this was caused by the besluittype plugin generating errors which caused some rendering hiccups. The latest version of that plugin solves the issue. 

The problem only appeared on prod, cause the kind of errors it generated are only warnings when running local dev server, but errors on prod. 

This pr is then just a version bump, but also a bugfix

Fixes https://binnenland.atlassian.net/browse/GN-2944