### PR TITLE
fix sorting on status in the agendapoint table

### DIFF
--- a/app/templates/inbox/agendapoints.hbs
+++ b/app/templates/inbox/agendapoints.hbs
@@ -20,7 +20,7 @@
     <c.header>
       <AuDataTableThSortable @field="currentVersion.title" @currentSorting={{this.sort}} @label={{t 'inbox.agendapoints.titleLabel'}} />
       <AuDataTableThSortable @field="currentVersion.updatedOn" @currentSorting={{this.sort}} @label={{t 'inbox.agendapoints.updatedOnLabel'}} />
-      <AuDataTableThSortable @field="status" @currentSorting={{this.sort}} @label={{t 'inbox.agendapoints.statusLabel'}} />
+      <AuDataTableThSortable @field="status.label" @currentSorting={{this.sort}} @label={{t 'inbox.agendapoints.statusLabel'}} />
       <th><span class="au-c-data-table__header-title au-c-data-table__header-title--sortable">Zitting</span></th>
     </c.header>
     <c.body as |container|>


### PR DESCRIPTION
while reviewing #207 I noticed the status sort doesn't work as it should, by sorting on the label of the status this behaves as expected