### PR TITLE
Bugfix/agendapoint ordering

### DIFF
--- a/app/components/agenda-manager/agenda-context.js
+++ b/app/components/agenda-manager/agenda-context.js
@@ -102,6 +102,9 @@ export default class AgendaManagerAgendaContextComponent extends Component {
    */
   @task
   * deleteItemTask(item) {
+    // we don't use item.position here to guard against problems
+    // with position logic. The performance hit of searching here
+    // is probably minimal.
     const index = this.items.indexOf(item);
 
     this.items.splice(index, 1);

--- a/app/components/agenda-manager/agenda-context.js
+++ b/app/components/agenda-manager/agenda-context.js
@@ -74,6 +74,9 @@ export default class AgendaManagerAgendaContextComponent extends Component {
    */
   @task
   * updateItemTask(item) {
+    if(item.isNew) {
+      const treatment = yield item.behandeling;
+    }
     const treatment = yield item.behandeling;
     yield treatment.saveAndPersistDocument();
 
@@ -102,7 +105,7 @@ export default class AgendaManagerAgendaContextComponent extends Component {
    */
   @task
   * deleteItemTask(item) {
-    const index = item.position;
+    const index = this.items.indexOf(item);
 
     this.items.splice(index, 1);
 
@@ -168,8 +171,6 @@ export default class AgendaManagerAgendaContextComponent extends Component {
    * update the item position and links
    * Only updates when necessary, does not persist the changes
    *
-   * @param {number} [from]
-   * @param {number} [to]
    * @private
    * */
   @task
@@ -180,10 +181,13 @@ export default class AgendaManagerAgendaContextComponent extends Component {
       if(item.position !== index || previousItem !== previous) {
         this.setProperty(item, "position", index);
         this.setProperty(item, "vorigeAgendapunt", previous);
-        const treatment = yield item.treatment;
-        if(treatment) {
-          const previousTreatment = yield previous.treatment;
-          this.setProperty(treatment, "vorigeBehandelingVanAgendapunt", previousTreatment);
+        const treatment = yield item.behandeling;
+        if(previous) {
+          const previousTreatment = yield previous.behandeling;
+          if(treatment && previous) {
+            this.setProperty(treatment, "vorigeBehandelingVanAgendapunt", previousTreatment);
+          }
+
         }
       }
       previous = item;

--- a/app/components/agenda-manager/edit.js
+++ b/app/components/agenda-manager/edit.js
@@ -13,7 +13,7 @@ export default class AgendaManagerEditComponent extends Component {
   }
   @task
   * submitTask(item) {
-    yield this.args.saveTask.perform(item);
+    yield this.args.saveTask.unlinked().perform(item);
     this.args.onClose();
   }
   @action
@@ -22,7 +22,7 @@ export default class AgendaManagerEditComponent extends Component {
   }
   @task
   * deleteTask(item) {
-    yield this.args.deleteTask.perform(item);
+    yield this.args.deleteTask.unlinked().perform(item);
     this.args.onClose();
   }
   @task


### PR DESCRIPTION
probably fixes https://binnenland.atlassian.net/browse/GN-3037
It's hard to exactly reproduce the problem, but this pr solves 2 database inconsistency issues related to agendapoint ordering logic.
Imo the most likely cause was closing the modal while the update/delete tasks were still running. 
Due to (once again) https://github.com/machty/ember-concurrency/issues/161 this can easily cause inconsistent database state. (e.g. an agenda-item without treatment)
