### PR TITLE
Only save document if it's in a dirty state

### DIFF
--- a/app/controllers/meetings/edit/treatment.js
+++ b/app/controllers/meetings/edit/treatment.js
@@ -144,7 +144,9 @@ export default class MeetingsEditTreatmentController extends Controller {
   
   @task 
   *toggleUploadAndSave(){
-    yield this.saveDocumentTask.perform();
+    if(this.dirty) {
+      yield this.saveDocumentTask.perform();
+    }
     this.uploading=!this.uploading;
     this.fetchDecisions.perform();
   }


### PR DESCRIPTION
I used the dirty attribute we are using to show the confirmation modal when we are leaving the route