### PR TITLE
correctly set the default for "openbaar" on treatment

### DIFF
--- a/app/components/agenda-manager/agenda-context.js
+++ b/app/components/agenda-manager/agenda-context.js
@@ -80,6 +80,7 @@ export default class AgendaManagerAgendaContextComponent extends Component {
     if (item.isNew) {
       const zitting = yield this.store.findRecord("zitting", this.args.zittingId);
       this.setProperty(item, "zitting", zitting);
+      this.setProperty(treatment, "openbaar", item.geplandOpenbaar);
     }
 
     yield this.updatePositionTask.unlinked().perform(item);


### PR DESCRIPTION
the value of geplandOpenbaar on the agendapoint should be the default for "openbaar" on the treatment, this was not the case.