### PR TITLE
add a warning to attachment overview if no decisions were found

### DIFF
--- a/app/components/document-attachments.hbs
+++ b/app/components/document-attachments.hbs
@@ -18,6 +18,16 @@
         </tr>
       </thead>
       <tbody>
+        {{#if (not @decisions.length)}}
+          <tr>
+            <td colspan="5">
+              <AuAlert @alertIcon="alert-triangle" @alertTitle={{t "attachments.noDecisionsFound"}} @alertskin="warning">
+                <p>{{t "attachments.decisionRequired"}}</p>
+              </AuAlert>
+
+            </td>
+          </tr>
+        {{/if}}
         {{#each this.attachments as |attachment|}}
         <tr>
           <td>

--- a/app/components/document-attachments.hbs
+++ b/app/components/document-attachments.hbs
@@ -18,7 +18,7 @@
         </tr>
       </thead>
       <tbody>
-        {{#if (not @decisions.length)}}
+        {{#unless @decisions.length}}
           <tr>
             <td colspan="5">
               <AuAlert @alertIcon="alert-triangle" @alertTitle={{t "attachments.noDecisionsFound"}} @alertskin="warning">
@@ -27,7 +27,7 @@
 
             </td>
           </tr>
-        {{/if}}
+        {{/unless}}
         {{#each this.attachments as |attachment|}}
         <tr>
           <td>

--- a/app/components/document-attachments.hbs
+++ b/app/components/document-attachments.hbs
@@ -1,4 +1,4 @@
-<div class="au-o-box au-c-theme-gray-200">
+<div class="au-o-box au-o-box--small au-c-theme-gray-200">
   <AuFileUpload @title={{t "attachments.attach" }} @helpTextDragDrop={{t "attachments.drag" }} @modelName={{"file"}}
     @endPoint={{"/files"}} @onFinishUpload={{perform this.uploadedAttachement}} @maxFileSizeMB="1024"
     @multiple={{true}} />
@@ -18,16 +18,6 @@
         </tr>
       </thead>
       <tbody>
-        {{#unless @decisions.length}}
-          <tr>
-            <td colspan="5">
-              <AuAlert @alertIcon="alert-triangle" @alertTitle={{t "attachments.noDecisionsFound"}} @alertskin="warning">
-                <p>{{t "attachments.decisionRequired"}}</p>
-              </AuAlert>
-
-            </td>
-          </tr>
-        {{/unless}}
         {{#each this.attachments as |attachment|}}
         <tr>
           <td>
@@ -66,3 +56,11 @@
   </div>
 </div>
 {{/if}}
+
+{{#unless @decisions.length}}
+<AuToolbar @border="top" @nowrap="true" @size="small">
+  <AuAlert @alertIcon="alert-triangle" @alertTitle={{t "attachments.noDecisionsFound"}} @alertskin="warning" class="au-u-margin-bottom-none au-u-1-1">
+    <p>{{t "attachments.decisionRequired"}}</p>
+  </AuAlert>
+</AuToolbar>
+{{/unless}}

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -364,6 +364,8 @@ attachments:
   typePlaceholder: none
   regulatory: regulatory
   saveAndGo: Save and go to attachments
+  noDecisonsFound: No decisions found
+  decisionRequired: Only attachments linked to a decision are included in the publication.
 documentCreator:
   titleField: Agendapoint title
   template: Template

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -364,7 +364,7 @@ attachments:
   typePlaceholder: none
   regulatory: regulatory
   saveAndGo: Save and go to attachments
-  noDecisonsFound: No decisions found
+  noDecisionsFound: No decisions found
   decisionRequired: Only attachments linked to a decision are included in the publication.
 documentCreator:
   titleField: Agendapoint title

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -363,6 +363,8 @@ attachments:
   typePlaceholder: geen
   regulatory: regelgevend
   saveAndGo: Opslaan en bijlagen toevoegen
+  noDecisionsFound: Geen besluiten gevonden
+  decisionRequired: enkel bijlagen bij een besluit worden opgenomen in de publicatie.
 documentCreator:
   titleField: Titel agendapunt
   template: Sjabloon

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -364,7 +364,7 @@ attachments:
   regulatory: regelgevend
   saveAndGo: Opslaan en bijlagen toevoegen
   noDecisionsFound: Geen besluiten gevonden
-  decisionRequired: enkel bijlagen bij een besluit worden opgenomen in de publicatie.
+  decisionRequired: Enkel bijlagen bij een besluit worden opgenomen in de publicatie.
 documentCreator:
   titleField: Titel agendapunt
   template: Sjabloon


### PR DESCRIPTION
![warningexample](https://user-images.githubusercontent.com/878686/136183323-bd4cee7e-d765-45ad-812c-440ee5087869.png)
An attempt to make it a bit more clear how it works. 

@Dietr not sure about the placement of the warning (currently inside the table and feels a bit messy). 
In general: might consider just converting this to a regular info box and always show it?
