### PR TITLE
Linting after upgrade 3.28

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,24 +10,18 @@ module.exports = {
       legacyDecorators: true,
     },
   },
-  "globals": {
-    "flatpickr": false
-  },
-  plugins: [
-    'ember'
-  ],
+  plugins: ['ember'],
   extends: [
     'eslint:recommended',
     'plugin:ember/recommended',
-    // Disable the Prettier rules for now
-    // 'plugin:prettier/recommended',
+    'plugin:prettier/recommended',
   ],
   env: {
     browser: true,
   },
   rules: {
     'ember/no-mixins': 'warn',
-    'semi': 'error', // Remove this rule once Prettier is enabled
+    semi: 'error', // Remove this rule once Prettier is enabled
   },
   overrides: [
     // node files

--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -8,6 +8,6 @@ module.exports = {
     },
     'no-implicit-this': {
       allow: ['unique-id'],
-    }
-  }
+    },
+  },
 };

--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -2,13 +2,11 @@ import JSONAPIAdapter from '@ember-data/adapter/json-api';
 
 export default class ApplicationAdapter extends JSONAPIAdapter {
   ajax(url, method) {
-    if (method === 'POST')
-      return super.ajax(...arguments);
+    if (method === 'POST') return super.ajax(...arguments);
 
     return retryOnError(super.ajax.bind(this), arguments);
   }
 }
-
 
 async function retryOnError(ajax, ajaxArgs, retryCount = 0) {
   const MAX_RETRIES = 5;
@@ -23,7 +21,6 @@ async function retryOnError(ajax, ajaxArgs, retryCount = 0) {
       throw new Error(error);
     }
   }
-
 }
 
 function sleep(time) {

--- a/app/components/administrative-body-select.js
+++ b/app/components/administrative-body-select.js
@@ -6,21 +6,21 @@ import sub from 'date-fns/sub';
 import isAfter from 'date-fns/isAfter';
 
 const VALID_ADMINISTRATIVE_BODY_CLASSIFICATIONS = [
-  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000005", //	"Gemeenteraad"
-  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000007", //	"Raad voor Maatschappelijk Welzijn"
-  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000009", //	"Bijzonder Comité voor de Sociale Dienst"
-  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000a", //	"Districtsraad"
-  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000c", //	"Provincieraad"
-  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/53c0d8cd-f3a2-411d-bece-4bd83ae2bbc9", //	"Voorzitter van het Bijzonder Comité voor de Sociale Dienst"
-  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/9314533e-891f-4d84-a492-0338af104065", //	"Districtsburgemeester"
-  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000b", //	"Districtscollege"
-  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/180a2fba-6ca9-4766-9b94-82006bb9c709", //	"Gouverneur"
-  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/e14fe683-e061-44a2-b7c8-e10cab4e6ed9", //	"Voorzitter van de Raad voor Maatschappelijk Welzijn"
-  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000006", //	"College van Burgemeester en Schepenen"
-  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/4c38734d-2cc1-4d33-b792-0bd493ae9fc2", //	"Voorzitter van de Gemeenteraad"
-  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000d", //	"Deputatie"
-  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/4955bd72cd0e4eb895fdbfab08da0284", //	"Burgemeester"
-  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000008" //	"Vast Bureau"
+  'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000005', //	"Gemeenteraad"
+  'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000007', //	"Raad voor Maatschappelijk Welzijn"
+  'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000009', //	"Bijzonder Comité voor de Sociale Dienst"
+  'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000a', //	"Districtsraad"
+  'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000c', //	"Provincieraad"
+  'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/53c0d8cd-f3a2-411d-bece-4bd83ae2bbc9', //	"Voorzitter van het Bijzonder Comité voor de Sociale Dienst"
+  'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/9314533e-891f-4d84-a492-0338af104065', //	"Districtsburgemeester"
+  'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000b', //	"Districtscollege"
+  'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/180a2fba-6ca9-4766-9b94-82006bb9c709', //	"Gouverneur"
+  'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/e14fe683-e061-44a2-b7c8-e10cab4e6ed9', //	"Voorzitter van de Raad voor Maatschappelijk Welzijn"
+  'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000006', //	"College van Burgemeester en Schepenen"
+  'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/4c38734d-2cc1-4d33-b792-0bd493ae9fc2', //	"Voorzitter van de Gemeenteraad"
+  'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000d', //	"Deputatie"
+  'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/4955bd72cd0e4eb895fdbfab08da0284', //	"Burgemeester"
+  'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000008', //	"Vast Bureau"
 ];
 
 /**
@@ -32,7 +32,7 @@ const VALID_ADMINISTRATIVE_BODY_CLASSIFICATIONS = [
  * @property {boolean} error whether there is a form value error and we should render as such
  */
 
- /** @extends {Component<Args>} */
+/** @extends {Component<Args>} */
 export default class AdministrativeBodySelectComponent extends Component {
   @service currentSession;
   @service store;
@@ -49,16 +49,17 @@ export default class AdministrativeBodySelectComponent extends Component {
    * end date is not older than 2 months before the current date
    */
   @task
-  * fetchAdministrativeBodies() {
+  *fetchAdministrativeBodies() {
     let currentAdministrativeUnitId = this.currentSession.group.id;
 
     let administrativeBodiesInTime = yield this.store.query('bestuursorgaan', {
-      'filter[is-tijdsspecialisatie-van][bestuurseenheid][id]': currentAdministrativeUnitId,
-      'include': [
+      'filter[is-tijdsspecialisatie-van][bestuurseenheid][id]':
+        currentAdministrativeUnitId,
+      include: [
         'is-tijdsspecialisatie-van.bestuurseenheid',
         'is-tijdsspecialisatie-van.classificatie',
       ].join(),
-      'sort': '-binding-start'
+      sort: '-binding-start',
     });
 
     this.administrativeBodyOptions = administrativeBodiesInTime.filter(
@@ -74,11 +75,11 @@ export default class AdministrativeBodySelectComponent extends Component {
         }
 
         const endDate = administrativeBodyInTime.bindingEinde;
-        if(!endDate) {
+        if (!endDate) {
           return true;
         }
-        const twoMonthsAgo = sub(new Date(), {months: 2});
-        return isAfter(endDate,twoMonthsAgo);
+        const twoMonthsAgo = sub(new Date(), { months: 2 });
+        return isAfter(endDate, twoMonthsAgo);
       }
     );
   }

--- a/app/components/agenda-manager/agenda-context.js
+++ b/app/components/agenda-manager/agenda-context.js
@@ -1,9 +1,13 @@
 import Component from '@glimmer/component';
-import {task, all} from "ember-concurrency";
-import {action} from '@ember/object';
-import {inject as service} from '@ember/service';
-import {tracked} from 'tracked-built-ins';
-import {DRAFT_STATUS_ID, PUBLISHED_STATUS_ID, SCHEDULED_STATUS_ID} from "../../utils/constants";
+import { task, all } from 'ember-concurrency';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import { tracked } from 'tracked-built-ins';
+import {
+  DRAFT_STATUS_ID,
+  PUBLISHED_STATUS_ID,
+  SCHEDULED_STATUS_ID,
+} from '../../utils/constants';
 
 export default class AgendaManagerAgendaContextComponent extends Component {
   @service store;
@@ -17,32 +21,33 @@ export default class AgendaManagerAgendaContextComponent extends Component {
   }
 
   @task
-  * loadItemsTask() {
+  *loadItemsTask() {
     const agendaItems = [];
     const pageSize = 10;
 
     const firstPage = yield this.store.query('agendapunt', {
-      "filter[zitting][:id:]": this.args.zittingId,
-      "page[size]": pageSize,
-      include: "vorige-agendapunt,behandeling.vorige-behandeling-van-agendapunt"
+      'filter[zitting][:id:]': this.args.zittingId,
+      'page[size]': pageSize,
+      include:
+        'vorige-agendapunt,behandeling.vorige-behandeling-van-agendapunt',
     });
     const count = firstPage.meta.count;
-    firstPage.forEach(result => agendaItems.push(result));
+    firstPage.forEach((result) => agendaItems.push(result));
     let pageNumber = 1;
 
-    while (((pageNumber) * pageSize) < count) {
+    while (pageNumber * pageSize < count) {
       const pageResults = yield this.store.query('agendapunt', {
-        "filter[zitting][:id:]": this.args.zittingId,
-        "page[size]": pageSize,
-        "page[number]": pageNumber,
-      include: "vorige-agendapunt,behandeling.vorige-behandeling-van-agendapunt"
+        'filter[zitting][:id:]': this.args.zittingId,
+        'page[size]': pageSize,
+        'page[number]': pageNumber,
+        include:
+          'vorige-agendapunt,behandeling.vorige-behandeling-van-agendapunt',
       });
-      pageResults.forEach(result => agendaItems.push(result));
+      pageResults.forEach((result) => agendaItems.push(result));
       pageNumber++;
     }
     this.items = tracked(agendaItems.sortBy('position'));
   }
-
 
   /**
    * Create a new agenda item
@@ -50,17 +55,20 @@ export default class AgendaManagerAgendaContextComponent extends Component {
    */
   @action
   createAgendaItem() {
-    const agendaItem = this.store.createRecord("agendapunt", {
-      titel: "",
-      beschrijving: "",
+    const agendaItem = this.store.createRecord('agendapunt', {
+      titel: '',
+      beschrijving: '',
       geplandOpenbaar: true,
-      position: this.items.length
+      position: this.items.length,
     });
 
-    agendaItem.behandeling = this.store.createRecord("behandeling-van-agendapunt", {
-      openbaar: agendaItem.geplandOpenbaar,
-      onderwerp: agendaItem,
-      });
+    agendaItem.behandeling = this.store.createRecord(
+      'behandeling-van-agendapunt',
+      {
+        openbaar: agendaItem.geplandOpenbaar,
+        onderwerp: agendaItem,
+      }
+    );
 
     this.args.onCreate(agendaItem);
     return agendaItem;
@@ -73,24 +81,30 @@ export default class AgendaManagerAgendaContextComponent extends Component {
    * @param {Agendapunt} item
    */
   @task
-  * updateItemTask(item) {
+  *updateItemTask(item) {
     const treatment = yield item.behandeling;
     yield treatment.saveAndPersistDocument();
 
     if (item.isNew) {
-      const zitting = yield this.store.findRecord("zitting", this.args.zittingId);
-      this.setProperty(item, "zitting", zitting);
-      this.setProperty(treatment, "openbaar", item.geplandOpenbaar);
+      const zitting = yield this.store.findRecord(
+        'zitting',
+        this.args.zittingId
+      );
+      this.setProperty(item, 'zitting', zitting);
+      this.setProperty(treatment, 'openbaar', item.geplandOpenbaar);
     }
 
     yield this.updatePositionTask.unlinked().perform(item);
 
-    const container = yield treatment.get("documentContainer");
-    const status = yield container.get("status");
-    if (!status || status.get("id") !== PUBLISHED_STATUS_ID) {
+    const container = yield treatment.get('documentContainer');
+    const status = yield container.get('status');
+    if (!status || status.get('id') !== PUBLISHED_STATUS_ID) {
       // it's not published, so we set the status
-      const conceptStatus = yield this.store.findRecord('concept', SCHEDULED_STATUS_ID);
-      this.setProperty(container, "status", conceptStatus);
+      const conceptStatus = yield this.store.findRecord(
+        'concept',
+        SCHEDULED_STATUS_ID
+      );
+      this.setProperty(container, 'status', conceptStatus);
     }
 
     this.changeSet.add(item);
@@ -102,7 +116,7 @@ export default class AgendaManagerAgendaContextComponent extends Component {
    * @param {Agendapunt} item the item to be deleted
    */
   @task
-  * deleteItemTask(item) {
+  *deleteItemTask(item) {
     // we don't use item.position here to guard against problems
     // with position logic. The performance hit of searching here
     // is probably minimal.
@@ -114,8 +128,11 @@ export default class AgendaManagerAgendaContextComponent extends Component {
     if (treatment) {
       const container = yield treatment.documentContainer;
       if (container) {
-        const draftStatus = yield this.store.findRecord('concept', DRAFT_STATUS_ID);
-        this.setProperty(container, "status", draftStatus);
+        const draftStatus = yield this.store.findRecord(
+          'concept',
+          DRAFT_STATUS_ID
+        );
+        this.setProperty(container, 'status', draftStatus);
       }
       yield treatment.destroyRecord();
     }
@@ -124,26 +141,24 @@ export default class AgendaManagerAgendaContextComponent extends Component {
     yield this.saveItemsTask.unlinked().perform();
   }
 
-
   /**
    * Handles a rearrangement of the this.items array
    * Takes the array index as source of truth.
    */
   @task
-  * onSortTask() {
+  *onSortTask() {
     yield this.repairPositionsTask.unlinked().perform();
     yield this.saveItemsTask.unlinked().perform();
   }
 
   @task
-  * resetItemTask(agendaItem) {
+  *resetItemTask(agendaItem) {
     let behandeling = yield agendaItem.behandeling;
     behandeling.rollbackAttributes();
     agendaItem.rollbackAttributes();
 
     this.args.onCancel();
   }
-
 
   /**
    * Take item.position as source of truth and update the linked list and the this.items
@@ -153,19 +168,18 @@ export default class AgendaManagerAgendaContextComponent extends Component {
    * @private
    */
   @task
-  * updatePositionTask(item) {
+  *updatePositionTask(item) {
     const position = item.position;
 
-    if(this.items[position] !== item) {
+    if (this.items[position] !== item) {
       const oldIndex = this.items.indexOf(item);
-      if(oldIndex > -1) {
+      if (oldIndex > -1) {
         this.items.splice(oldIndex, 1);
       }
       this.items.splice(position, 0, item);
       yield this.repairPositionsTask.unlinked().perform();
     }
   }
-
 
   /**
    * Take the this.items array index as source of truth and
@@ -175,21 +189,24 @@ export default class AgendaManagerAgendaContextComponent extends Component {
    * @private
    * */
   @task
-  * repairPositionsTask(){
+  *repairPositionsTask() {
     let previous = null;
     for (const [index, item] of this.items.entries()) {
       const previousItem = yield item.vorigeAgendapunt;
-      if(item.position !== index || previousItem !== previous) {
-        this.setProperty(item, "position", index);
-        this.setProperty(item, "vorigeAgendapunt", previous);
+      if (item.position !== index || previousItem !== previous) {
+        this.setProperty(item, 'position', index);
+        this.setProperty(item, 'vorigeAgendapunt', previous);
         const treatment = yield item.behandeling;
-        if(treatment) {
-          if(previous) {
+        if (treatment) {
+          if (previous) {
             const previousTreatment = yield previous.behandeling;
-            this.setProperty(treatment, "vorigeBehandelingVanAgendapunt", previousTreatment);
-
+            this.setProperty(
+              treatment,
+              'vorigeBehandelingVanAgendapunt',
+              previousTreatment
+            );
           } else {
-            this.setProperty(treatment, "vorigeBehandelingVanAgendapunt", null);
+            this.setProperty(treatment, 'vorigeBehandelingVanAgendapunt', null);
           }
         }
       }
@@ -202,12 +219,11 @@ export default class AgendaManagerAgendaContextComponent extends Component {
    * @private
    */
   @task
-  * saveItemsTask() {
-    yield all([...this.changeSet].map(model => model.save()));
+  *saveItemsTask() {
+    yield all([...this.changeSet].map((model) => model.save()));
     this.changeSet.clear();
     yield this.args.onSave();
   }
-
 
   /**
    * Set a property on an ember data model and track its changes.
@@ -220,7 +236,7 @@ export default class AgendaManagerAgendaContextComponent extends Component {
    * @private
    */
   setProperty(model, property, value) {
-    if(value !== model.get(property)) {
+    if (value !== model.get(property)) {
       this.changeSet.add(model);
     }
     model.set(property, value);

--- a/app/components/agenda-manager/agenda-item-form/index.js
+++ b/app/components/agenda-manager/agenda-item-form/index.js
@@ -1,9 +1,8 @@
 import Component from '@glimmer/component';
-import {task} from "ember-concurrency";
-import {action} from "@ember/object";
+import { task } from 'ember-concurrency';
+import { action } from '@ember/object';
 
 export default class AgendaManagerAgendaItemFormIndexComponent extends Component {
-
   @task
   *submitTask() {
     yield this.args.onSubmit(this.args.model);

--- a/app/components/agenda-manager/agenda-item-form/radio/index.js
+++ b/app/components/agenda-manager/agenda-item-form/radio/index.js
@@ -1,13 +1,12 @@
 import Component from '@glimmer/component';
-import {action} from '@ember/object';
+import { action } from '@ember/object';
 
 export default class AgendaManagerAgendaItemFormRadioIndexComponent extends Component {
   get selectedOption() {
     return this.args.model[this.args.for];
   }
   @action
-  selectOption(value){
+  selectOption(value) {
     this.args.model[this.args.for] = value;
   }
-
 }

--- a/app/components/agenda-manager/agenda-item-form/select-draft.js
+++ b/app/components/agenda-manager/agenda-item-form/select-draft.js
@@ -1,18 +1,18 @@
 import Component from '@glimmer/component';
-import { inject as service } from "@ember/service";
-import { action } from "@ember/object";
-import { tracked } from "@glimmer/tracking";
-import { restartableTask } from "ember-concurrency";
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { restartableTask } from 'ember-concurrency';
 
-const DRAFT_STATUS_ID = "a1974d071e6a47b69b85313ebdcef9f7";
-const FOLDER_ID = "ae5feaed-7b70-4533-9417-10fbbc480a4c";
+const DRAFT_STATUS_ID = 'a1974d071e6a47b69b85313ebdcef9f7';
+const FOLDER_ID = 'ae5feaed-7b70-4533-9417-10fbbc480a4c';
 
 export default class AgendaManagerAgendaItemFormSelectDraftComponent extends Component {
   @service store;
   @tracked options;
   @tracked selected;
 
-  constructor(...args){
+  constructor(...args) {
     super(...args);
     this.getDrafts.perform();
   }
@@ -22,15 +22,15 @@ export default class AgendaManagerAgendaItemFormSelectDraftComponent extends Com
   }
 
   @restartableTask
-  * getDrafts(searchParams=''){
-    const query={
+  *getDrafts(searchParams = '') {
+    const query = {
       include: 'current-version,status',
       'filter[status][:id:]': DRAFT_STATUS_ID,
       'filter[folder][:id:]': FOLDER_ID,
-      'sort': "current-version.title"
+      sort: 'current-version.title',
     };
-    if(searchParams.length>1){
-      query['filter[current-version][title]']=searchParams;
+    if (searchParams.length > 1) {
+      query['filter[current-version][title]'] = searchParams;
     }
     const containers = yield this.store.query('document-container', query);
     this.options = containers;
@@ -39,9 +39,9 @@ export default class AgendaManagerAgendaItemFormSelectDraftComponent extends Com
   @action
   select(draft) {
     this.selected = draft;
-    this.agendaItem.set("behandeling.documentContainer", draft);
+    this.agendaItem.set('behandeling.documentContainer', draft);
     if (draft) {
-      this.agendaItem.titel = draft.get("currentVersion.title");
+      this.agendaItem.titel = draft.get('currentVersion.title');
     } else {
       this.agendaItem.titel = '';
     }

--- a/app/components/agenda-manager/agenda-item-form/select-location.js
+++ b/app/components/agenda-manager/agenda-item-form/select-location.js
@@ -6,28 +6,27 @@ export default class AgendaManagerAgendaItemFormSelectLocationComponent extends 
   @tracked locationOptions = [
     { code: 'start', name: 'Vooraan in agenda' },
     { code: 'after', name: 'Na agendapunt' },
-    { code: 'end', name: 'Achteraan in agenda' }
+    { code: 'end', name: 'Achteraan in agenda' },
   ];
   @tracked selectedLocation;
   @tracked selectedAfterItem;
 
-
-
   get showAfterItemOptions() {
-    return this.selectedLocation && this.selectedLocation.code === "after";
+    return this.selectedLocation && this.selectedLocation.code === 'after';
   }
 
   get afterItemOptions() {
-    return this.args.agendaItems.sortBy("position").reject((x) => x === this.args.currentItem);
+    return this.args.agendaItems
+      .sortBy('position')
+      .reject((x) => x === this.args.currentItem);
   }
 
   @action
   selectLocation(value) {
     this.selectedLocation = value;
-    if(value.code === "start") {
+    if (value.code === 'start') {
       this.args.model[this.args.for] = 0;
-    }
-    else if (value.code === "end"){
+    } else if (value.code === 'end') {
       this.args.model[this.args.for] = this.args.agendaItems.length - 1;
     }
   }

--- a/app/components/agenda-manager/agenda-table/row.js
+++ b/app/components/agenda-manager/agenda-table/row.js
@@ -8,23 +8,23 @@ export default class AgendaManagerAgendaTableRowComponent extends Component {
   @service store;
   @tracked published = false;
 
-  constructor(...args){
+  constructor(...args) {
     super(...args);
     this.getAgendaPointStatus.perform();
   }
 
   @task
-  *getAgendaPointStatus(){
-    const behandeling=(yield this.store.query("behandeling-van-agendapunt", {
-      "filter[onderwerp][:id:]": this.args.item.id,
-      include: 'document-container.status'
+  *getAgendaPointStatus() {
+    const behandeling = (yield this.store.query('behandeling-van-agendapunt', {
+      'filter[onderwerp][:id:]': this.args.item.id,
+      include: 'document-container.status',
     })).firstObject;
 
-    if(behandeling){
+    if (behandeling) {
       const statusId = behandeling.get('documentContainer.status.id');
 
-      if(statusId==PUBLISHED_STATUS_ID){
-        this.published=true;
+      if (statusId == PUBLISHED_STATUS_ID) {
+        this.published = true;
       }
     }
   }

--- a/app/components/agenda-manager/edit.js
+++ b/app/components/agenda-manager/edit.js
@@ -1,18 +1,16 @@
-import Component from "@glimmer/component";
-import { action } from "@ember/object";
-import {task} from "ember-concurrency";
-import { inject as service } from "@ember/service";
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { task } from 'ember-concurrency';
+import { inject as service } from '@ember/service';
 
 export default class AgendaManagerEditComponent extends Component {
-
   @service documentService;
-
 
   get isNew() {
     return this.args.itemToEdit && this.args.itemToEdit.isNew;
   }
   @task
-  * submitTask(item) {
+  *submitTask(item) {
     yield this.args.saveTask.unlinked().perform(item);
     this.args.onClose();
   }
@@ -21,7 +19,7 @@ export default class AgendaManagerEditComponent extends Component {
     this.args.onCancel();
   }
   @task
-  * deleteTask(item) {
+  *deleteTask(item) {
     yield this.args.deleteTask.unlinked().perform(item);
     this.args.onClose();
   }

--- a/app/components/agenda-manager/index.js
+++ b/app/components/agenda-manager/index.js
@@ -1,12 +1,11 @@
 import Component from '@glimmer/component';
-import {tracked} from '@glimmer/tracking';
-import {action} from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
 
 /**
  * @typedef {Object} Args
  * @property {string} zittingId
  */
-
 
 /** @extends {Component<Args>} */
 export default class AgendaManagerIndexComponent extends Component {

--- a/app/components/agenda-punt-link.js
+++ b/app/components/agenda-punt-link.js
@@ -1,19 +1,20 @@
 import Component from '@glimmer/component';
-import { DRAFT_STATUS_ID, PUBLISHED_STATUS_ID, PLANNED_STATUS_ID } from 'frontend-gelinkt-notuleren/utils/constants';
+import {
+  DRAFT_STATUS_ID,
+  PUBLISHED_STATUS_ID,
+  PLANNED_STATUS_ID,
+} from 'frontend-gelinkt-notuleren/utils/constants';
 export default class AgendaPuntLinkComponent extends Component {
   get editorStatus() {
     const statusId = this.args.documentContainer.status.get('id');
     if (statusId == DRAFT_STATUS_ID) {
-      return "draft";
-    }
-    else if (statusId == PLANNED_STATUS_ID) {
-      return "planned";
-    }
-    else if (statusId == PUBLISHED_STATUS_ID) {
-      return "published";
-    }
-    else {
-      return "unknown";
+      return 'draft';
+    } else if (statusId == PLANNED_STATUS_ID) {
+      return 'planned';
+    } else if (statusId == PUBLISHED_STATUS_ID) {
+      return 'published';
+    } else {
+      return 'unknown';
     }
   }
 }

--- a/app/components/app-chrome.js
+++ b/app/components/app-chrome.js
@@ -13,7 +13,9 @@ export default class AppChromeComponent extends Component {
   }
 
   get isNotAllowedToTrash() {
-    return (! this.documentStatus) || this.documentStatus.get('id') != DRAFT_STATUS_ID;
+    return (
+      !this.documentStatus || this.documentStatus.get('id') != DRAFT_STATUS_ID
+    );
   }
 
   @action

--- a/app/components/attachments-number.js
+++ b/app/components/attachments-number.js
@@ -1,10 +1,10 @@
 import Component from '@glimmer/component';
-import {tracked} from '@glimmer/tracking';
+import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
-import { restartableTask } from "ember-concurrency";
+import { restartableTask } from 'ember-concurrency';
 
 export default class AttachmentsNumberComponent extends Component {
-  constructor(...args){
+  constructor(...args) {
     super(...args);
     this.getAttachmentsNumber.perform();
   }
@@ -14,9 +14,8 @@ export default class AttachmentsNumberComponent extends Component {
   @tracked attachmentsNumber;
 
   @restartableTask
-  * getAttachmentsNumber(){
+  *getAttachmentsNumber() {
     const attachments = yield this.args.documentContainer.attachments;
     this.attachmentsNumber = attachments.meta.count;
   }
 }
-

--- a/app/components/behandeling-van-agendapunt.js
+++ b/app/components/behandeling-van-agendapunt.js
@@ -100,16 +100,16 @@ export default class BehandelingVanAgendapuntComponent extends Component {
 
   @task
   *getStatus() {
-    const behandeling=(yield this.store.query("behandeling-van-agendapunt", {
-      "filter[:id:]": this.args.behandeling.id,
-      include: 'document-container.status'
+    const behandeling = (yield this.store.query('behandeling-van-agendapunt', {
+      'filter[:id:]': this.args.behandeling.id,
+      include: 'document-container.status',
     })).firstObject;
 
-    if(behandeling){
+    if (behandeling) {
       const status = yield behandeling.get('documentContainer.status');
       const statusId = status.id;
 
-      if(statusId === PUBLISHED_STATUS_ID){
+      if (statusId === PUBLISHED_STATUS_ID) {
         this.published = true;
       }
     }

--- a/app/components/besluit-document-container.js
+++ b/app/components/besluit-document-container.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
 
 export default class BesluitDocumentContainerComponent extends Component {
-  profile = 'draftDecisionsProfile'
+  profile = 'draftDecisionsProfile';
 }

--- a/app/components/contact-form.js
+++ b/app/components/contact-form.js
@@ -3,7 +3,7 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
 export default class ContactFormComponent extends Component {
-  @tracked mailto = "gelinktnotuleren@vlaanderen.be";
+  @tracked mailto = 'gelinktnotuleren@vlaanderen.be';
 
   @action
   setMailto(value) {

--- a/app/components/date-time-picker.js
+++ b/app/components/date-time-picker.js
@@ -1,8 +1,8 @@
 import Component from '@glimmer/component';
-import { action } from "@ember/object";
+import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 
-export default class DateTimePicker extends Component{
+export default class DateTimePicker extends Component {
   @service intl;
   date;
   hours;
@@ -10,7 +10,7 @@ export default class DateTimePicker extends Component{
 
   constructor() {
     super(...arguments);
-    if(this.args.value) {
+    if (this.args.value) {
       this.date = new Date(this.args.value);
       this.hours = this.date.getHours();
       this.minutes = this.date.getMinutes();
@@ -38,7 +38,7 @@ export default class DateTimePicker extends Component{
   onChangeDate(isoDate, date) {
     let wasDateInputCleared = !date;
     if (!wasDateInputCleared) {
-      if(!this.date) {
+      if (!this.date) {
         this.date = new Date();
       }
       this.date.setDate(date.getDate());
@@ -51,14 +51,14 @@ export default class DateTimePicker extends Component{
   @action
   onChangeTime(type, event) {
     const value = event.target.value;
-    if(!this.date) {
+    if (!this.date) {
       this.date = new Date();
     }
-    if(type === 'hours') {
-      if(value < 0 || value > 24) return;
+    if (type === 'hours') {
+      if (value < 0 || value > 24) return;
       this.date.setHours(value);
     } else {
-      if(value < 0 || value > 60) return;
+      if (value < 0 || value > 60) return;
       this.date.setMinutes(value);
     }
     this.args.onChange(this.date);
@@ -67,19 +67,17 @@ export default class DateTimePicker extends Component{
 
 function getLocalizedMonths(intl, monthFormat = 'long') {
   let someYear = 2021;
-  return [...Array(12).keys()]
-    .map((monthIndex) => {
-      let date = new Date(someYear, monthIndex);
-      return intl.formatDate(date, { month: monthFormat });
-    });
+  return [...Array(12).keys()].map((monthIndex) => {
+    let date = new Date(someYear, monthIndex);
+    return intl.formatDate(date, { month: monthFormat });
+  });
 }
 
 function getLocalizedDays(intl, weekdayFormat = 'long') {
   let someSunday = new Date('2021-01-03');
-  return [...Array(7).keys()]
-    .map((index) => {
-      let weekday = new Date(someSunday.getTime());
-      weekday.setDate(someSunday.getDate() + index);
-      return intl.formatDate(weekday, { weekday: weekdayFormat });
-    });
+  return [...Array(7).keys()].map((index) => {
+    let weekday = new Date(someSunday.getTime());
+    weekday.setDate(someSunday.getDate() + index);
+    return intl.formatDate(weekday, { weekday: weekdayFormat });
+  });
 }

--- a/app/components/document-attachments.js
+++ b/app/components/document-attachments.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { task } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
-import {REGULATORY_TYPE_ID}  from 'frontend-gelinkt-notuleren/utils/constants';
+import { REGULATORY_TYPE_ID } from 'frontend-gelinkt-notuleren/utils/constants';
 
 export default class DocumentAttachmentsComponent extends Component {
   constructor(...args) {
@@ -18,12 +18,14 @@ export default class DocumentAttachmentsComponent extends Component {
 
   @task
   *updateAttachmentIsRegulatory(attachment, isRegulatory) {
-    if(!isRegulatory){
-      attachment.type=null;
-    }
-    else{
-      const concept=yield this.store.findRecord('concept', REGULATORY_TYPE_ID);
-      attachment.type=concept;
+    if (!isRegulatory) {
+      attachment.type = null;
+    } else {
+      const concept = yield this.store.findRecord(
+        'concept',
+        REGULATORY_TYPE_ID
+      );
+      attachment.type = concept;
     }
     yield attachment.save();
   }
@@ -40,7 +42,7 @@ export default class DocumentAttachmentsComponent extends Component {
     this.attachments = yield this.store.query('attachment', {
       page: { size: 100 },
       'filter[document-container][:id:]': this.args.documentContainer.id,
-      include: "type"
+      include: 'type',
     });
   }
 

--- a/app/components/editor-document-title.js
+++ b/app/components/editor-document-title.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import {action } from '@ember/object';
+import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
 export default class EditorDocumentTitleComponent extends Component {
@@ -28,11 +28,10 @@ export default class EditorDocumentTitleComponent extends Component {
 
   @action
   toggleActive() {
-    if (this.active && ! this.title) {
+    if (this.active && !this.title) {
       this.error = true;
-    }
-    else {
-      this.active = ! this.active;
+    } else {
+      this.active = !this.active;
     }
   }
 }

--- a/app/components/editor-status-pill.js
+++ b/app/components/editor-status-pill.js
@@ -1,20 +1,21 @@
 import Component from '@glimmer/component';
-import { DRAFT_STATUS_ID, PUBLISHED_STATUS_ID, PLANNED_STATUS_ID } from 'frontend-gelinkt-notuleren/utils/constants';
+import {
+  DRAFT_STATUS_ID,
+  PUBLISHED_STATUS_ID,
+  PLANNED_STATUS_ID,
+} from 'frontend-gelinkt-notuleren/utils/constants';
 
 export default class EditorDocumentStatusPillComponent extends Component {
   get editorStatusClass() {
     const statusId = this.args.status?.get('id');
     if (statusId == DRAFT_STATUS_ID) {
-      return "border";
-    }
-    else if (statusId == PLANNED_STATUS_ID) {
-      return "action";
-    }
-    else if (statusId == PUBLISHED_STATUS_ID) {
-      return "success";
-    }
-    else {
-      return "border";
+      return 'border';
+    } else if (statusId == PLANNED_STATUS_ID) {
+      return 'action';
+    } else if (statusId == PUBLISHED_STATUS_ID) {
+      return 'success';
+    } else {
+      return 'border';
     }
   }
 }

--- a/app/components/language-select.js
+++ b/app/components/language-select.js
@@ -14,7 +14,7 @@ export default class LanguageSelect extends Component {
     super(...arguments);
 
     if (!this.selected) {
-      const defaultOption = this.options.find(o => o.id == 'nl');
+      const defaultOption = this.options.find((o) => o.id == 'nl');
       this.selectLanguage(defaultOption);
     }
   }

--- a/app/components/manage-intermissions/edit.js
+++ b/app/components/manage-intermissions/edit.js
@@ -1,9 +1,13 @@
 import Component from '@glimmer/component';
-import { task } from "ember-concurrency";
-import { tracked } from "@glimmer/tracking";
-import { action } from "@ember/object";
+import { task } from 'ember-concurrency';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
-import {BEFORE_POS_ID, DURING_POS_ID, AFTER_POS_ID}  from 'frontend-gelinkt-notuleren/utils/constants';
+import {
+  BEFORE_POS_ID,
+  DURING_POS_ID,
+  AFTER_POS_ID,
+} from 'frontend-gelinkt-notuleren/utils/constants';
 
 export default class manageIntermissionsEditComponent extends Component {
   @tracked startedAt;
@@ -11,13 +15,13 @@ export default class manageIntermissionsEditComponent extends Component {
   @tracked comment;
   @service store;
   @service intl;
- 
-  constructor(...args){
+
+  constructor(...args) {
     super(...args);
   }
 
   get startedAtExternal() {
-    if(this.startedAt === '' || !this.startedAt) {
+    if (this.startedAt === '' || !this.startedAt) {
       return this.args.intermissionToEdit.startedAt;
     } else {
       return this.startedAt;
@@ -25,7 +29,7 @@ export default class manageIntermissionsEditComponent extends Component {
   }
 
   get endedAtExternal() {
-    if(this.endedAt === '' || !this.endedAt) {
+    if (this.endedAt === '' || !this.endedAt) {
       return this.args.intermissionToEdit.endedAt;
     } else {
       return this.endedAt;
@@ -33,7 +37,7 @@ export default class manageIntermissionsEditComponent extends Component {
   }
 
   get commentExternal() {
-    if(this.comment === '' || !this.comment) {
+    if (this.comment === '' || !this.comment) {
       return this.args.intermissionToEdit.comment;
     } else {
       return this.comment;
@@ -55,18 +59,18 @@ export default class manageIntermissionsEditComponent extends Component {
   }
 
   @task
-  *saveIntermission(){
+  *saveIntermission() {
     const intermission = this.args.intermissionToEdit;
-    if(this.startedAt) {
+    if (this.startedAt) {
       intermission.startedAt = this.startedAt;
     }
-    if(this.endedAt) {
+    if (this.endedAt) {
       intermission.endedAt = this.endedAt;
     }
-    if(this.comment) {
+    if (this.comment) {
       intermission.comment = this.comment;
     }
-    if(intermission.isNew) {
+    if (intermission.isNew) {
       this.args.zitting.intermissions.pushObject(intermission);
     }
     yield this.savePosition.perform();
@@ -89,13 +93,25 @@ export default class manageIntermissionsEditComponent extends Component {
   //position stuff
   get positionOptions() {
     return [
-      { code: 'before', name: this.intl.t('manageIntermissions.beforeAp'), conceptUuid: BEFORE_POS_ID },
-      { code: 'during', name: this.intl.t('manageIntermissions.duringAp'), conceptUuid: DURING_POS_ID },
-      { code: 'after', name: this.intl.t('manageIntermissions.afterAp'), conceptUuid: AFTER_POS_ID }
+      {
+        code: 'before',
+        name: this.intl.t('manageIntermissions.beforeAp'),
+        conceptUuid: BEFORE_POS_ID,
+      },
+      {
+        code: 'during',
+        name: this.intl.t('manageIntermissions.duringAp'),
+        conceptUuid: DURING_POS_ID,
+      },
+      {
+        code: 'after',
+        name: this.intl.t('manageIntermissions.afterAp'),
+        conceptUuid: AFTER_POS_ID,
+      },
     ];
   }
   @action
-  updatedIntermission(){
+  updatedIntermission() {
     this.fetchPosition.perform();
   }
 
@@ -110,9 +126,11 @@ export default class manageIntermissionsEditComponent extends Component {
     }
     agendaPos.agendapoint = this.selectedAp;
     if (this.selectedAp && this.selectedPosition) {
-      agendaPos.position = yield this.store.findRecord('concept', this.selectedPosition.conceptUuid);
-    }
-    else {
+      agendaPos.position = yield this.store.findRecord(
+        'concept',
+        this.selectedPosition.conceptUuid
+      );
+    } else {
       agendaPos.position = null;
     }
     yield agendaPos.save();
@@ -125,20 +143,19 @@ export default class manageIntermissionsEditComponent extends Component {
     if (agendaPos) {
       const posConcept = yield agendaPos.position;
       if (posConcept) {
-        this.selectedPosition = this.positionOptions.find(e => e.conceptUuid === posConcept.id);
-      }
-      else {
+        this.selectedPosition = this.positionOptions.find(
+          (e) => e.conceptUuid === posConcept.id
+        );
+      } else {
         this.selectedPosition = null;
       }
       const posAp = yield agendaPos.agendapoint;
       if (posAp) {
         this.selectedAp = posAp;
-      }
-      else {
+      } else {
         this.selectedAp = null;
       }
-    }
-    else {
+    } else {
       this.selectedAp = null;
       this.selectedPosition = null;
     }

--- a/app/components/manage-intermissions/index.js
+++ b/app/components/manage-intermissions/index.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
-import { task } from "ember-concurrency";
-import { tracked } from "@glimmer/tracking";
-import {action} from '@ember/object';
+import { task } from 'ember-concurrency';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 
 export default class manageIntermissionsComponent extends Component {
@@ -17,8 +17,8 @@ export default class manageIntermissionsComponent extends Component {
 
   @action
   addIntermission() {
-    this.intermissionToEdit = this.store.createRecord("intermission", {
-      startedAt: this.args.zitting.geplandeStart
+    this.intermissionToEdit = this.store.createRecord('intermission', {
+      startedAt: this.args.zitting.geplandeStart,
     });
     this.showModal = true;
   }
@@ -30,8 +30,8 @@ export default class manageIntermissionsComponent extends Component {
   }
 
   @task
-  *fetchIntermissions(){
-    this.intermissions =  yield this.args.zitting.get('intermissions');
+  *fetchIntermissions() {
+    this.intermissions = yield this.args.zitting.get('intermissions');
   }
 
   @action

--- a/app/components/participation-list/functionaris-selector.js
+++ b/app/components/participation-list/functionaris-selector.js
@@ -1,12 +1,14 @@
 import Component from '@glimmer/component';
-import {task} from 'ember-concurrency';
+import { task } from 'ember-concurrency';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 const PROVINCE_CLASSIFICATION_ID = '5ab0e9b8a3b2ca7c5e000000';
 const GRIFFIER_CLASSIFICATION_ID = '5ab19107-82d2-4273-a986-3da86fda050d';
-const ALGEMEEN_DIRECTEUR_CLASSIFICATION_ID = '39854196-f214-4688-87a1-d6ad12baa2fa';
-const ADJUNCT_ALGEMEEN_DIRECTEUR_CLASSIFICATION_ID = '11f0af9e-016c-4e0b-983a-d8bc73804abc';
+const ALGEMEEN_DIRECTEUR_CLASSIFICATION_ID =
+  '39854196-f214-4688-87a1-d6ad12baa2fa';
+const ADJUNCT_ALGEMEEN_DIRECTEUR_CLASSIFICATION_ID =
+  '11f0af9e-016c-4e0b-983a-d8bc73804abc';
 export default class ParticipationListFunctionarisSelectorComponent extends Component {
   @tracked options = [];
 
@@ -19,7 +21,7 @@ export default class ParticipationListFunctionarisSelectorComponent extends Comp
   @service currentSession;
 
   @task
-  *loadData(){
+  *loadData() {
     const group = this.currentSession.group;
     const adminUnitClassification = yield group.classificatie;
     let relevantBestuursOrgaanClassifications = `${ALGEMEEN_DIRECTEUR_CLASSIFICATION_ID},${ADJUNCT_ALGEMEEN_DIRECTEUR_CLASSIFICATION_ID}`;
@@ -28,19 +30,29 @@ export default class ParticipationListFunctionarisSelectorComponent extends Comp
     }
     const bestuursorganen = yield this.store.query('bestuursorgaan', {
       filter: {
-        "is-tijdsspecialisatie-van": {
-          "bestuurseenheid": { ":id:": group.id },
-          "classificatie": {":id:": relevantBestuursOrgaanClassifications }
-        }
-      }
+        'is-tijdsspecialisatie-van': {
+          bestuurseenheid: { ':id:': group.id },
+          classificatie: { ':id:': relevantBestuursOrgaanClassifications },
+        },
+      },
     });
-    const startOfMeeting = this.args.meeting.gestartOpTijdstip ? this.args.meeting.gestartOpTijdstip : this.args.meeting.geplandeStart;
+    const startOfMeeting = this.args.meeting.gestartOpTijdstip
+      ? this.args.meeting.gestartOpTijdstip
+      : this.args.meeting.geplandeStart;
     let queryParams = {
       sort: 'is-bestuurlijke-alias-van.achternaam',
-      'filter[bekleedt][bevat-in][:id:]': bestuursorganen.map((b) => b.id).join(','),
-      'filter[:lte:start]': startOfMeeting.toISOString()
+      'filter[bekleedt][bevat-in][:id:]': bestuursorganen
+        .map((b) => b.id)
+        .join(','),
+      'filter[:lte:start]': startOfMeeting.toISOString(),
     };
-    const candidateOptions = yield this.store.query('functionaris', queryParams);
-    this.options = candidateOptions.reject((functionaris) => functionaris.einde && functionaris.einde < startOfMeeting);
+    const candidateOptions = yield this.store.query(
+      'functionaris',
+      queryParams
+    );
+    this.options = candidateOptions.reject(
+      (functionaris) =>
+        functionaris.einde && functionaris.einde < startOfMeeting
+    );
   }
 }

--- a/app/components/signatures/agenda/timeline-step.js
+++ b/app/components/signatures/agenda/timeline-step.js
@@ -1,4 +1,4 @@
-import Component from "@glimmer/component";
+import Component from '@glimmer/component';
 /** @typedef {import("../../../models/agenda").default} Agenda */
 
 /**
@@ -17,7 +17,7 @@ export default class SignaturesAgendaTimelineStep extends Component {
   get mockAgenda() {
     return {
       body: this.args.agenda.renderedContent,
-      signedId: this.args.agenda.zitting.get('id')
+      signedId: this.args.agenda.zitting.get('id'),
     };
   }
 }

--- a/app/components/signatures/besluitenlijst/timeline-step.js
+++ b/app/components/signatures/besluitenlijst/timeline-step.js
@@ -4,7 +4,7 @@ export default class SignaturesBesluitenlijstTimelineStep extends Component {
   get mockLijst() {
     return {
       body: this.args.lijst.content,
-      signedId: this.args.lijst.zitting.get('id')
+      signedId: this.args.lijst.zitting.get('id'),
     };
   }
 }

--- a/app/components/signatures/notulen/behandelingen-list.js
+++ b/app/components/signatures/notulen/behandelingen-list.js
@@ -1,6 +1,5 @@
 import Component from '@glimmer/component';
 
-
 export default class SignaturesNotulenBehandelingList extends Component {
   get isPublished() {
     return this.args.notulen.get('publishedResource');

--- a/app/components/signatures/notulen/timeline-step.js
+++ b/app/components/signatures/notulen/timeline-step.js
@@ -8,7 +8,7 @@ export default class SignaturesNotulenTimelineStep extends Component {
   get mockNotulen() {
     return {
       body: this.args.notulen.content,
-      signedId: this.args.notulen.zitting.get('id')
+      signedId: this.args.notulen.zitting.get('id'),
     };
   }
 }

--- a/app/components/signatures/publication-status.js
+++ b/app/components/signatures/publication-status.js
@@ -1,28 +1,30 @@
 import Component from '@glimmer/component';
-import {tracked} from "@glimmer/tracking";
-import { action } from "@ember/object";
-
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
 
 export default class SignaturesPublicationStatus extends Component {
   @tracked signedResources = [];
-  @tracked publishedResource
+  @tracked publishedResource;
   @tracked ready = false;
-  @action  
+  @action
   async loadResource() {
     console.log(this.args.versionedResource.get('signedResources'));
-    this.signedResources = await this.args.versionedResource.get('signedResources') || [];
-    this.publishedResource = await this.args.versionedResource.get('publishedResource');
+    this.signedResources =
+      (await this.args.versionedResource.get('signedResources')) || [];
+    this.publishedResource = await this.args.versionedResource.get(
+      'publishedResource'
+    );
     this.ready = true;
   }
-  get publicationStatus(){
+  get publicationStatus() {
     if (this.publishedResource) {
-      return {label: 'Gepubliceerd', color: 'action'};
-    }else if (this.signedResources.length === 1) {
-      return {label: 'Eerste ondertekening verkregen', color: 'warning'};
+      return { label: 'Gepubliceerd', color: 'action' };
+    } else if (this.signedResources.length === 1) {
+      return { label: 'Eerste ondertekening verkregen', color: 'warning' };
     } else if (this.signedResources.length === 2) {
-      return {label: 'Getekend', color: 'success'};
+      return { label: 'Getekend', color: 'success' };
     } else {
-      return {label: 'Concept'};
+      return { label: 'Concept' };
     }
   }
 }

--- a/app/components/signatures/published-resource.js
+++ b/app/components/signatures/published-resource.js
@@ -1,13 +1,17 @@
 import Component from '@glimmer/component';
 
-
 export default class SignaturesPublishedResourceComponent extends Component {
   get submissionFailed() {
-    return this.args.publication.submissionStatus === "http://lblod.data.gift/publication-submission-statuses/failure";
+    return (
+      this.args.publication.submissionStatus ===
+      'http://lblod.data.gift/publication-submission-statuses/failure'
+    );
   }
 
   get submissionSucceeded() {
-    return this.args.publication.submissionStatus === "http://lblod.data.gift/publication-submission-statuses/success";
+    return (
+      this.args.publication.submissionStatus ===
+      'http://lblod.data.gift/publication-submission-statuses/success'
+    );
   }
 }
-

--- a/app/components/signatures/timeline-step.js
+++ b/app/components/signatures/timeline-step.js
@@ -1,7 +1,7 @@
-import Component from "@glimmer/component";
-import {inject as service} from '@ember/service';
-import {task, restartableTask} from 'ember-concurrency';
-import {tracked} from "@glimmer/tracking";
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+import { task, restartableTask } from 'ember-concurrency';
+import { tracked } from '@glimmer/tracking';
 import ENV from 'frontend-gelinkt-notuleren/config/environment';
 
 /**
@@ -35,8 +35,8 @@ export default class SignaturesTimelineStep extends Component {
   }
 
   get isPublished() {
-    if(this.args.publishedResource) {
-      return !! this.args.publishedResource.get("id");
+    if (this.args.publishedResource) {
+      return !!this.args.publishedResource.get('id');
     }
     return false;
   }
@@ -50,7 +50,7 @@ export default class SignaturesTimelineStep extends Component {
   }
 
   @restartableTask
-  * initTask() {
+  *initTask() {
     this.bestuurseenheid = this.currentSession.group;
     const currentUser = this.currentSession.user;
     let firstSignatureUser = null;
@@ -65,72 +65,66 @@ export default class SignaturesTimelineStep extends Component {
   }
 
   get isAgenda() {
-    return (this.args.name === 'ontwerpagenda') || (this.args.name === 'aanvullende agenda') || (this.args.name === 'spoedeisende agenda');
+    return (
+      this.args.name === 'ontwerpagenda' ||
+      this.args.name === 'aanvullende agenda' ||
+      this.args.name === 'spoedeisende agenda'
+    );
   }
 
   get title() {
     return `Voorvertoning ${this.args.name}`;
   }
 
-
   get headerWithDefault() {
     return this.args.header || this.args.name;
   }
 
   get status() {
-    if (this.isPublished)
-      return 'published';
-    if (this.signaturesCount === 1)
-      return 'firstSignature';
-    if (this.signaturesCount === 2)
-      return 'secondSignature';
+    if (this.isPublished) return 'published';
+    if (this.signaturesCount === 1) return 'firstSignature';
+    if (this.signaturesCount === 2) return 'secondSignature';
     return 'concept';
   }
 
   get handtekeningStatus() {
-
     if (this.signaturesCount === 1)
-      return {label: 'Tweede ondertekening vereist', color: 'warning'};
+      return { label: 'Tweede ondertekening vereist', color: 'warning' };
     if (this.signaturesCount === 2)
-      return {label: 'Ondertekend', color: 'action'};
-    return {label: 'Niet ondertekend', color: 'border'};
+      return { label: 'Ondertekend', color: 'action' };
+    return { label: 'Niet ondertekend', color: 'border' };
   }
 
   get voorVertoningStatus() {
     if (this.status === 'published')
-      return {label: 'Publieke versie', color: 'action'};
+      return { label: 'Publieke versie', color: 'action' };
     if (this.status === 'firstSignature' || this.status === 'secondSignature')
-      return {label: 'Ondertekende versie', color: 'success'};
-    return {label: 'Meest recente versie'};
-
+      return { label: 'Ondertekende versie', color: 'success' };
+    return { label: 'Meest recente versie' };
   }
 
   get algemeneStatus() {
     if (this.status === 'published')
-      return {label: 'Gepubliceerd', color: 'action'};
+      return { label: 'Gepubliceerd', color: 'action' };
     if (this.status === 'firstSignature')
-      return {label: 'Eerste ondertekening verkregen', color: 'warning'};
+      return { label: 'Eerste ondertekening verkregen', color: 'warning' };
     if (this.status === 'secondSignature')
-      return {label: 'Getekend', color: 'success'};
-    if (this.status === 'concept')
-      return {label: 'Concept'};
+      return { label: 'Getekend', color: 'success' };
+    if (this.status === 'concept') return { label: 'Concept' };
     return 'concept';
   }
 
-
   get iconName() {
-    if (this.status === 'concept')
-      return 'pencil';
+    if (this.status === 'concept') return 'pencil';
     if (this.status === 'firstSignature' || this.status === 'secondSignature')
       return 'message';
-    if (this.status === 'published')
-      return 'check';
+    if (this.status === 'published') return 'check';
 
     return 'pencil';
   }
 
   @task
-  * signDocument(signedId) {
+  *signDocument(signedId) {
     this.showSigningModal = false;
     this.isSignedByCurrentUser = true;
     yield this.args.signing(signedId);
@@ -139,7 +133,7 @@ export default class SignaturesTimelineStep extends Component {
   }
 
   @task
-  * publishDocument(signedId) {
+  *publishDocument(signedId) {
     this.showPublishingModal = false;
     yield this.args.publish(signedId);
   }

--- a/app/components/snippets-notifier.js
+++ b/app/components/snippets-notifier.js
@@ -28,7 +28,7 @@ export default class SnippetsNotifier extends Component {
   }
 
   @action
-  close(){
-    this.show=false;
+  close() {
+    this.show = false;
   }
 }

--- a/app/components/treatment/voting/edit.js
+++ b/app/components/treatment/voting/edit.js
@@ -1,6 +1,6 @@
-import { action } from "@ember/object";
-import Component from "@glimmer/component";
-import { inject as service } from "@ember/service";
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
 /**
  * @typedef {import("../../../models/stemming").default} Stemming
  */
@@ -15,7 +15,6 @@ import { inject as service } from "@ember/service";
 
 /** @extends {Component<Args>} */
 export default class TreatmentVotingEditComponent extends Component {
-
   @service editStemming;
 
   @action
@@ -25,7 +24,5 @@ export default class TreatmentVotingEditComponent extends Component {
   @action
   cancel() {
     this.args.onCancel && this.args.onCancel();
-
   }
-
 }

--- a/app/components/treatment/voting/manage-voters.js
+++ b/app/components/treatment/voting/manage-voters.js
@@ -17,6 +17,5 @@ import { inject as service } from '@ember/service';
  */
 /** @extends {Component<Args>} */
 export default class TreatmentVotingManageVotersComponent extends Component {
-    @service editStemming;
-
+  @service editStemming;
 }

--- a/app/components/treatment/voting/modal.js
+++ b/app/components/treatment/voting/modal.js
@@ -1,8 +1,8 @@
-import { inject as service } from "@ember/service";
-import { action } from "@ember/object";
-import { tracked } from "@glimmer/tracking";
-import Component from "@glimmer/component";
-import { task, restartableTask } from "ember-concurrency";
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import Component from '@glimmer/component';
+import { task, restartableTask } from 'ember-concurrency';
 /** @typedef {import("../../../models/behandeling-van-agendapunt").default} Behandeling*/
 /** @typedef {import("../../../models/bestuursorgaan").default} Bestuursorgaan*/
 /** @typedef {import("../../../models/stemming").default} Stemming*/
@@ -33,7 +33,9 @@ export default class TreatmentVotingModalComponent extends Component {
   @restartableTask
   /** @type {import("ember-concurrency").Task} */
   *fetchStemmingen() {
-    this.stemmingen = (yield this.args.behandeling.stemmingen).sortBy('position');
+    this.stemmingen = (yield this.args.behandeling.stemmingen).sortBy(
+      'position'
+    );
   }
 
   @task
@@ -41,8 +43,9 @@ export default class TreatmentVotingModalComponent extends Component {
   *saveStemming() {
     const isNew = this.editStemming.stemming.isNew;
 
-    if(isNew) {
-      this.editStemming.stemming.position = this.args.behandeling.stemmingen.length;
+    if (isNew) {
+      this.editStemming.stemming.position =
+        this.args.behandeling.stemmingen.length;
     }
     yield this.editStemming.saveTask.perform();
 
@@ -58,19 +61,19 @@ export default class TreatmentVotingModalComponent extends Component {
   @task
   /** @type {import("ember-concurrency").Task} */
   *addStemming() {
-    const richTreatment = yield this.store.query("behandeling-van-agendapunt", {
-      "filter[:id:]": this.args.behandeling.id,
-      include: "aanwezigen.bekleedt.bestuursfunctie"
+    const richTreatment = yield this.store.query('behandeling-van-agendapunt', {
+      'filter[:id:]': this.args.behandeling.id,
+      include: 'aanwezigen.bekleedt.bestuursfunctie',
     });
     const participants = richTreatment.firstObject.aanwezigen;
 
-    const stemmingToEdit = this.store.createRecord("stemming", {
-      onderwerp: "",
+    const stemmingToEdit = this.store.createRecord('stemming', {
+      onderwerp: '',
       geheim: false,
       aantalVoorstanders: 0,
       aantalTegenstanders: 0,
       aantalOnthouders: 0,
-      gevolg: "",
+      gevolg: '',
     });
     this.editMode = true;
     stemmingToEdit.aanwezigen.pushObjects(participants);

--- a/app/components/treatment/voting/voter-row.js
+++ b/app/components/treatment/voting/voter-row.js
@@ -15,7 +15,7 @@ import { action } from '@ember/object';
  * Ex
  * */
 export default class TreatmentVotingVoterRowComponent extends Component {
-  voteOptions = ["voor", "tegen", "onthouding"];
+  voteOptions = ['voor', 'tegen', 'onthouding'];
 
   constructor(parent, args) {
     super(parent, args);
@@ -24,14 +24,14 @@ export default class TreatmentVotingVoterRowComponent extends Component {
     return this.args.row[0].isBestuurlijkeAliasVan;
   }
   get isVoting() {
-    return this.args.row[1] !== "zalNietStemmen";
+    return this.args.row[1] !== 'zalNietStemmen';
   }
   get mandataris() {
     return this.args.row[0];
   }
   get selectedVote() {
-    if (this.args.row[1] === "zalStemmen") {
-      return "selecteer";
+    if (this.args.row[1] === 'zalStemmen') {
+      return 'selecteer';
     }
     return this.args.row[1];
   }
@@ -41,11 +41,11 @@ export default class TreatmentVotingVoterRowComponent extends Component {
 
   @action
   addStemmer() {
-    this.args.onVoteChange(this.args.row[0], "zalStemmen");
+    this.args.onVoteChange(this.args.row[0], 'zalStemmen');
   }
   @action
   removeStemmer() {
-    this.args.onVoteChange(this.args.row[0], "zalNietStemmen");
+    this.args.onVoteChange(this.args.row[0], 'zalNietStemmen');
   }
 
   @action
@@ -56,5 +56,4 @@ export default class TreatmentVotingVoterRowComponent extends Component {
     const vote = event.target.value;
     this.args.onVoteChange(this.args.row[0], vote);
   }
-
 }

--- a/app/components/treatment/voting/voter-table.js
+++ b/app/components/treatment/voting/voter-table.js
@@ -1,5 +1,5 @@
-import Component from "@glimmer/component";
-import { inject as service } from "@ember/service";
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
 /**
  * @typedef {import("../../../models/mandataris").default} Mandataris
  * @typedef {import("../../../services/edit-stemming").default} EditStemmingService
@@ -17,8 +17,10 @@ export default class TreatmentVotingVoterTableComponent extends Component {
     const map = this.editStemming.votingMap;
     const entries = [...map];
     return entries.sort((entry1, entry2) => {
-      const lastName1 = entry1[0].get("isBestuurlijkeAliasVan.achternaam") || "";
-      const lastName2 = entry2[0]?.get("isBestuurlijkeAliasVan.achternaam") || "";
+      const lastName1 =
+        entry1[0].get('isBestuurlijkeAliasVan.achternaam') || '';
+      const lastName2 =
+        entry2[0]?.get('isBestuurlijkeAliasVan.achternaam') || '';
       return lastName1.localeCompare(lastName2);
     });
   }

--- a/app/components/zitting-link.js
+++ b/app/components/zitting-link.js
@@ -1,11 +1,10 @@
 import Component from '@glimmer/component';
-import {tracked} from '@glimmer/tracking';
+import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
-import { restartableTask } from "ember-concurrency";
-
+import { restartableTask } from 'ember-concurrency';
 
 export default class ZittingLinkComponent extends Component {
-  constructor(...args){
+  constructor(...args) {
     super(...args);
     this.getMeeting.perform();
   }
@@ -15,12 +14,13 @@ export default class ZittingLinkComponent extends Component {
   @tracked meeting;
 
   @restartableTask
-  * getMeeting(){
-    const result = yield this.store.query("zitting", {
-      'filter[agendapunten][behandeling][document-container][:id:]': this.args.documentContainer.id,
+  *getMeeting() {
+    const result = yield this.store.query('zitting', {
+      'filter[agendapunten][behandeling][document-container][:id:]':
+        this.args.documentContainer.id,
       // Including the agendapunten relationship ensures the cache returns the proper response.
       // TODO: This is a workaround for a mu-cache issue. Remove the include once that's resolved.
-      'include': 'agendapunten'
+      include: 'agendapunten',
     });
     this.meeting = result.firstObject;
   }

--- a/app/components/zitting-text-document-container.js
+++ b/app/components/zitting-text-document-container.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
-import { task } from "ember-concurrency";
-import { action } from "@ember/object";
+import { task } from 'ember-concurrency';
+import { action } from '@ember/object';
 
 export default class ZittingTextDocumentContainerComponent extends Component {
   constructor(...args) {
@@ -16,19 +16,17 @@ export default class ZittingTextDocumentContainerComponent extends Component {
     showInsertButton: false,
     showRdfa: false,
     showRdfaHighlight: false,
-    showRdfaHover: false
+    showRdfaHover: false,
   };
 
-  get text(){
+  get text() {
     const zitting = this.args.zitting;
     if (this.type === 'ext:intro') {
       return zitting.intro;
-    }
-    else if (this.type === 'ext:outro') {
+    } else if (this.type === 'ext:outro') {
       return zitting.outro;
-    }
-    else{
-      return "";
+    } else {
+      return '';
     }
   }
 
@@ -38,8 +36,7 @@ export default class ZittingTextDocumentContainerComponent extends Component {
 
     if (this.type === 'ext:intro') {
       zitting.intro = this.editor.htmlContent;
-    }
-    else if (this.type === 'ext:outro') {
+    } else if (this.type === 'ext:outro') {
       zitting.outro = this.editor.htmlContent;
     }
     yield zitting.save();
@@ -51,5 +48,4 @@ export default class ZittingTextDocumentContainerComponent extends Component {
     this.editor = editor;
     this.args.onEditorInit(editor);
   }
-
 }

--- a/app/components/zitting/manage-zittingsdata.js
+++ b/app/components/zitting/manage-zittingsdata.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { action } from "@ember/object";
+import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
 export default class ZittingManageZittingsdataComponent extends Component {
@@ -22,11 +22,10 @@ export default class ZittingManageZittingsdataComponent extends Component {
     this.geeindigdOpTijdstip = this.args.zitting.geeindigdOpTijdstip;
     this.opLocatie = this.args.zitting.opLocatie;
     this.bestuursorgaan = this.args.zitting.bestuursorgaan;
-
   }
 
   @action
-  async saveZittingsData(){
+  async saveZittingsData() {
     this.zitting.geplandeStart = this.geplandeStart;
     this.zitting.gestartOpTijdstip = this.gestartOpTijdstip;
     this.zitting.geeindigdOpTijdstip = this.geeindigdOpTijdstip;
@@ -53,5 +52,4 @@ export default class ZittingManageZittingsdataComponent extends Component {
   changeDate(targetProperty, value) {
     this[targetProperty] = value;
   }
-
 }

--- a/app/config/custom-inflector-rules.js
+++ b/app/config/custom-inflector-rules.js
@@ -2,43 +2,46 @@ import Inflector from 'ember-inflector';
 
 const inflector = Inflector.inflector;
 
-inflector.plural(/$/,'en');
-inflector.plural(/e$/,'es');
-inflector.plural(/e([lnr])$/,'e$1s');
-inflector.plural(/([aiuo])$/,'$1s');
-inflector.plural(/([^aiuoe])([aiuo])([a-z])$/,'$1$2$3$3en'); // TODO: this is a bit hack
-inflector.plural(/uis$/,'uizen');
-inflector.plural(/ief$/,'ieven');
-inflector.plural(/or$/,'oren');
-inflector.plural(/ie$/,'ies');
-inflector.plural(/eid$/,'eden');
-inflector.plural(/aa([a-z])$/,'a$1en');
-inflector.plural(/uu([a-z])$/,'u$1en');
-inflector.plural(/oo([a-z])$/,'o$1en');
-inflector.singular(/en$/,'');
-inflector.singular(/es$/,'e');
-inflector.singular(/e([lnr])s$/,'e$1');
-inflector.singular(/([aiuo])s$/,'$1');
-inflector.singular(/([^aiuoe])([aiuo])([a-z])\3en$/,"$1$2$3"); // TODO: this is a bit hack
-inflector.singular(/uizen$/,'uis');
-inflector.singular(/ieven$/,'ief');
-inflector.singular(/ies$/,'ie');
-inflector.singular(/eden$/,'eid');
-inflector.singular(/a([a-z])en$/,'aa$1');
-inflector.singular(/u([a-z])en$/,'uu$1');
-inflector.singular(/o([a-z])en$/,'oo$1');
-inflector.singular(/([auio])s$/,'$1s');
-inflector.irregular("agenda","agendas");
+inflector.plural(/$/, 'en');
+inflector.plural(/e$/, 'es');
+inflector.plural(/e([lnr])$/, 'e$1s');
+inflector.plural(/([aiuo])$/, '$1s');
+inflector.plural(/([^aiuoe])([aiuo])([a-z])$/, '$1$2$3$3en'); // TODO: this is a bit hack
+inflector.plural(/uis$/, 'uizen');
+inflector.plural(/ief$/, 'ieven');
+inflector.plural(/or$/, 'oren');
+inflector.plural(/ie$/, 'ies');
+inflector.plural(/eid$/, 'eden');
+inflector.plural(/aa([a-z])$/, 'a$1en');
+inflector.plural(/uu([a-z])$/, 'u$1en');
+inflector.plural(/oo([a-z])$/, 'o$1en');
+inflector.singular(/en$/, '');
+inflector.singular(/es$/, 'e');
+inflector.singular(/e([lnr])s$/, 'e$1');
+inflector.singular(/([aiuo])s$/, '$1');
+inflector.singular(/([^aiuoe])([aiuo])([a-z])\3en$/, '$1$2$3'); // TODO: this is a bit hack
+inflector.singular(/uizen$/, 'uis');
+inflector.singular(/ieven$/, 'ief');
+inflector.singular(/ies$/, 'ie');
+inflector.singular(/eden$/, 'eid');
+inflector.singular(/a([a-z])en$/, 'aa$1');
+inflector.singular(/u([a-z])en$/, 'uu$1');
+inflector.singular(/o([a-z])en$/, 'oo$1');
+inflector.singular(/([auio])s$/, '$1s');
+inflector.irregular('agenda', 'agendas');
 inflector.uncountable('versioned-notulen');
-inflector.irregular("behandeling-van-agendapunt","behandelingen-van-agendapunten");
-inflector.irregular("rechtsgrond-aanstelling","rechtsgronden-aanstelling");
-inflector.irregular("rechtsgrond-artikel","rechtsgronden-artikel");
-inflector.irregular("rechtsgrond-beeindiging","rechtsgronden-beeindiging");
-inflector.irregular("rechtsgrond-besluit","rechtsgronden-besluit");
-inflector.irregular("editor-document", "editor-documents");
-inflector.irregular("editor-document-status", "editor-document-statuses");
-inflector.irregular("export", "exports");
-inflector.irregular("account", "accounts");
+inflector.irregular(
+  'behandeling-van-agendapunt',
+  'behandelingen-van-agendapunten'
+);
+inflector.irregular('rechtsgrond-aanstelling', 'rechtsgronden-aanstelling');
+inflector.irregular('rechtsgrond-artikel', 'rechtsgronden-artikel');
+inflector.irregular('rechtsgrond-beeindiging', 'rechtsgronden-beeindiging');
+inflector.irregular('rechtsgrond-besluit', 'rechtsgronden-besluit');
+inflector.irregular('editor-document', 'editor-documents');
+inflector.irregular('editor-document-status', 'editor-document-statuses');
+inflector.irregular('export', 'exports');
+inflector.irregular('account', 'accounts');
 inflector.irregular('identificator', 'identificatoren');
 inflector.irregular('file', 'files');
 inflector.irregular('document-status', 'document-statuses');
@@ -47,7 +50,10 @@ inflector.irregular('validation', 'validations');
 inflector.irregular('validation-execution', 'validation-executions');
 inflector.irregular('validation-error', 'validation-errors');
 inflector.irregular('inzending-voor-toezicht', 'inzendingen-voor-toezicht');
-inflector.irregular('toezicht-account-acceptance-status', 'toezicht-account-acceptance-statuses');
+inflector.irregular(
+  'toezicht-account-acceptance-status',
+  'toezicht-account-acceptance-statuses'
+);
 inflector.irregular('toezicht-fiscal-period', 'toezicht-fiscal-periods');
 inflector.irregular('form-solution', 'form-solutions');
 inflector.irregular('dynamic-subform', 'dynamic-subforms');

--- a/app/config/editor-document-default-context.js
+++ b/app/config/editor-document-default-context.js
@@ -12,8 +12,8 @@ const defaultContext = {
     besluittype: 'https://data.vlaanderen.be/id/concept/BesluitType/',
     dct: 'http://purl.org/dc/terms/',
     mobiliteit: 'https://data.vlaanderen.be/ns/mobiliteit#',
-    lblodmow: 'http://data.lblod.info/vocabularies/mobiliteit/'
-  }
+    lblodmow: 'http://data.lblod.info/vocabularies/mobiliteit/',
+  },
 };
 
 export default JSON.stringify(defaultContext);

--- a/app/config/editor-profiles.js
+++ b/app/config/editor-profiles.js
@@ -1,33 +1,33 @@
 export default {
   default: [
-    "rdfa-editor-standard-template-plugin",
-    "rdfa-editor-citaten-plugin",
-    "rdfa-editor-import-snippet-plugin",
-    "rdfa-editor-besluit-type-plugin",
+    'rdfa-editor-standard-template-plugin',
+    'rdfa-editor-citaten-plugin',
+    'rdfa-editor-import-snippet-plugin',
+    'rdfa-editor-besluit-type-plugin',
   ],
 
   //GEMEENTE
-  "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001": [
-    "rdfa-editor-standard-template-plugin",
-    "rdfa-editor-citaten-plugin",
-    "rdfa-editor-import-snippet-plugin",
-    "rdfa-editor-besluit-type-plugin",
-  ],
+  'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001':
+    [
+      'rdfa-editor-standard-template-plugin',
+      'rdfa-editor-citaten-plugin',
+      'rdfa-editor-import-snippet-plugin',
+      'rdfa-editor-besluit-type-plugin',
+    ],
 
   //OCMW
-  "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000002": [
-    "rdfa-editor-standard-template-plugin",
-    "rdfa-editor-citaten-plugin",
-    "rdfa-editor-import-snippet-plugin",
-    "rdfa-editor-besluit-type-plugin",
-
-  ],
+  'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000002':
+    [
+      'rdfa-editor-standard-template-plugin',
+      'rdfa-editor-citaten-plugin',
+      'rdfa-editor-import-snippet-plugin',
+      'rdfa-editor-besluit-type-plugin',
+    ],
   draftDecisionsProfile: [
-    "rdfa-editor-standard-template-plugin",
-    "rdfa-editor-citaten-plugin",
-    "rdfa-editor-import-snippet-plugin",
-    "rdfa-editor-besluit-type-plugin",
-
+    'rdfa-editor-standard-template-plugin',
+    'rdfa-editor-citaten-plugin',
+    'rdfa-editor-import-snippet-plugin',
+    'rdfa-editor-besluit-type-plugin',
   ],
-  none: []
+  none: [],
 };

--- a/app/controllers/agendapoints/edit.js
+++ b/app/controllers/agendapoints/edit.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
-import { task } from "ember-concurrency";
+import { task } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
@@ -44,26 +44,32 @@ export default class AgendapointsEditController extends Controller {
 
   @task
   *copyAgendapunt() {
-    const response = yield fetch(`/agendapoint-service/${this.documentContainer.id}/copy`, {method: 'POST'});
+    const response = yield fetch(
+      `/agendapoint-service/${this.documentContainer.id}/copy`,
+      { method: 'POST' }
+    );
     const json = yield response.json();
     const agendapuntId = json.uuid;
     yield this.router.transitionTo('agendapoints.edit', agendapuntId);
   }
 
   @action
-  toggleDeleteModal(){
-    this.displayDeleteModal = ! this.displayDeleteModal;
+  toggleDeleteModal() {
+    this.displayDeleteModal = !this.displayDeleteModal;
   }
 
   @action
-  closeValidationModal(){
+  closeValidationModal() {
     this.hasDocumentValidationErrors = false;
   }
 
   @action
-  async deleteDocument(){
+  async deleteDocument() {
     const container = this.documentContainer;
-    const deletedStatus = await this.store.findRecord('concept', TRASH_STATUS_ID);
+    const deletedStatus = await this.store.findRecord(
+      'concept',
+      TRASH_STATUS_ID
+    );
     container.status = deletedStatus;
     await container.save();
     this.displayDeleteModal = false;
@@ -72,10 +78,9 @@ export default class AgendapointsEditController extends Controller {
 
   @task
   *saveTask() {
-    if (! this.editorDocument.title) {
+    if (!this.editorDocument.title) {
       this.hasDocumentValidationErrors = true;
-    }
-    else {
+    } else {
       this.hasDocumentValidationErrors = false;
       const html = this.editor.htmlContent;
       const editorDocument = this.store.createRecord('editor-document');
@@ -93,18 +98,18 @@ export default class AgendapointsEditController extends Controller {
     }
   }
 
-  @action toggleUpload(){
-    this.uploading=!this.uploading;
+  @action toggleUpload() {
+    this.uploading = !this.uploading;
     this.fetchDecisions.perform();
   }
-  
-  @task 
-  *toggleUploadAndSave(){
-    if(this.dirty) {
+
+  @task
+  *toggleUploadAndSave() {
+    if (this.dirty) {
       yield this.saveTask.perform();
     }
     yield this.fetchDecisions.perform();
-    this.uploading=!this.uploading;
+    this.uploading = !this.uploading;
   }
 
   @task

--- a/app/controllers/agendapoints/revisions.js
+++ b/app/controllers/agendapoints/revisions.js
@@ -18,23 +18,23 @@ export default class AgendapointsRevisionsController extends Controller {
     this.model.container.set('currentVersion', revision);
     yield this.model.container.save();
     this.model.editorDocument = revision;
-    yield Promise.all(revisionsToRemove.map( r => r.destroyRecord()));
+    yield Promise.all(revisionsToRemove.map((r) => r.destroyRecord()));
     this.orderedRevisions.removeObjects(revisionsToRemove);
     this.flushThingsToRemove();
   }
 
-  getRevisionsToRemove(revision){
+  getRevisionsToRemove(revision) {
     let revisionsToRemove = [];
 
-    for(let r of this.orderedRevisions){
-      if(r.id === revision.id) break;
+    for (let r of this.orderedRevisions) {
+      if (r.id === revision.id) break;
       revisionsToRemove.pushObject(r);
     }
 
     return revisionsToRemove;
   }
 
-  flushThingsToRemove(){
+  flushThingsToRemove() {
     this.showConfirmationModal = false;
     this.revisionToRemove = null;
     this.revisionsToRemove = null;
@@ -42,29 +42,32 @@ export default class AgendapointsRevisionsController extends Controller {
   }
 
   @action
-  cancelConfirmRevisionsToRemove(){
+  cancelConfirmRevisionsToRemove() {
     this.flushThingsToRemove();
   }
 
   @action
-  confirmRevisionsToRemove(revision){
+  confirmRevisionsToRemove(revision) {
     this.showConfirmationModal = true;
     this.revisionsToRemove = this.getRevisionsToRemove(revision);
     this.revisionToRemove = revision;
   }
 
   @action
-  restore(){
-    this.setNewRevisionHistory.perform(this.revisionsToRemove, this.revisionToRemove);
+  restore() {
+    this.setNewRevisionHistory.perform(
+      this.revisionsToRemove,
+      this.revisionToRemove
+    );
   }
 
   @action
-  details(revision){
+  details(revision) {
     this.revisionDetail = revision;
   }
 
   @action
-  cancelDetails(){
+  cancelDetails() {
     this.revisionDetail = null;
   }
 }

--- a/app/controllers/agendapoints/show.js
+++ b/app/controllers/agendapoints/show.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
-import { task } from "ember-concurrency";
+import { task } from 'ember-concurrency';
 import generateExportFromEditorDocument from 'frontend-gelinkt-notuleren/utils/generate-export-from-editor-document';
 import { action } from '@ember/object';
 
@@ -15,13 +15,16 @@ export default class AgendapointsShowController extends Controller {
 
   @task
   *copyAgendapunt() {
-    const response = yield fetch(`/agendapoint-service/${this.model.documentContainer.id}/copy`, {method: 'POST'});
+    const response = yield fetch(
+      `/agendapoint-service/${this.model.documentContainer.id}/copy`,
+      { method: 'POST' }
+    );
     const json = yield response.json();
     const agendapuntId = json.uuid;
     yield this.router.transitionTo('agendapoints.edit', agendapuntId);
   }
 
-  get readOnly(){
+  get readOnly() {
     return !this.currentSession.canWrite && this.currentSession.canRead;
   }
 }

--- a/app/controllers/inbox/agendapoints.js
+++ b/app/controllers/inbox/agendapoints.js
@@ -1,18 +1,20 @@
 import Controller from '@ember/controller';
 import DefaultQueryParamsMixin from 'ember-data-table/mixins/default-query-params';
 import { inject as service } from '@ember/service';
-import {action} from '@ember/object';
+import { action } from '@ember/object';
 
-export default class InboxDraftDecisionsController extends Controller.extend(DefaultQueryParamsMixin) {
+export default class InboxDraftDecisionsController extends Controller.extend(
+  DefaultQueryParamsMixin
+) {
   @service currentSession;
   @service router;
-  sort='-current-version.updated-on';
+  sort = '-current-version.updated-on';
 
   @action
   openNewDocument() {
     this.router.transitionTo('agendapoints.new');
   }
-  get readOnly(){
+  get readOnly() {
     return !this.currentSession.canWrite && this.currentSession.canRead;
   }
 }

--- a/app/controllers/inbox/meetings.js
+++ b/app/controllers/inbox/meetings.js
@@ -3,11 +3,13 @@ import Controller from '@ember/controller';
 import DefaultQueryParamsMixin from 'ember-data-table/mixins/default-query-params';
 import { tracked } from '@glimmer/tracking';
 
-export default class InboxMeetingsController extends Controller.extend(DefaultQueryParamsMixin) {
+export default class InboxMeetingsController extends Controller.extend(
+  DefaultQueryParamsMixin
+) {
   @service currentSession;
   @tracked sort = '-geplande-start';
 
-  get readOnly(){
+  get readOnly() {
     return !this.currentSession.canWrite && this.currentSession.canRead;
   }
 }

--- a/app/controllers/inbox/meetings/new.js
+++ b/app/controllers/inbox/meetings/new.js
@@ -11,12 +11,15 @@ export default class InboxMeetingsNewController extends Controller {
   }
 
   @dropTask
-  * saveMeetingTask(event) {
+  *saveMeetingTask(event) {
     event.preventDefault();
 
     let bestuursorgaan = yield this.meeting.bestuursorgaan;
     if (!bestuursorgaan) {
-      this.meeting.errors.add('bestuursorgaan', 'inbox.meetings.new.meeting.errors.administrativeBody.required');
+      this.meeting.errors.add(
+        'bestuursorgaan',
+        'inbox.meetings.new.meeting.errors.administrativeBody.required'
+      );
     }
 
     if (this.meeting.isValid) {

--- a/app/controllers/inbox/trash.js
+++ b/app/controllers/inbox/trash.js
@@ -3,15 +3,20 @@ import Controller from '@ember/controller';
 import DefaultQueryParamsMixin from 'ember-data-table/mixins/default-query-params';
 import { action } from '@ember/object';
 
-const CONCEPT_STATUS = "a1974d071e6a47b69b85313ebdcef9f7";
-export default class InboxTrashController extends Controller.extend(DefaultQueryParamsMixin) {
+const CONCEPT_STATUS = 'a1974d071e6a47b69b85313ebdcef9f7';
+export default class InboxTrashController extends Controller.extend(
+  DefaultQueryParamsMixin
+) {
   @service currentSession;
   @service store;
   @service router;
 
   @action
   async moveToConcepts(documents /*, datatable */) {
-    const conceptStatus = await this.store.findRecord('concept', CONCEPT_STATUS);
+    const conceptStatus = await this.store.findRecord(
+      'concept',
+      CONCEPT_STATUS
+    );
     for (const document of documents) {
       document.status = conceptStatus;
       await document.save();

--- a/app/controllers/meetings/edit/intro.js
+++ b/app/controllers/meetings/edit/intro.js
@@ -35,5 +35,4 @@ export default class MeetingsEditIntroController extends Controller {
     zitting.intro = this.editor.htmlContent;
     yield zitting.save();
   }
-
 }

--- a/app/controllers/meetings/edit/outro.js
+++ b/app/controllers/meetings/edit/outro.js
@@ -5,7 +5,7 @@ import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 
 export default class MeetingsEditOutroController extends Controller {
-  @service router
+  @service router;
   @tracked editor;
 
   get dirty() {

--- a/app/controllers/meetings/edit/treatment.js
+++ b/app/controllers/meetings/edit/treatment.js
@@ -30,7 +30,7 @@ export default class MeetingsEditTreatmentController extends Controller {
 
   @action
   closeModal() {
-    this.uploading=false;
+    this.uploading = false;
     this.router.transitionTo('meetings.edit');
   }
 
@@ -138,17 +138,17 @@ export default class MeetingsEditTreatmentController extends Controller {
     this.document = document;
   }
 
-  @action toggleUpload(){
-    this.uploading=!this.uploading;
+  @action toggleUpload() {
+    this.uploading = !this.uploading;
     this.fetchDecisions.perform();
   }
-  
-  @task 
-  *toggleUploadAndSave(){
-    if(this.dirty) {
+
+  @task
+  *toggleUploadAndSave() {
+    if (this.dirty) {
       yield this.saveDocumentTask.perform();
     }
-    this.uploading=!this.uploading;
+    this.uploading = !this.uploading;
     this.fetchDecisions.perform();
   }
 

--- a/app/controllers/meetings/publish/agenda.js
+++ b/app/controllers/meetings/publish/agenda.js
@@ -1,24 +1,25 @@
-import Controller from "@ember/controller";
-import {task} from "ember-concurrency";
-import {tracked} from "@glimmer/tracking";
+import Controller from '@ember/controller';
+import { task } from 'ember-concurrency';
+import { tracked } from '@glimmer/tracking';
 import fetch from 'fetch';
 import { inject as service } from '@ember/service';
 
 /** @typedef {import("../../../models/agenda").default} Agenda */
 /** @typedef {import("../../../models/zitting").default} Zitting */
 
-
 // agenda kind uuid's as defined in the codelist
 // mapping ontwerp to "gepland"
-const KIND_GEPLAND_UUID = "bdf68a65-ce15-42c8-ae1b-19eeb39e20d0";
-const KIND_AANVULLENDE_UUID = "b122db75-fd93-4f03-b57a-2a9269289782";
-const KIND_SPOEDEISENDE_UUID = "8c143571-175c-4d13-acaa-9f471180a8c9";
+const KIND_GEPLAND_UUID = 'bdf68a65-ce15-42c8-ae1b-19eeb39e20d0';
+const KIND_AANVULLENDE_UUID = 'b122db75-fd93-4f03-b57a-2a9269289782';
+const KIND_SPOEDEISENDE_UUID = '8c143571-175c-4d13-acaa-9f471180a8c9';
 
-const KIND_LABEL_TO_UUID_MAP = new Map(Object.entries({
-  'gepland': KIND_GEPLAND_UUID,
-  'aanvullend': KIND_AANVULLENDE_UUID,
-  'spoedeisend': KIND_SPOEDEISENDE_UUID
-}));
+const KIND_LABEL_TO_UUID_MAP = new Map(
+  Object.entries({
+    gepland: KIND_GEPLAND_UUID,
+    aanvullend: KIND_AANVULLENDE_UUID,
+    spoedeisend: KIND_SPOEDEISENDE_UUID,
+  })
+);
 
 /**
  * @extends {Controller}
@@ -60,19 +61,22 @@ export default class MeetingsPublishAgendaController extends Controller {
   }
 
   @task
-  * initializeAgendas() {
-    this.ontwerpAgenda = yield this.initializeAgenda.perform("gepland");
-    this.aanvullendeAgenda = yield this.initializeAgenda.perform("aanvullend");
-    this.spoedeisendeAgenda = yield this.initializeAgenda.perform("spoedeisend");
+  *initializeAgendas() {
+    this.ontwerpAgenda = yield this.initializeAgenda.perform('gepland');
+    this.aanvullendeAgenda = yield this.initializeAgenda.perform('aanvullend');
+    this.spoedeisendeAgenda = yield this.initializeAgenda.perform(
+      'spoedeisend'
+    );
   }
 
   @task
-  * reloadAgendas() {
-    this.ontwerpAgenda = yield this.initializeAgenda.perform("gepland");
-    this.aanvullendeAgenda = yield this.initializeAgenda.perform("aanvullend");
-    this.spoedeisendeAgenda = yield this.initializeAgenda.perform("spoedeisend");
+  *reloadAgendas() {
+    this.ontwerpAgenda = yield this.initializeAgenda.perform('gepland');
+    this.aanvullendeAgenda = yield this.initializeAgenda.perform('aanvullend');
+    this.spoedeisendeAgenda = yield this.initializeAgenda.perform(
+      'spoedeisend'
+    );
   }
-
 
   /**
    * @this {MeetingsPublishAgendaController}
@@ -80,30 +84,30 @@ export default class MeetingsPublishAgendaController extends Controller {
    * @return {Generator<*, void, *>}
    */
   @task
-  * initializeAgenda(type) {
-    const agendas = yield this.store.query("agenda",
-      {
-        'filter[zitting][:id:]': this.meeting.id,
-        'filter[agenda-type]': type,
-        include: "signed-resources,published-resource"
-      }
-    );
+  *initializeAgenda(type) {
+    const agendas = yield this.store.query('agenda', {
+      'filter[zitting][:id:]': this.meeting.id,
+      'filter[agenda-type]': type,
+      include: 'signed-resources,published-resource',
+    });
     if (agendas.length) {
       return agendas.firstObject;
     } else {
-      const prePublish = yield this.createPrePublishedResource.perform(KIND_LABEL_TO_UUID_MAP.get(type));
-      const rslt = yield this.store.createRecord("agenda", {
+      const prePublish = yield this.createPrePublishedResource.perform(
+        KIND_LABEL_TO_UUID_MAP.get(type)
+      );
+      const rslt = yield this.store.createRecord('agenda', {
         agendaType: type,
         zitting: this.model,
         agendapunten: this.model.behandeldeAgendapunten,
-        renderedContent: prePublish
+        renderedContent: prePublish,
       });
       return rslt;
     }
   }
 
   @task
-  * createPrePublishedResource(kindUuid) {
+  *createPrePublishedResource(kindUuid) {
     const id = this.meeting.id;
     const response = yield fetch(`/prepublish/agenda/${kindUuid}/${id}`);
     const json = yield response.json();
@@ -115,9 +119,9 @@ export default class MeetingsPublishAgendaController extends Controller {
    * @this {MeetingsPublishAgendaController}
    */
   @task
-  * createSignedResource(kindUuid) {
+  *createSignedResource(kindUuid) {
     const id = this.model.id;
-    yield fetch(`/signing/agenda/sign/${kindUuid}/${id}`, { method: 'POST'});
+    yield fetch(`/signing/agenda/sign/${kindUuid}/${id}`, { method: 'POST' });
     yield this.reloadAgendas.perform();
   }
 
@@ -126,9 +130,11 @@ export default class MeetingsPublishAgendaController extends Controller {
    * @this {MeetingsPublishAgendaController}
    */
   @task
-    * createPublishedResource(kindUuid) {
+  *createPublishedResource(kindUuid) {
     const id = this.model.id;
-    yield fetch(`/signing/agenda/publish/${kindUuid}/${id}`, { method: 'POST'});
+    yield fetch(`/signing/agenda/publish/${kindUuid}/${id}`, {
+      method: 'POST',
+    });
     yield this.reloadAgendas.perform();
   }
 }

--- a/app/controllers/meetings/publish/besluitenlijst.js
+++ b/app/controllers/meetings/publish/besluitenlijst.js
@@ -1,17 +1,15 @@
-import Controller from "@ember/controller";
-import {task, timeout} from "ember-concurrency";
-import {tracked} from "@glimmer/tracking";
+import Controller from '@ember/controller';
+import { task, timeout } from 'ember-concurrency';
+import { tracked } from '@glimmer/tracking';
 import { fetch } from 'fetch';
 import { inject as service } from '@ember/service';
 /** @typedef {import("../../../models/zitting").default} Zitting */
-
 
 /**
  * @extends {Controller}
  * @property {Zitting} model
  */
 export default class MeetingsPublishBesluitenlijstController extends Controller {
-
   @service store;
   @tracked besluitenlijst;
   @tracked validationErrors;
@@ -25,29 +23,31 @@ export default class MeetingsPublishBesluitenlijstController extends Controller 
     this.initializeBesluitenLijst.perform();
   }
 
-
   @task
-    * initializeBesluitenLijst() {
-      try {
-        const behandelings = yield this.store.query('versioned-besluiten-lijst',{
-          'filter[zitting][:id:]': this.model.id,
-          include: 'signed-resources,published-resource'
-        });
-        if(behandelings.length) {
-          this.besluitenlijst = behandelings.firstObject;
-        } else {
-          const {content, errors} = yield this.createPrePublishedResource.perform();
-          const rslt = yield this.store.createRecord("versioned-besluiten-lijst", {
+  *initializeBesluitenLijst() {
+    try {
+      const behandelings = yield this.store.query('versioned-besluiten-lijst', {
+        'filter[zitting][:id:]': this.model.id,
+        include: 'signed-resources,published-resource',
+      });
+      if (behandelings.length) {
+        this.besluitenlijst = behandelings.firstObject;
+      } else {
+        const { content, errors } =
+          yield this.createPrePublishedResource.perform();
+        const rslt = yield this.store.createRecord(
+          'versioned-besluiten-lijst',
+          {
             zitting: this.model,
-            content: content
-          });
-          this.besluitenlijst = rslt;
-          this.validationErrors = errors;
-        }
+            content: content,
+          }
+        );
+        this.besluitenlijst = rslt;
+        this.validationErrors = errors;
       }
-      catch(e) {
-        this.error = e;
-      }
+    } catch (e) {
+      this.error = e;
+    }
   }
 
   async pollForPrepublisherResults(meetingId) {
@@ -70,14 +70,13 @@ export default class MeetingsPublishBesluitenlijstController extends Controller 
   }
 
   @task
-  * reloadBesluitenLijst() {
-    const behandelings = yield this.store.query('versioned-besluiten-lijst',{
+  *reloadBesluitenLijst() {
+    const behandelings = yield this.store.query('versioned-besluiten-lijst', {
       'filter[zitting][:id:]': this.model.id,
-      include: 'signed-resources,published-resource'
+      include: 'signed-resources,published-resource',
     });
     this.besluitenlijst = behandelings.firstObject;
   }
-
 
   @task
   *createPrePublishedResource() {
@@ -87,12 +86,14 @@ export default class MeetingsPublishBesluitenlijstController extends Controller 
   }
 
   @task
-  * createSignedResource() {
+  *createSignedResource() {
     const id = this.model.id;
-    const result = yield fetch(`/signing/besluitenlijst/sign/${id}`, { method: 'POST' });
+    const result = yield fetch(`/signing/besluitenlijst/sign/${id}`, {
+      method: 'POST',
+    });
     const json = yield result.json();
     const taskId = json.data.id;
-    let maxIterations  = 600;
+    let maxIterations = 600;
     let status;
     let iteration = 0;
     do {
@@ -101,17 +102,23 @@ export default class MeetingsPublishBesluitenlijstController extends Controller 
       const json = yield result.json();
       status = json.data.status;
       iteration++;
-    } while (status != "http://lblod.data.gift/besluit-publicatie-melding-statuses/success" || iteration > maxIterations);
+    } while (
+      status !=
+        'http://lblod.data.gift/besluit-publicatie-melding-statuses/success' ||
+      iteration > maxIterations
+    );
     yield this.reloadBesluitenLijst.perform();
   }
 
   @task
-  * createPublishedResource() {
+  *createPublishedResource() {
     const id = this.model.id;
-    const result = yield fetch(`/signing/besluitenlijst/publish/${id}`, { method: 'POST' });
+    const result = yield fetch(`/signing/besluitenlijst/publish/${id}`, {
+      method: 'POST',
+    });
     const json = yield result.json();
     const taskId = json.data.id;
-    let maxIterations  = 600;
+    let maxIterations = 600;
     let status;
     let iteration = 0;
     do {
@@ -120,7 +127,11 @@ export default class MeetingsPublishBesluitenlijstController extends Controller 
       const json = yield result.json();
       status = json.data.status;
       iteration++;
-    } while (status != "http://lblod.data.gift/besluit-publicatie-melding-statuses/success" || iteration > maxIterations);
+    } while (
+      status !=
+        'http://lblod.data.gift/besluit-publicatie-melding-statuses/success' ||
+      iteration > maxIterations
+    );
     yield this.reloadBesluitenLijst.perform();
   }
 }

--- a/app/controllers/meetings/publish/uittreksels/index.js
+++ b/app/controllers/meetings/publish/uittreksels/index.js
@@ -1,7 +1,8 @@
 import Controller from '@ember/controller';
 import DefaultQueryParamsMixin from 'ember-data-table/mixins/default-query-params';
 
-export default class MeetingsPublishUittrekselsController extends Controller.extend(DefaultQueryParamsMixin) {
-  sort='position';
-
+export default class MeetingsPublishUittrekselsController extends Controller.extend(
+  DefaultQueryParamsMixin
+) {
+  sort = 'position';
 }

--- a/app/controllers/meetings/publish/uittreksels/show.js
+++ b/app/controllers/meetings/publish/uittreksels/show.js
@@ -12,7 +12,7 @@ export default class MeetingsPublishUittrekselsShowController extends Controller
   @service router;
 
   get agendapoint() {
-    return  this.model.get('onderwerp');
+    return this.model.get('onderwerp');
   }
 
   get meeting() {
@@ -32,44 +32,52 @@ export default class MeetingsPublishUittrekselsShowController extends Controller
   }
 
   @task
-    *_createSignedResourceTask(behandeling) {
-      try {
-        this.error = null;
-        const result = yield fetch(`/signing/behandeling/sign/${this.meeting.get('id')}/${behandeling.get('id')}`, {
+  *_createSignedResourceTask(behandeling) {
+    try {
+      this.error = null;
+      const result = yield fetch(
+        `/signing/behandeling/sign/${this.meeting.get('id')}/${behandeling.get(
+          'id'
+        )}`,
+        {
           method: 'POST',
-        });
-        if (! result.ok) {
-          const json = yield result.json();
-          const errors = json?.errors?.join("\n");
-          throw errors;
         }
-        yield this.loadExtract.perform();
+      );
+      if (!result.ok) {
+        const json = yield result.json();
+        const errors = json?.errors?.join('\n');
+        throw errors;
       }
-      catch(e) {
-        this.extract = null;
-        this.error = e;
-      }
+      yield this.loadExtract.perform();
+    } catch (e) {
+      this.extract = null;
+      this.error = e;
     }
+  }
 
   @task
-    *_createPublishedResourceTask(behandeling) {
-      try {
-        this.error = null;
-        const result = yield fetch(`/signing/behandeling/publish/${this.meeting.get('id')}/${behandeling.get('id')}`, {
-        method: 'POST',
-        });
-        if (! result.ok) {
-          const json = yield result.json();
-          const errors = json?.errors?.join("\n");
-          throw errors;
+  *_createPublishedResourceTask(behandeling) {
+    try {
+      this.error = null;
+      const result = yield fetch(
+        `/signing/behandeling/publish/${this.meeting.get(
+          'id'
+        )}/${behandeling.get('id')}`,
+        {
+          method: 'POST',
         }
-        yield this.loadExtract.perform();
+      );
+      if (!result.ok) {
+        const json = yield result.json();
+        const errors = json?.errors?.join('\n');
+        throw errors;
       }
-      catch(e) {
-        this.extract = null;
-        this.error = e;
-      }
+      yield this.loadExtract.perform();
+    } catch (e) {
+      this.extract = null;
+      this.error = e;
     }
+  }
 
   @action
   print(extract) {
@@ -83,21 +91,19 @@ export default class MeetingsPublishUittrekselsShowController extends Controller
   get mockBehandeling() {
     return {
       body: this.extract.document.content,
-      signedId: this.meeting.get('id')
+      signedId: this.meeting.get('id'),
     };
   }
 
   @task
-    * loadExtract() {
-      try {
-        this.extract = null;
-        this.error = null;
-        const treatment = this.model;
-        this.extract = yield this.publish.fetchExtract(treatment);
-      }
-      catch(e) {
-        this.error = e;
-      }
+  *loadExtract() {
+    try {
+      this.extract = null;
+      this.error = null;
+      const treatment = this.model;
+      this.extract = yield this.publish.fetchExtract(treatment);
+    } catch (e) {
+      this.error = e;
     }
+  }
 }
-

--- a/app/controllers/mock-login.js
+++ b/app/controllers/mock-login.js
@@ -12,21 +12,20 @@ export default class MockLoginController extends Controller {
   @tracked size = 10;
 
   @task
-  * queryStore() {
+  *queryStore() {
     const filter = { provider: 'https://github.com/lblod/mock-login-service' };
-    if (this.gemeente)
-      filter.gebruiker = { 'achternaam': this.gemeente};
+    if (this.gemeente) filter.gebruiker = { achternaam: this.gemeente };
     const accounts = yield this.store.query('account', {
       include: 'gebruiker,gebruiker.bestuurseenheden',
       filter: filter,
       page: { size: this.size, number: this.page },
-      sort: 'gebruiker.achternaam'
+      sort: 'gebruiker.achternaam',
     });
     return accounts;
   }
 
   @restartableTask
-  * updateSearch(value) {
+  *updateSearch(value) {
     yield timeout(500);
     this.page = 0;
     this.gemeente = value;

--- a/app/formats.js
+++ b/app/formats.js
@@ -3,28 +3,28 @@ export default {
     hhmmss: {
       hour: 'numeric',
       minute: 'numeric',
-      second: 'numeric'
-    }
+      second: 'numeric',
+    },
   },
   date: {
     hhmmss: {
       hour: 'numeric',
       minute: 'numeric',
-      second: 'numeric'
-    }
+      second: 'numeric',
+    },
   },
   number: {
     EUR: {
       style: 'currency',
       currency: 'EUR',
       minimumFractionDigits: 2,
-      maximumFractionDigits: 2
+      maximumFractionDigits: 2,
     },
     USD: {
       style: 'currency',
       currency: 'USD',
       minimumFractionDigits: 2,
-      maximumFractionDigits: 2
-    }
-  }
+      maximumFractionDigits: 2,
+    },
+  },
 };

--- a/app/helpers/behandeling-subject.js
+++ b/app/helpers/behandeling-subject.js
@@ -1,13 +1,12 @@
 import { helper } from '@ember/component/helper';
 
-export function behandelingSubject([body]/*, hash*/) {
+export function behandelingSubject([body] /*, hash*/) {
   if (body) {
     const div = document.createElement('div');
     div.innerHTML = body;
 
     const subjectNode = div.querySelector("[property='dc:subject']");
-    if (subjectNode)
-      return subjectNode.textContent.trim();
+    if (subjectNode) return subjectNode.textContent.trim();
   }
   return null;
 }

--- a/app/helpers/clean-spaces.js
+++ b/app/helpers/clean-spaces.js
@@ -2,7 +2,7 @@ import { helper } from '@ember/component/helper';
 
 const whitespaceRegex = new RegExp(String.fromCharCode(160), 'g'); // &nbsp;
 
-export function cleanSpaces([value]/*, hash*/) {
+export function cleanSpaces([value] /*, hash*/) {
   if (value) {
     return value.replace(whitespaceRegex, ' ');
   }

--- a/app/helpers/detailed-date.js
+++ b/app/helpers/detailed-date.js
@@ -1,14 +1,16 @@
 import { helper } from '@ember/component/helper';
 
-export default helper(function detailedDate([datetime]/*, hash*/) {
+export default helper(function detailedDate([datetime] /*, hash*/) {
   //If not a date (e.g. date is undefined) return "" for printing on screen.
-  if (!(datetime instanceof Date)) return "";
+  if (!(datetime instanceof Date)) return '';
 
   try {
-    return Intl.DateTimeFormat("nl-BE", { dateStyle: "short", timeStyle: "short" }).format(datetime);
-  }
-  catch(e) {
+    return Intl.DateTimeFormat('nl-BE', {
+      dateStyle: 'short',
+      timeStyle: 'short',
+    }).format(datetime);
+  } catch (e) {
     console.error(e);
-    return "";
+    return '';
   }
 });

--- a/app/helpers/ember-index.js
+++ b/app/helpers/ember-index.js
@@ -1,5 +1,7 @@
 import { helper } from '@ember/component/helper';
 
-export default helper(function emberIndex([agendapunten, agendapunt]/*, hash*/) {
+export default helper(function emberIndex(
+  [agendapunten, agendapunt] /*, hash*/
+) {
   return agendapunten.indexOf(agendapunt);
 });

--- a/app/helpers/human-friendly-date.js
+++ b/app/helpers/human-friendly-date.js
@@ -3,15 +3,16 @@ import formatRelative from 'date-fns/formatRelative';
 import { nl } from 'date-fns/locale';
 
 // this is a helper to mimic the moment-calendar behaviour
-export default helper(function humanFriendlyDate([referenceDatetime]/*, hash*/) {
+export default helper(function humanFriendlyDate(
+  [referenceDatetime] /*, hash*/
+) {
   //If not a date (e.g. date is undefined) return "" for printing on screen.
-  if (!(referenceDatetime instanceof Date)) return "";
+  if (!(referenceDatetime instanceof Date)) return '';
 
   try {
     return formatRelative(referenceDatetime, new Date(), { locale: nl });
-  }
-  catch(e) {
+  } catch (e) {
     console.error(e);
-    return "";
+    return '';
   }
 });

--- a/app/helpers/plain-date.js
+++ b/app/helpers/plain-date.js
@@ -1,14 +1,15 @@
 import { helper } from '@ember/component/helper';
 
-export default helper(function plainDate([datetime]/*, hash*/) {
+export default helper(function plainDate([datetime] /*, hash*/) {
   //If not a date (e.g. date is undefined) return "" for printing on screen.
-  if (!(datetime instanceof Date)) return "";
+  if (!(datetime instanceof Date)) return '';
 
   try {
-    return Intl.DateTimeFormat("nl-BE", { dateStyle: "short" }).format(datetime);
-  }
-  catch(e) {
+    return Intl.DateTimeFormat('nl-BE', { dateStyle: 'short' }).format(
+      datetime
+    );
+  } catch (e) {
     console.error(e);
-    return "";
+    return '';
   }
 });

--- a/app/initializers/analytics.js
+++ b/app/initializers/analytics.js
@@ -1,19 +1,19 @@
 import ENV from 'frontend-gelinkt-notuleren/config/environment';
 export function initialize(/* application */) {
-  if (ENV.APP.analytics.appDomain !== "{{ANALYTICS_APP_DOMAIN}}" &&
-      ENV.APP.analytics.plausibleScript !== "{{ANALYTICS_PLAUSIBLE_SCRIPT}}"
-     )
-  {
+  if (
+    ENV.APP.analytics.appDomain !== '{{ANALYTICS_APP_DOMAIN}}' &&
+    ENV.APP.analytics.plausibleScript !== '{{ANALYTICS_PLAUSIBLE_SCRIPT}}'
+  ) {
     const head = document.querySelector('head');
     const script = document.createElement('script');
-    script.setAttribute("src", ENV.APP.analytics.plausibleScript);
-    script.setAttribute("data-domain", ENV.APP.analytics.appDomain);
-    script.setAttribute("async", "async");
-    script.setAttribute("defer", "defer");
+    script.setAttribute('src', ENV.APP.analytics.plausibleScript);
+    script.setAttribute('data-domain', ENV.APP.analytics.appDomain);
+    script.setAttribute('async', 'async');
+    script.setAttribute('defer', 'defer');
     head.appendChild(script);
   }
 }
 
 export default {
-  initialize
+  initialize,
 };

--- a/app/instance-initializers/intl.js
+++ b/app/instance-initializers/intl.js
@@ -1,13 +1,12 @@
-
 // Initialize the intl service in a instance-initializer.
 // Because we need to have access to a initialized service in order
 // to set the locale
 export function initialize(appInstance) {
   const intl = appInstance.lookup('service:intl');
-  const userLocale = ( navigator.language || navigator.languages[0] );
+  const userLocale = navigator.language || navigator.languages[0];
   intl.setLocale([userLocale, 'nl-BE']);
 }
 
 export default {
-  initialize
+  initialize,
 };

--- a/app/models/agenda-position.js
+++ b/app/models/agenda-position.js
@@ -1,8 +1,8 @@
 import Model, { belongsTo } from '@ember-data/model';
 
 export default class AgendaPositionModel extends Model {
-  @belongsTo("concept") position;
-  @belongsTo("agendapunt") agendapoint;
+  @belongsTo('concept') position;
+  @belongsTo('agendapunt') agendapoint;
 }
 
 // skos:prefLabel "before";

--- a/app/models/agenda.js
+++ b/app/models/agenda.js
@@ -5,9 +5,9 @@ export default class Agenda extends Model {
   @attr agendaType;
   @attr renderedContent;
 
-  @belongsTo('zitting', {inverse: null}) zitting;
+  @belongsTo('zitting', { inverse: null }) zitting;
   @belongsTo('published-resource') publishedResource;
 
-  @hasMany('agendapunt', {inverse: null}) agendapunten;
+  @hasMany('agendapunt', { inverse: null }) agendapunten;
   @hasMany('signed-resource') signedResources;
 }

--- a/app/models/agendapunt.js
+++ b/app/models/agendapunt.js
@@ -4,12 +4,13 @@ export default class Agendapunt extends Model {
   @attr beschrijving;
   @attr geplandOpenbaar;
   @attr heeftOntwerpbesluit;
-  @attr("string") titel;
-  @attr("string-set") type;
-  @attr("number") position;
-  @belongsTo('agendapunt', {inverse: null}) vorigeAgendapunt;
-  @hasMany('agendapunt', {inverse: null}) referenties;
-  @belongsTo('agenda', {inverse: null}) agenda;
-  @belongsTo('zitting', {inverse: 'agendapunten'}) zitting;
-  @belongsTo('behandeling-van-agendapunt', {inverse: "onderwerp"}) behandeling;
+  @attr('string') titel;
+  @attr('string-set') type;
+  @attr('number') position;
+  @belongsTo('agendapunt', { inverse: null }) vorigeAgendapunt;
+  @hasMany('agendapunt', { inverse: null }) referenties;
+  @belongsTo('agenda', { inverse: null }) agenda;
+  @belongsTo('zitting', { inverse: 'agendapunten' }) zitting;
+  @belongsTo('behandeling-van-agendapunt', { inverse: 'onderwerp' })
+  behandeling;
 }

--- a/app/models/attachment.js
+++ b/app/models/attachment.js
@@ -1,8 +1,9 @@
-import Model, { attr, belongsTo} from '@ember-data/model';
+import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class AttachmentModel extends Model {
   @attr decision;
-  @belongsTo("concept", { inverse: null }) type;
-  @belongsTo("document-container", { inverse: "attachments" }) documentContainer;
-  @belongsTo("file", { inverse: null }) file;
+  @belongsTo('concept', { inverse: null }) type;
+  @belongsTo('document-container', { inverse: 'attachments' })
+  documentContainer;
+  @belongsTo('file', { inverse: null }) file;
 }

--- a/app/models/behandeling-van-agendapunt.js
+++ b/app/models/behandeling-van-agendapunt.js
@@ -1,5 +1,5 @@
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
-import {DRAFT_FOLDER_ID, SCHEDULED_STATUS_ID} from "../utils/constants";
+import { DRAFT_FOLDER_ID, SCHEDULED_STATUS_ID } from '../utils/constants';
 import { inject as service } from '@ember/service';
 
 export default class BehandelingVanAgendapunt extends Model {
@@ -7,31 +7,39 @@ export default class BehandelingVanAgendapunt extends Model {
   @attr openbaar;
   @attr afgeleidUit;
   @attr('string') gevolg;
-  @belongsTo('behandeling-van-agendapunt', { inverse: null }) vorigeBehandelingVanAgendapunt;
+  @belongsTo('behandeling-van-agendapunt', { inverse: null })
+  vorigeBehandelingVanAgendapunt;
   @belongsTo('agendapunt', { inverse: 'behandeling' }) onderwerp;
   @belongsTo('functionaris', { inverse: null }) secretaris;
   @belongsTo('mandataris', { inverse: null }) voorzitter;
-  @hasMany('besluit', { inverse: 'volgendUitBehandelingVanAgendapunt' }) besluiten;
+  @hasMany('besluit', { inverse: 'volgendUitBehandelingVanAgendapunt' })
+  besluiten;
   @hasMany('mandataris', { inverse: null }) aanwezigen;
   @hasMany('mandataris', { inverse: null }) afwezigen;
-  @hasMany("stemming", {inverse: null}) stemmingen;
+  @hasMany('stemming', { inverse: null }) stemmingen;
   @belongsTo('document-container') documentContainer;
   @belongsTo('versioned-behandeling') versionedBehandeling;
 
   async initializeDocument() {
     const agendaItem = await this.onderwerp;
-    const draftDecisionFolder = await  this.store.findRecord("editor-document-folder", DRAFT_FOLDER_ID);
-    const scheduledStatus = await this.store.findRecord("concept", SCHEDULED_STATUS_ID);
+    const draftDecisionFolder = await this.store.findRecord(
+      'editor-document-folder',
+      DRAFT_FOLDER_ID
+    );
+    const scheduledStatus = await this.store.findRecord(
+      'concept',
+      SCHEDULED_STATUS_ID
+    );
 
-    const document = this.store.createRecord("editor-document", {
+    const document = this.store.createRecord('editor-document', {
       title: agendaItem.titel,
       createdOn: new Date(),
-      updatedOn: new Date()
+      updatedOn: new Date(),
     });
 
-    const container = this.store.createRecord("document-container", {
+    const container = this.store.createRecord('document-container', {
       folder: draftDecisionFolder,
-      status: scheduledStatus
+      status: scheduledStatus,
     });
 
     container.currentVersion = document;

--- a/app/models/besluit.js
+++ b/app/models/besluit.js
@@ -2,6 +2,7 @@ import Model, { belongsTo } from '@ember-data/model';
 
 export default class BesluitModel extends Model {
   @belongsTo('rechtsgrond-besluit', { inverse: null }) realistatie;
-  @belongsTo('behandeling-van-agendapunt', { inverse: 'besluiten' }) volgendUitBehandelingVanAgendapunt;
+  @belongsTo('behandeling-van-agendapunt', { inverse: 'besluiten' })
+  volgendUitBehandelingVanAgendapunt;
   @belongsTo('editor-document', { inverse: null }) afgeleidUitNotule;
 }

--- a/app/models/bestuurseenheid-classificatie-code.js
+++ b/app/models/bestuurseenheid-classificatie-code.js
@@ -6,8 +6,8 @@ export default class BestuurseenheidClassificatieCodeModel extends Model {
   @attr uri;
 
   rdfaBindings = {
-    class: "http://www.w3.org/2004/02/skos/core#Concept",
-    label: "http://www.w3.org/2004/02/skos/core#prefLabel",
-    scopeNote: "http://www.w3.org/2004/02/skos/core#scopeNote"
-  }
+    class: 'http://www.w3.org/2004/02/skos/core#Concept',
+    label: 'http://www.w3.org/2004/02/skos/core#prefLabel',
+    scopeNote: 'http://www.w3.org/2004/02/skos/core#scopeNote',
+  };
 }

--- a/app/models/bestuurseenheid.js
+++ b/app/models/bestuurseenheid.js
@@ -3,14 +3,15 @@ import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 export default class BestuurseenheidModel extends Model {
   @attr naam;
   @attr uri;
-  @belongsTo('bestuurseenheid-classificatie-code', { inverse: null }) classificatie;
+  @belongsTo('bestuurseenheid-classificatie-code', { inverse: null })
+  classificatie;
   @hasMany('bestuursorgaan', { inverse: 'bestuurseenheid' }) bestuursorganen;
 
   rdfaBindings = {
-    naam: "http://www.w3.org/2004/02/skos/core#prefLabel",
-    class: "http://data.vlaanderen.be/ns/besluit#Bestuurseenheid",
-    werkingsgebied: "http://data.vlaanderen.be/ns/besluit#werkingsgebied",
-    bestuursorgaan: "http://data.vlaanderen.be/ns/besluit#bestuurt",
-    classificatie: "http://data.vlaanderen.be/ns/besluit#classificatie"
-  }
+    naam: 'http://www.w3.org/2004/02/skos/core#prefLabel',
+    class: 'http://data.vlaanderen.be/ns/besluit#Bestuurseenheid',
+    werkingsgebied: 'http://data.vlaanderen.be/ns/besluit#werkingsgebied',
+    bestuursorgaan: 'http://data.vlaanderen.be/ns/besluit#bestuurt',
+    classificatie: 'http://data.vlaanderen.be/ns/besluit#classificatie',
+  };
 }

--- a/app/models/bestuursfunctie-code.js
+++ b/app/models/bestuursfunctie-code.js
@@ -4,10 +4,11 @@ export default class BestuursfunctieCodeModel extends Model {
   @attr label;
   @attr scopeNote;
   @attr uri;
-  @hasMany('bestuursorgaan-classificatie-code', { inverse: 'standaardType' }) standaardTypeVan;
+  @hasMany('bestuursorgaan-classificatie-code', { inverse: 'standaardType' })
+  standaardTypeVan;
 
   rdfaBindings = {
-    class: "http://www.w3.org/2004/02/skos/core#Concept",
-    label: "http://www.w3.org/2004/02/skos/core#prefLabel"
-  }
+    class: 'http://www.w3.org/2004/02/skos/core#Concept',
+    label: 'http://www.w3.org/2004/02/skos/core#prefLabel',
+  };
 }

--- a/app/models/bestuursfunctie.js
+++ b/app/models/bestuursfunctie.js
@@ -6,8 +6,9 @@ export default class BestuursfunctieModel extends Model {
   @hasMany('bestuursorgaan', { inverse: 'bevat' }) bevatIn;
 
   rdfaBindings = {
-    class: "http://data.lblod.info/vocabularies/leidinggevenden/Bestuursfunctie",
-    rol: "http://www.w3.org/ns/org#role",
-    bevatIn: "http://www.w3.org/ns/org#hasPost"
-  }
+    class:
+      'http://data.lblod.info/vocabularies/leidinggevenden/Bestuursfunctie',
+    rol: 'http://www.w3.org/ns/org#role',
+    bevatIn: 'http://www.w3.org/ns/org#hasPost',
+  };
 }

--- a/app/models/bestuursorgaan-classificatie-code.js
+++ b/app/models/bestuursorgaan-classificatie-code.js
@@ -4,6 +4,7 @@ export default class BestuursorgaanClassificatieCodeModel extends Model {
   @attr label;
   @attr scopeNote;
   @attr uri;
-  @hasMany('bestuursfunctie-code', { inverse: 'standaardTypeVan' }) standaardType;
+  @hasMany('bestuursfunctie-code', { inverse: 'standaardTypeVan' })
+  standaardType;
   @hasMany('bestuursorgaan', { inverse: null }) isClassificatieVan;
 }

--- a/app/models/bestuursorgaan.js
+++ b/app/models/bestuursorgaan.js
@@ -6,20 +6,25 @@ export default class BestuursorgaanModel extends Model {
   @attr('date') bindingEinde;
   @attr('date') bindingStart;
   @belongsTo('bestuurseenheid', { inverse: 'bestuursorganen' }) bestuurseenheid;
-  @belongsTo('bestuursorgaan-classificatie-code', { inverse: null }) classificatie;
-  @belongsTo('bestuursorgaan', { inverse: 'heeftTijdsspecialisaties' }) isTijdsspecialisatieVan;
-  @belongsTo('rechtstreekse-verkiezing', { inverse: 'steltSamen' }) wordtSamengesteldDoor;
-  @hasMany('bestuursorgaan', { inverse: 'isTijdsspecialisatieVan' }) heeftTijdsspecialisaties;
+  @belongsTo('bestuursorgaan-classificatie-code', { inverse: null })
+  classificatie;
+  @belongsTo('bestuursorgaan', { inverse: 'heeftTijdsspecialisaties' })
+  isTijdsspecialisatieVan;
+  @belongsTo('rechtstreekse-verkiezing', { inverse: 'steltSamen' })
+  wordtSamengesteldDoor;
+  @hasMany('bestuursorgaan', { inverse: 'isTijdsspecialisatieVan' })
+  heeftTijdsspecialisaties;
   @hasMany('mandaat', { inverse: 'bevatIn' }) bevat;
 
   rdfaBindings = {
-    naam: "http://www.w3.org/2004/02/skos/core#prefLabel",
-    class: "http://data.vlaanderen.be/ns/besluit#Bestuursorgaan",
-    bindingStart: "http://data.vlaanderen.be/ns/mandaat#bindingStart",
-    bindingEinde: "http://data.vlaanderen.be/ns/mandaat#bindingEinde",
-    bestuurseenheid: "http://data.vlaanderen.be/ns/besluit#bestuurt",
-    classificatie: "http://data.vlaanderen.be/ns/besluit#classificatie",
-    isTijdsspecialisatieVan: "http://data.vlaanderen.be/ns/mandaat#isTijdspecialisatieVan",
-    bevat: "http://www.w3.org/ns/org#hasPost"
-  }
+    naam: 'http://www.w3.org/2004/02/skos/core#prefLabel',
+    class: 'http://data.vlaanderen.be/ns/besluit#Bestuursorgaan',
+    bindingStart: 'http://data.vlaanderen.be/ns/mandaat#bindingStart',
+    bindingEinde: 'http://data.vlaanderen.be/ns/mandaat#bindingEinde',
+    bestuurseenheid: 'http://data.vlaanderen.be/ns/besluit#bestuurt',
+    classificatie: 'http://data.vlaanderen.be/ns/besluit#classificatie',
+    isTijdsspecialisatieVan:
+      'http://data.vlaanderen.be/ns/mandaat#isTijdspecialisatieVan',
+    bevat: 'http://www.w3.org/ns/org#hasPost',
+  };
 }

--- a/app/models/blockchain-status.js
+++ b/app/models/blockchain-status.js
@@ -6,18 +6,30 @@ export default class BlockchainStatusModel extends Model {
   @attr description;
 
   get isUnpublished() {
-    return this.uri === 'http://mu.semte.ch/vocabularies/ext/signing/publication-status/unpublished';
+    return (
+      this.uri ===
+      'http://mu.semte.ch/vocabularies/ext/signing/publication-status/unpublished'
+    );
   }
 
   get isPublishing() {
-    return this.uri === 'http://mu.semte.ch/vocabularies/ext/signing/publication-status/publishing';
+    return (
+      this.uri ===
+      'http://mu.semte.ch/vocabularies/ext/signing/publication-status/publishing'
+    );
   }
 
   get isPublished() {
-    return this.uri === 'http://mu.semte.ch/vocabularies/ext/signing/publication-status/published';
+    return (
+      this.uri ===
+      'http://mu.semte.ch/vocabularies/ext/signing/publication-status/published'
+    );
   }
 
   get publicationFailed() {
-    return this.uri === 'http://mu.semte.ch/vocabularies/ext/signing/publication-status/publication_failed';
+    return (
+      this.uri ===
+      'http://mu.semte.ch/vocabularies/ext/signing/publication-status/publication_failed'
+    );
   }
 }

--- a/app/models/concept-scheme.js
+++ b/app/models/concept-scheme.js
@@ -1,9 +1,9 @@
-import Model, { attr, hasMany }from '@ember-data/model';
+import Model, { attr, hasMany } from '@ember-data/model';
 
 export default class ConceptSchemeModel extends Model {
-  @attr uri
-  @attr label
+  @attr uri;
+  @attr label;
 
-  @hasMany('concept', { inverse: null }) concepts
-  @hasMany('concept', { inverse: null }) topConcepts
+  @hasMany('concept', { inverse: null }) concepts;
+  @hasMany('concept', { inverse: null }) topConcepts;
 }

--- a/app/models/concept.js
+++ b/app/models/concept.js
@@ -1,9 +1,9 @@
-import Model, { attr, hasMany }from '@ember-data/model';
+import Model, { attr, hasMany } from '@ember-data/model';
 
 export default class ConceptModel extends Model {
-  @attr uri
-  @attr label
+  @attr uri;
+  @attr label;
 
-  @hasMany("concept-scheme", { inverse: null }) conceptSchemes
-  @hasMany("concept-scheme", { inverse: null }) topConceptSchemes
+  @hasMany('concept-scheme', { inverse: null }) conceptSchemes;
+  @hasMany('concept-scheme', { inverse: null }) topConceptSchemes;
 }

--- a/app/models/document-container.js
+++ b/app/models/document-container.js
@@ -10,5 +10,5 @@ export default class DocumentContainerModel extends Model {
   @hasMany('versioned-notulen') versionedNotulen;
   @hasMany('versioned-besluiten-lijst') versionedBesluitenLijsten;
   @hasMany('versioned-behandelingen') versionedBehandelingen;
-  @hasMany('attachment', {inverse: "documentContainer"}) attachments;
+  @hasMany('attachment', { inverse: 'documentContainer' }) attachments;
 }

--- a/app/models/editor-document-status.js
+++ b/app/models/editor-document-status.js
@@ -3,4 +3,3 @@ import Model, { attr } from '@ember-data/model';
 export default class EditorDocumentStatusModel extends Model {
   @attr name;
 }
-

--- a/app/models/editor-document.js
+++ b/app/models/editor-document.js
@@ -6,18 +6,17 @@ export default class EditorDocumentModel extends Model {
   @attr uri;
   @attr title;
   @attr content;
-  @attr('string', { defaultValue: defaultContext}) context;
+  @attr('string', { defaultValue: defaultContext }) context;
   @attr('datetime') createdOn;
   @attr('datetime') updatedOn;
-  @belongsTo('editor-document', {inverse: 'nextVersion'})
+  @belongsTo('editor-document', { inverse: 'nextVersion' })
   previousVersion;
-  @belongsTo('editor-document', {inverse: 'previousVersion'})
+  @belongsTo('editor-document', { inverse: 'previousVersion' })
   nextVersion;
-  @belongsTo('document-container', {inverse: 'revisions'})
+  @belongsTo('document-container', { inverse: 'revisions' })
   documentContainer;
 
   get htmlSafeContent() {
     return htmlSafe(this.content);
   }
 }
-

--- a/app/models/extract-preview.js
+++ b/app/models/extract-preview.js
@@ -3,6 +3,5 @@ import Model, { belongsTo, attr } from '@ember-data/model';
 export default class ExtractPreviewModel extends Model {
   @belongsTo('behandeling-van-agendapunt') treatment;
   @attr html;
-  @attr('string-set') validationErrors
-
+  @attr('string-set') validationErrors;
 }

--- a/app/models/file.js
+++ b/app/models/file.js
@@ -1,5 +1,4 @@
-import Model, { attr }from '@ember-data/model';
-
+import Model, { attr } from '@ember-data/model';
 
 export default class FileModel extends Model {
   @attr name;
@@ -8,7 +7,7 @@ export default class FileModel extends Model {
   @attr extension;
   @attr('datetime') created;
 
-  get humanReadableSize(){
+  get humanReadableSize() {
     //ripped from https://stackoverflow.com/questions/15900485/correct-way-to-convert-size-in-bytes-to-kb-mb-gb-in-javascript
     const bytes = this.size;
     const sizes = ['bytes', 'KB', 'MB', 'GB', 'TB'];
@@ -17,7 +16,7 @@ export default class FileModel extends Model {
     return Math.round(bytes / Math.pow(1024, i), 2) + ' ' + sizes[i];
   }
 
-  get downloadLink(){
+  get downloadLink() {
     return `/files/${this.id}/download?name=${this.name}`;
   }
 }

--- a/app/models/fractie.js
+++ b/app/models/fractie.js
@@ -12,6 +12,6 @@ export default class FractieModel extends Model {
     naam: 'http://www.w3.org/ns/regorg#legalName',
     fractietype: 'http://mu.semte.ch/vocabularies/ext/isFractietype',
     bestuursorganenInTijd: 'http://www.w3.org/ns/org#memberOf',
-    bestuurseenheid: 'http://www.w3.org/ns/org#linkedTo'
-  }
+    bestuurseenheid: 'http://www.w3.org/ns/org#linkedTo',
+  };
 }

--- a/app/models/fractietype.js
+++ b/app/models/fractietype.js
@@ -5,15 +5,21 @@ export default class FractieTypeModel extends Model {
   @attr label;
 
   get isOnafhankelijk() {
-    return this.uri === 'http://data.vlaanderen.be/id/concept/Fractietype/Onafhankelijk';
+    return (
+      this.uri ===
+      'http://data.vlaanderen.be/id/concept/Fractietype/Onafhankelijk'
+    );
   }
 
   get isSamenwerkingsverband() {
-    return this.uri === 'http://data.vlaanderen.be/id/concept/Fractietype/Samenwerkingsverband';
+    return (
+      this.uri ===
+      'http://data.vlaanderen.be/id/concept/Fractietype/Samenwerkingsverband'
+    );
   }
 
   rdfaBindings = {
     class: 'http://mu.semte.ch/vocabularies/ext/Fractietype',
-    label: 'http://www.w3.org/2004/02/skos/core#prefLabel'
-  }
+    label: 'http://www.w3.org/2004/02/skos/core#prefLabel',
+  };
 }

--- a/app/models/functionaris-status-code.js
+++ b/app/models/functionaris-status-code.js
@@ -5,7 +5,8 @@ export default class FunctionarisStatusCodeModel extends Model {
   @attr label;
 
   rdfaBindings = {
-    class: "http://data.lblod.info/vocabularies/leidinggevenden/FunctionarisStatusCode",
-    label: "http://www.w3.org/2004/02/skos/core#prefLabel"
-  }
+    class:
+      'http://data.lblod.info/vocabularies/leidinggevenden/FunctionarisStatusCode',
+    label: 'http://www.w3.org/2004/02/skos/core#prefLabel',
+  };
 }

--- a/app/models/functionaris.js
+++ b/app/models/functionaris.js
@@ -5,15 +5,16 @@ export default class FunctionarisModel extends Model {
   @attr('datetime') einde;
   @attr uri;
   @belongsTo('bestuursfunctie', { inverse: null }) bekleedt;
-  @belongsTo('persoon', { inverse: 'isAangesteldAls'}) isBestuurlijkeAliasVan;
+  @belongsTo('persoon', { inverse: 'isAangesteldAls' }) isBestuurlijkeAliasVan;
   @belongsTo('functionaris-status-code', { inverse: null }) status;
 
   rdfaBindings = {
-    class: "http://data.lblod.info/vocabularies/leidinggevenden/Functionaris",
-    start: "http://data.vlaanderen.be/ns/mandaat#start",
-    einde: "http://data.vlaanderen.be/ns/mandaat#einde",
-    bekleedt: "http://www.w3.org/ns/org#holds",
-    isBestuurlijkeAliasVan: "http://data.vlaanderen.be/ns/mandaat#isBestuurlijkeAliasVan",
-    status: "http://data.vlaanderen.be/ns/mandaat#status"
-  }
+    class: 'http://data.lblod.info/vocabularies/leidinggevenden/Functionaris',
+    start: 'http://data.vlaanderen.be/ns/mandaat#start',
+    einde: 'http://data.vlaanderen.be/ns/mandaat#einde',
+    bekleedt: 'http://www.w3.org/ns/org#holds',
+    isBestuurlijkeAliasVan:
+      'http://data.vlaanderen.be/ns/mandaat#isBestuurlijkeAliasVan',
+    status: 'http://data.vlaanderen.be/ns/mandaat#status',
+  };
 }

--- a/app/models/geslacht-code.js
+++ b/app/models/geslacht-code.js
@@ -1,11 +1,11 @@
 import Model, { attr } from '@ember-data/model';
 
 export default class GeslachtCodeModel extends Model {
-  @attr uri
+  @attr uri;
   @attr label;
 
   rdfaBindings = {
-    class: "http://mu.semte.ch/vocabularies/ext/GeslachtCode",
-    label: "http://www.w3.org/2004/02/skos/core#prefLabel"
-  }
+    class: 'http://mu.semte.ch/vocabularies/ext/GeslachtCode',
+    label: 'http://www.w3.org/2004/02/skos/core#prefLabel',
+  };
 }

--- a/app/models/intermission.js
+++ b/app/models/intermission.js
@@ -1,8 +1,8 @@
 import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class IntermissionModel extends Model {
-  @attr("datetime") startedAt;
-  @attr("datetime") endedAt;
+  @attr('datetime') startedAt;
+  @attr('datetime') endedAt;
   @attr comment;
   @belongsTo('zitting', { inverse: 'intermissions' }) zitting;
   @belongsTo('agenda-position') agendaPosition;

--- a/app/models/kandidatenlijst.js
+++ b/app/models/kandidatenlijst.js
@@ -4,13 +4,14 @@ export default class KandidatenlijstModel extends Model {
   @attr uri;
   @attr lijstnaam;
   @attr lijstnummer;
-  @belongsTo('rechtstreekse-verkiezing', { inverse: 'heeftLijst' }) rechtstreekseVerkiezing;
+  @belongsTo('rechtstreekse-verkiezing', { inverse: 'heeftLijst' })
+  rechtstreekseVerkiezing;
   @hasMany('persoon', { inverse: 'isKandidaatVoor' }) kandidaten;
 
   rdfaBindings = {
-    lijstnaam: "http://www.w3.org/2004/02/skos/core#prefLabel",
-    lijstnummer: "http://data.vlaanderen.be/ns/mandaat#lijstnummer",
-    kandidaten: "http://data.vlaanderen.be/ns/mandaat#heeftKandidaat",
-    rechtstreekseVerkiezing: "http://data.vlaanderen.be/ns/mandaat#behoortTot",
-  }
+    lijstnaam: 'http://www.w3.org/2004/02/skos/core#prefLabel',
+    lijstnummer: 'http://data.vlaanderen.be/ns/mandaat#lijstnummer',
+    kandidaten: 'http://data.vlaanderen.be/ns/mandaat#heeftKandidaat',
+    rechtstreekseVerkiezing: 'http://data.vlaanderen.be/ns/mandaat#behoortTot',
+  };
 }

--- a/app/models/mandaat.js
+++ b/app/models/mandaat.js
@@ -7,9 +7,9 @@ export default class MandaatModel extends Model {
   @hasMany('bestuursorgaan', { inverse: 'bevat' }) bevatIn;
 
   rdfaBindings = {
-    class: "http://data.vlaanderen.be/ns/mandaat#Mandaat",
-    aantalHouders: "http://data.vlaanderen.be/ns/mandaat#aantalHouders",
-    bestuursfunctie: "http://www.w3.org/ns/org#role",
-    bevatIn: "http://www.w3.org/ns/org#hasPost"
-  }
+    class: 'http://data.vlaanderen.be/ns/mandaat#Mandaat',
+    aantalHouders: 'http://data.vlaanderen.be/ns/mandaat#aantalHouders',
+    bestuursfunctie: 'http://www.w3.org/ns/org#role',
+    bevatIn: 'http://www.w3.org/ns/org#hasPost',
+  };
 }

--- a/app/models/mandataris.js
+++ b/app/models/mandataris.js
@@ -17,11 +17,12 @@ export default class MandatarisModel extends Model {
   @belongsTo('mandataris-status-code', { inverse: null }) status;
 
   rdfaBindings = {
-    class: "http://data.vlaanderen.be/ns/mandaat#Mandataris",
-    start: "http://data.vlaanderen.be/ns/mandaat#start",
-    einde: "http://data.vlaanderen.be/ns/mandaat#einde",
-    rangorde: "http://data.vlaanderen.be/ns/mandaat#rangorde",
-    bekleedt: "http://www.w3.org/ns/org#holds",
-    isBestuurlijkeAliasVan: "http://data.vlaanderen.be/ns/mandaat#isBestuurlijkeAliasVan"
-  }
+    class: 'http://data.vlaanderen.be/ns/mandaat#Mandataris',
+    start: 'http://data.vlaanderen.be/ns/mandaat#start',
+    einde: 'http://data.vlaanderen.be/ns/mandaat#einde',
+    rangorde: 'http://data.vlaanderen.be/ns/mandaat#rangorde',
+    bekleedt: 'http://www.w3.org/ns/org#holds',
+    isBestuurlijkeAliasVan:
+      'http://data.vlaanderen.be/ns/mandaat#isBestuurlijkeAliasVan',
+  };
 }

--- a/app/models/persoon.js
+++ b/app/models/persoon.js
@@ -16,12 +16,12 @@ export default class PersoonModel extends Model {
   }
 
   rdfaBindings = {
-    class: "http://www.w3.org/ns/person#Person",
-    achternaam: "http://xmlns.com/foaf/0.1/familyName",
-    gebruikteVoornaam: "http://data.vlaanderen.be/ns/persoon#gebruikteVoornaam",
-    alternatieveNaam: "http://xmlns.com/foaf/0.1/name",
-    geslacht: "http://data.vlaanderen.be/ns/persoon#geslacht",
-    isAangesteldAls: "http://data.vlaanderen.be/ns/mandaat#isAangesteldAls",
-    geboorte: "http://data.vlaanderen.be/ns/persoon#heeftGeboorte"
-  }
+    class: 'http://www.w3.org/ns/person#Person',
+    achternaam: 'http://xmlns.com/foaf/0.1/familyName',
+    gebruikteVoornaam: 'http://data.vlaanderen.be/ns/persoon#gebruikteVoornaam',
+    alternatieveNaam: 'http://xmlns.com/foaf/0.1/name',
+    geslacht: 'http://data.vlaanderen.be/ns/persoon#geslacht',
+    isAangesteldAls: 'http://data.vlaanderen.be/ns/mandaat#isAangesteldAls',
+    geboorte: 'http://data.vlaanderen.be/ns/persoon#heeftGeboorte',
+  };
 }

--- a/app/models/rdfs-class.js
+++ b/app/models/rdfs-class.js
@@ -1,1 +1,1 @@
-export { default } from '@lblod/ember-rdfa-editor-generic-model-plugin/models/rdfs-class' ;
+export { default } from '@lblod/ember-rdfa-editor-generic-model-plugin/models/rdfs-class';

--- a/app/models/rdfs-property.js
+++ b/app/models/rdfs-property.js
@@ -1,1 +1,1 @@
-export { default } from '@lblod/ember-rdfa-editor-generic-model-plugin/models/rdfs-property' ;
+export { default } from '@lblod/ember-rdfa-editor-generic-model-plugin/models/rdfs-property';

--- a/app/models/rechtstreekse-verkiezing.js
+++ b/app/models/rechtstreekse-verkiezing.js
@@ -4,5 +4,6 @@ export default class RechtstreekseVerkiezingModel extends Model {
   @attr('date') datum;
   @attr('date') geldigheid;
   @belongsTo('bestuursorgaan', { inverse: 'wordtSamengesteldDoor' }) steltSamen;
-  @hasMany('kandidatenlijst', { inverse: 'rechtstreekseVerkiezing' }) heeftLijst;
+  @hasMany('kandidatenlijst', { inverse: 'rechtstreekseVerkiezing' })
+  heeftLijst;
 }

--- a/app/models/stemming.js
+++ b/app/models/stemming.js
@@ -1,18 +1,18 @@
 import Model, { attr, hasMany } from '@ember-data/model';
 
 export default class StemmingModel extends Model {
-  @attr("number") position;
-  @attr("number") aantalOnthouders;
-  @attr("number") aantalTegenstanders;
-  @attr("number") aantalVoorstanders;
+  @attr('number') position;
+  @attr('number') aantalOnthouders;
+  @attr('number') aantalTegenstanders;
+  @attr('number') aantalVoorstanders;
   @attr geheim;
   // @attr title;
-  @attr("string") gevolg;
-  @attr("string") onderwerp;
+  @attr('string') gevolg;
+  @attr('string') onderwerp;
   /** @type {import("ember-data").DS.RecordArray} */
-  @hasMany("mandataris", { inverse: null }) aanwezigen;
-  @hasMany("mandataris", { inverse: null }) onthouders;
-  @hasMany("mandataris", { inverse: null }) stemmers;
-  @hasMany("mandataris", { inverse: null }) tegenstanders;
-  @hasMany("mandataris", { inverse: null }) voorstanders;
+  @hasMany('mandataris', { inverse: null }) aanwezigen;
+  @hasMany('mandataris', { inverse: null }) onthouders;
+  @hasMany('mandataris', { inverse: null }) stemmers;
+  @hasMany('mandataris', { inverse: null }) tegenstanders;
+  @hasMany('mandataris', { inverse: null }) voorstanders;
 }

--- a/app/models/zitting.js
+++ b/app/models/zitting.js
@@ -6,10 +6,11 @@ export default class ZittingModel extends Model {
   @attr('datetime') geeindigdOpTijdstip;
   @attr opLocatie;
   @attr afgeleidUit;
-  @attr( { defaultValue: "" } ) intro;
-  @attr( { defaultValue: "" } ) outro;
+  @attr({ defaultValue: '' }) intro;
+  @attr({ defaultValue: '' }) outro;
   @belongsTo('bestuursorgaan', { inverse: null }) bestuursorgaan;
-  @hasMany('behandeling-van-agendapunt', { inverse: null }) behandeldeAgendapunten;
+  @hasMany('behandeling-van-agendapunt', { inverse: null })
+  behandeldeAgendapunten;
   @belongsTo('editor-document', { inverse: null }) notulen;
   @hasMany('agenda', { inverse: null }) publicatieAgendas;
   @hasMany('agendapunt', { inverse: 'zitting' }) agendapunten;
@@ -18,6 +19,6 @@ export default class ZittingModel extends Model {
   @hasMany('mandataris', { inverse: null }) aanwezigenBijStart;
   @hasMany('mandataris', { inverse: null }) afwezigenBijStart;
   @hasMany('intermission', { inverse: 'zitting' }) intermissions;
-  @hasMany('versioned-behandeling', {inverse: 'zitting'}) versionedBehandelingen;
+  @hasMany('versioned-behandeling', { inverse: 'zitting' })
+  versionedBehandelingen;
 }
-

--- a/app/router.js
+++ b/app/router.js
@@ -6,55 +6,55 @@ export default class Router extends EmberRouter {
   rootURL = config.rootURL;
 }
 
-Router.map(function() {
+Router.map(function () {
   this.route('switch-login');
-  this.route('inbox', function() {
+  this.route('inbox', function () {
     this.route('trash');
-    this.route('agendapoints', function() {
+    this.route('agendapoints', function () {
       this.route('new');
     });
-    this.route('meetings', function() {
+    this.route('meetings', function () {
       this.route('new');
     });
   });
   this.route('mock-login');
   this.route('login');
 
-  this.route('legaal', function() {
+  this.route('legaal', function () {
     this.route('disclaimer');
     this.route('cookieverklaring');
     this.route('toegankelijkheidsverklaring');
   });
   this.route('contact');
-  this.route('print', function() {
+  this.route('print', function () {
     this.route('uittreksel', { path: 'uittreksel/:meeting_id/:treatment_id' });
   });
   this.route('route-not-found', {
-    path: '/*wildcard'
+    path: '/*wildcard',
   });
 
-  this.route('import', function() {
+  this.route('import', function () {
     this.route('new');
     this.route('edit');
   });
 
-  this.route('agendapoints', function() {
+  this.route('agendapoints', function () {
     this.route('edit', { path: '/:id/edit' });
-    this.route('show', { path: ':id/show'});
+    this.route('show', { path: ':id/show' });
     this.route('revisions', { path: '/:id/revisions' });
   });
 
-  this.route('meetings', function() {
+  this.route('meetings', function () {
     this.route('edit', { path: '/:id/edit' }, function () {
       this.route('intro');
       this.route('outro');
       this.route('treatment', { path: ':treatment_id' });
     });
-    this.route('publish',{path: '/:id/publish'}, function() {
+    this.route('publish', { path: '/:id/publish' }, function () {
       this.route('agenda');
       this.route('besluitenlijst');
-      this.route('uittreksels', function() {
-        this.route('show', {path: '/:treatment_id'});
+      this.route('uittreksels', function () {
+        this.route('show', { path: '/:treatment_id' });
       });
       this.route('notulen');
     });

--- a/app/routes/agendapoints/edit.js
+++ b/app/routes/agendapoints/edit.js
@@ -1,6 +1,6 @@
 import RSVP from 'rsvp';
 import Route from '@ember/routing/route';
-import { action } from "@ember/object";
+import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 
 export default class AgendapointsEditRoute extends Route {
@@ -9,29 +9,33 @@ export default class AgendapointsEditRoute extends Route {
   @service router;
 
   beforeModel(transition) {
-    if(!this.currentSession.canWrite) {
+    if (!this.currentSession.canWrite) {
       const id = transition.to.params?.id;
       this.router.transitionTo('agendapoints.show', id);
       return;
     }
   }
 
-  async model(params){
-    const container = await this.store.findRecord('document-container', params.id, { include: 'status' });
+  async model(params) {
+    const container = await this.store.findRecord(
+      'document-container',
+      params.id,
+      { include: 'status' }
+    );
     return RSVP.hash({
       documentContainer: container,
-      editorDocument: await container.get('currentVersion')
+      editorDocument: await container.get('currentVersion'),
     });
   }
   setupController(controller, model) {
     super.setupController(controller, model);
-    controller.uploading=false;
+    controller.uploading = false;
     controller._editorDocument = null;
   }
 
   @action
   error(error /*, transition */) {
-    if (error.errors && error.errors[0].status === "404") {
+    if (error.errors && error.errors[0].status === '404') {
       this.router.transitionTo('route-not-found');
     } else {
       // Let the route above this handle the error.

--- a/app/routes/agendapoints/revisions.js
+++ b/app/routes/agendapoints/revisions.js
@@ -7,18 +7,21 @@ export default class AgendapointsRevisionsRoute extends Route {
   @service store;
 
   async model(params) {
-    const container = await this.store.findRecord('documentContainer', params.id);
+    const container = await this.store.findRecord(
+      'documentContainer',
+      params.id
+    );
     const editorDocument = await container.get('currentVersion');
     return RSVP.hash({
       revisions: this.fetchRevisions.perform(editorDocument),
       container,
-      editorDocument
+      editorDocument,
     });
   }
 
   @task
   *fetchRevisions(currentVersion) {
-    let revisions = [ currentVersion ];
+    let revisions = [currentVersion];
     let revision = yield currentVersion.get('previousVersion');
     while (revision) {
       revisions.push(revision);

--- a/app/routes/agendapoints/show.js
+++ b/app/routes/agendapoints/show.js
@@ -6,10 +6,14 @@ export default class AgendapointsShowRoute extends Route {
   @service store;
 
   async model(params) {
-    const container = await this.store.findRecord('document-container', params.id, { include: 'status' });
+    const container = await this.store.findRecord(
+      'document-container',
+      params.id,
+      { include: 'status' }
+    );
     return RSVP.hash({
       documentContainer: container,
-      editorDocument: await container.get('currentVersion')
+      editorDocument: await container.get('currentVersion'),
     });
   }
 }

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -27,10 +27,8 @@ export default class ApplicationRoute extends Route {
       if (match) {
         const featureFlag = match[1];
         const isEnabled = queryParams[key] == 'true';
-        if (isEnabled)
-          this.features.enable(featureFlag);
-        else
-          this.features.disable(featureFlag);
+        if (isEnabled) this.features.enable(featureFlag);
+        else this.features.disable(featureFlag);
       }
     }
   }

--- a/app/routes/import/edit.js
+++ b/app/routes/import/edit.js
@@ -4,7 +4,7 @@ import { warn } from '@ember/debug';
 
 export default class ImportEditRoute extends Route {
   queryParams = {
-    target: { refreshModel: true }
+    target: { refreshModel: true },
   };
 
   @service importRdfaSnippet;
@@ -19,18 +19,24 @@ export default class ImportEditRoute extends Route {
     if (documentContainerUri) {
       const documentContainers = await this.store.query('document-container', {
         'filter[:uri:]': documentContainerUri,
-        page: { size: 1 }
+        page: { size: 1 },
       });
 
-      if (documentContainers.length){
+      if (documentContainers.length) {
         const documentContainer = documentContainers.firstObject;
         this.router.transitionTo('editor-documents.edit', documentContainer.id);
       } else {
-        warn(`No document container found with URI '${documentContainerUri}' to import snippet in. Redirecting to inbox.`, { id: 'document-container.not-found' });
+        warn(
+          `No document container found with URI '${documentContainerUri}' to import snippet in. Redirecting to inbox.`,
+          { id: 'document-container.not-found' }
+        );
         this.router.transitionTo('inbox');
       }
     } else {
-      warn(`No target document container specified to import snippet in. Redirecting to inbox.`, { id: 'document-container.no-target' });
+      warn(
+        `No target document container specified to import snippet in. Redirecting to inbox.`,
+        { id: 'document-container.no-target' }
+      );
       this.router.transitionTo('inbox');
     }
   }

--- a/app/routes/inbox/agendapoints.js
+++ b/app/routes/inbox/agendapoints.js
@@ -1,7 +1,9 @@
 import Route from '@ember/routing/route';
 import DataTableRouteMixin from 'ember-data-table/mixins/route';
 
-export default class InboxAgendapointsRoute extends Route.extend(DataTableRouteMixin) {
+export default class InboxAgendapointsRoute extends Route.extend(
+  DataTableRouteMixin
+) {
   modelName = 'document-container';
 
   queryParams = {
@@ -10,14 +12,15 @@ export default class InboxAgendapointsRoute extends Route.extend(DataTableRouteM
     sort: { refreshModel: true },
     filter: { refreshModel: true },
     // filter params
-    title: { refreshModel: true }
+    title: { refreshModel: true },
   };
 
   mergeQueryOptions(params) {
     const query = {
       include: 'status,current-version',
-      'filter[status][:id:]': 'a1974d071e6a47b69b85313ebdcef9f7,7186547b61414095aa2a4affefdcca67,ef8e4e331c31430bbdefcdb2bdfbcc06', // concept, geagendeerd or published
-      'filter[folder][:id:]': 'ae5feaed-7b70-4533-9417-10fbbc480a4c' // decision drafts
+      'filter[status][:id:]':
+        'a1974d071e6a47b69b85313ebdcef9f7,7186547b61414095aa2a4affefdcca67,ef8e4e331c31430bbdefcdb2bdfbcc06', // concept, geagendeerd or published
+      'filter[folder][:id:]': 'ae5feaed-7b70-4533-9417-10fbbc480a4c', // decision drafts
     };
 
     if (params.title && params.title.length > 0)

--- a/app/routes/inbox/meetings.js
+++ b/app/routes/inbox/meetings.js
@@ -1,28 +1,28 @@
 import Route from '@ember/routing/route';
 import DataTableRouteMixin from 'ember-data-table/mixins/route';
 
-export default class InboxMeetingsRoute extends Route.extend(DataTableRouteMixin) {
+export default class InboxMeetingsRoute extends Route.extend(
+  DataTableRouteMixin
+) {
   modelName = 'zitting';
 
   queryParams = {
     page: { refreshModel: true },
     size: { refreshModel: true },
-    sort: { refreshModel: true  },
+    sort: { refreshModel: true },
     filter: { refreshModel: true },
     // filter params
-    title: { refreshModel: true }
+    title: { refreshModel: true },
   };
 
   mergeQueryOptions(params) {
     var sort;
-    if(!params.sort){
-      sort=params.sort;
-    }
-    else if(!params.sort.includes('geplande-start')){
-      sort=params.sort+',-geplande-start';
-    }
-    else{
-      sort=params.sort;
+    if (!params.sort) {
+      sort = params.sort;
+    } else if (!params.sort.includes('geplande-start')) {
+      sort = params.sort + ',-geplande-start';
+    } else {
+      sort = params.sort;
     }
     return { sort: sort };
   }

--- a/app/routes/inbox/trash.js
+++ b/app/routes/inbox/trash.js
@@ -10,13 +10,13 @@ export default class InboxTrashRoute extends Route.extend(DataTableRouteMixin) {
     sort: { refreshModel: true },
     filter: { refreshModel: true },
     // filter params
-    title: { refreshModel: true }
+    title: { refreshModel: true },
   };
 
   mergeQueryOptions(params) {
     const query = {
       include: 'status,current-version',
-      'filter[status][id]': '5A8304E8C093B00009000010' // trash
+      'filter[status][id]': '5A8304E8C093B00009000010', // trash
     };
 
     if (params.title && params.title.length > 0)

--- a/app/routes/legaal/toegankelijkheidsverklaring.js
+++ b/app/routes/legaal/toegankelijkheidsverklaring.js
@@ -1,4 +1,3 @@
 import Route from '@ember/routing/route';
 
-export default class LegaalToegankelijkheidsverklaringRoute extends Route {
-}
+export default class LegaalToegankelijkheidsverklaringRoute extends Route {}

--- a/app/routes/meetings/edit.js
+++ b/app/routes/meetings/edit.js
@@ -1,13 +1,12 @@
-import Route from "@ember/routing/route";
+import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
 export default class MeetingsEditRoute extends Route {
   @service store;
 
   async model(params) {
-    const zitting = await this.store.findRecord("zitting", params.id, {
-      include:
-        "bestuursorgaan,secretaris,voorzitter,intermissions",
+    const zitting = await this.store.findRecord('zitting', params.id, {
+      include: 'bestuursorgaan,secretaris,voorzitter,intermissions',
     });
     return zitting;
   }

--- a/app/routes/meetings/publish.js
+++ b/app/routes/meetings/publish.js
@@ -1,14 +1,14 @@
-import Route from "@ember/routing/route";
+import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
 export default class MeetingsPublishRoute extends Route {
   @service store;
 
   async model(params) {
-    const zitting = await this.store.findRecord("zitting", params.id, {
-      include: "aanwezigen-bij-start,agendapunten,secretaris,voorzitter",
+    const zitting = await this.store.findRecord('zitting', params.id, {
+      include: 'aanwezigen-bij-start,agendapunten,secretaris,voorzitter',
     });
-    zitting.agendapunten = (await zitting.agendapunten).sortBy("position");
+    zitting.agendapunten = (await zitting.agendapunten).sortBy('position');
     return zitting;
   }
 }

--- a/app/routes/meetings/publish/agenda.js
+++ b/app/routes/meetings/publish/agenda.js
@@ -1,8 +1,8 @@
-import Route from "@ember/routing/route";
+import Route from '@ember/routing/route';
 
 export default class MeetingsPublishAgendaRoute extends Route {
   model() {
-    return this.modelFor("meetings.publish");
+    return this.modelFor('meetings.publish');
   }
 
   setupController(controller, model) {

--- a/app/routes/meetings/publish/besluitenlijst.js
+++ b/app/routes/meetings/publish/besluitenlijst.js
@@ -1,8 +1,8 @@
-import Route from "@ember/routing/route";
+import Route from '@ember/routing/route';
 
 export default class MeetingsPublishBesluitenlijstRoute extends Route {
   model() {
-    return this.modelFor("meetings.publish");
+    return this.modelFor('meetings.publish');
   }
 
   setupController(controller, model) {

--- a/app/routes/meetings/publish/notulen.js
+++ b/app/routes/meetings/publish/notulen.js
@@ -2,7 +2,7 @@ import Route from '@ember/routing/route';
 
 export default class MeetingsPublishNotulenRoute extends Route {
   model() {
-    return this.modelFor("meetings.publish");
+    return this.modelFor('meetings.publish');
   }
 
   setupController(controller, model) {

--- a/app/routes/meetings/publish/uittreksels/index.js
+++ b/app/routes/meetings/publish/uittreksels/index.js
@@ -1,7 +1,9 @@
 import Route from '@ember/routing/route';
 import DataTableRouteMixin from 'ember-data-table/mixins/route';
 
-export default class MeetingsPublishUittrekselsRoute extends Route.extend(DataTableRouteMixin) {
+export default class MeetingsPublishUittrekselsRoute extends Route.extend(
+  DataTableRouteMixin
+) {
   modelName = 'agendapunt';
 
   beforeModel() {
@@ -14,15 +16,14 @@ export default class MeetingsPublishUittrekselsRoute extends Route.extend(DataTa
     sort: { refreshModel: true },
     filter: { refreshModel: true },
     // filter params
-    title: { refreshModel: true }
+    title: { refreshModel: true },
   };
-
 
   mergeQueryOptions(params) {
     console.log(params);
     const query = {
       include: 'behandeling.versioned-behandeling',
-      filter: { zitting: { ":id:": this.meetingId}}
+      filter: { zitting: { ':id:': this.meetingId } },
     };
 
     if (params.title && params.title.length > 0)

--- a/app/routes/meetings/publish/uittreksels/show.js
+++ b/app/routes/meetings/publish/uittreksels/show.js
@@ -5,7 +5,11 @@ export default class MeetingsPublishUittrekselsShowRoute extends Route {
   @service store;
 
   async model(params) {
-    return this.store.findRecord('behandeling-van-agendapunt', params.treatment_id, { include: 'onderwerp.zitting'});
+    return this.store.findRecord(
+      'behandeling-van-agendapunt',
+      params.treatment_id,
+      { include: 'onderwerp.zitting' }
+    );
   }
 
   setupController(controller) {

--- a/app/routes/mock-login.js
+++ b/app/routes/mock-login.js
@@ -7,8 +7,8 @@ export default class MockLoginRoute extends Route {
 
   queryParams = {
     page: {
-      refreshModel: true
-    }
+      refreshModel: true,
+    },
   };
 
   beforeModel() {
@@ -17,13 +17,12 @@ export default class MockLoginRoute extends Route {
 
   model(params) {
     const filter = { provider: 'https://github.com/lblod/mock-login-service' };
-    if (params.gemeente)
-      filter.gebruiker = { 'achternaam': params.gemeente};
+    if (params.gemeente) filter.gebruiker = { achternaam: params.gemeente };
     return this.store.query('account', {
       include: 'gebruiker.bestuurseenheden',
       filter: filter,
       page: { size: 10, number: params.page },
-      sort: 'gebruiker.achternaam'
+      sort: 'gebruiker.achternaam',
     });
   }
 }

--- a/app/routes/print/uittreksel.js
+++ b/app/routes/print/uittreksel.js
@@ -7,7 +7,11 @@ export default class PrintUittrekselRoute extends Route {
 
   async model(params) {
     const { treatment_id: treatmentId, meeting_id: meetingId } = params;
-    const treatment = await this.store.findRecord('behandeling-van-agendapunt', treatmentId, { include: 'onderwerp.zitting'});
+    const treatment = await this.store.findRecord(
+      'behandeling-van-agendapunt',
+      treatmentId,
+      { include: 'onderwerp.zitting' }
+    );
     const extract = await this.publish.fetchExtract(treatment);
     return { document: extract.document, meetingId, treatmentId };
   }

--- a/app/routes/switch-login.js
+++ b/app/routes/switch-login.js
@@ -4,17 +4,18 @@ import { inject as service } from '@ember/service';
 export default class SwitchLoginRoute extends Route {
   @service session;
 
-  beforeModel(){
+  beforeModel() {
     this.session.prohibitAuthentication('index');
   }
 
   async model() {
     try {
-      return await this.session.authenticate('authenticator:torii', 'acmidm-oauth2');
-    }
-    catch(e) {
+      return await this.session.authenticate(
+        'authenticator:torii',
+        'acmidm-oauth2'
+      );
+    } catch (e) {
       return 'Fout bij het aanmelden. Gelieve opnieuw te proberen.';
     }
   }
 }
-

--- a/app/serializers/application.js
+++ b/app/serializers/application.js
@@ -1,7 +1,9 @@
 import JSONAPISerializer from '@ember-data/serializer/json-api';
 import DataTableSerializerMixin from 'ember-data-table/mixins/serializer';
 
-export default class ApplicationSerializer extends JSONAPISerializer.extend(DataTableSerializerMixin) {
+export default class ApplicationSerializer extends JSONAPISerializer.extend(
+  DataTableSerializerMixin
+) {
   serializeAttribute(snapshot, json, key, attributes) {
     if (key !== 'uri')
       super.serializeAttribute(snapshot, json, key, attributes);

--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -11,11 +11,11 @@ export default class CurrentSessionService extends Service {
   @tracked group;
   @tracked roles = [];
 
-  get canRead(){
+  get canRead() {
     return this.hasRole('GelinktNotuleren-lezer');
   }
 
-  get canWrite(){
+  get canWrite() {
     return this.hasRole('GelinktNotuleren-schrijver');
   }
 
@@ -29,15 +29,16 @@ export default class CurrentSessionService extends Service {
 
   async load() {
     if (this.session.isAuthenticated) {
-      let accountId = this.session.data.authenticated.relationships.account.data.id;
+      let accountId =
+        this.session.data.authenticated.relationships.account.data.id;
       this.account = await this.store.findRecord('account', accountId, {
-        include: 'gebruiker'
+        include: 'gebruiker',
       });
       this.user = await this.account.get('gebruiker');
 
       let groupId = this.session.data.authenticated.relationships.group.data.id;
       this.group = await this.store.findRecord('bestuurseenheid', groupId, {
-        include: 'classificatie'
+        include: 'classificatie',
       });
 
       this.roles = this.session.data.authenticated.data.attributes.roles;

--- a/app/services/document-service.js
+++ b/app/services/document-service.js
@@ -1,5 +1,5 @@
 import Service from '@ember/service';
-import {analyse} from '@lblod/marawa/rdfa-context-scanner';
+import { analyse } from '@lblod/marawa/rdfa-context-scanner';
 
 export default class DocumentService extends Service {
   extractTriplesFromDocument(editorDocument) {
@@ -15,36 +15,52 @@ export default class DocumentService extends Service {
   }
   getDescription(editorDocument) {
     const triples = this.extractTriplesFromDocument(editorDocument);
-    const decisionUris = triples.filter((t) => t.predicate === "a" && t.object === "http://data.vlaanderen.be/ns/besluit#Besluit");
+    const decisionUris = triples.filter(
+      (t) =>
+        t.predicate === 'a' &&
+        t.object === 'http://data.vlaanderen.be/ns/besluit#Besluit'
+    );
     const firstDecision = decisionUris[0];
-    if(!firstDecision) return '';
-    const descriptionOfFirstDecision = triples.filter((t) => t.predicate === 'http://data.europa.eu/eli/ontology#description' && t.subject === firstDecision.subject)[0].object;
+    if (!firstDecision) return '';
+    const descriptionOfFirstDecision = triples.filter(
+      (t) =>
+        t.predicate === 'http://data.europa.eu/eli/ontology#description' &&
+        t.subject === firstDecision.subject
+    )[0].object;
     return descriptionOfFirstDecision;
   }
   cleanupTriples(triples) {
     const cleantriples = {};
     for (const triple of triples) {
       const hash = JSON.stringify(triple);
-      cleantriples[hash]=triple;
+      cleantriples[hash] = triple;
     }
-    return Object.keys(cleantriples).map( (k) => cleantriples[k]);
+    return Object.keys(cleantriples).map((k) => cleantriples[k]);
   }
   convertPrefixesToString(prefix) {
     let prefixesString = '';
-    for(let prefixKey in prefix) {
+    for (let prefixKey in prefix) {
       prefixesString += `${prefixKey}: ${prefix[prefixKey]} `;
     }
     return prefixesString;
   }
   getDecisions(editorDocument) {
     const triples = this.extractTriplesFromDocument(editorDocument);
-    const decisionUris = triples.filter((t) => t.predicate === "a" && t.object === "http://data.vlaanderen.be/ns/besluit#Besluit");
+    const decisionUris = triples.filter(
+      (t) =>
+        t.predicate === 'a' &&
+        t.object === 'http://data.vlaanderen.be/ns/besluit#Besluit'
+    );
     const decisions = decisionUris.map((decisionUriTriple) => {
-      const uri =  decisionUriTriple.subject;
-      const title = triples.filter((t) => t.predicate === 'http://data.europa.eu/eli/ontology#title' && t.subject === uri)[0].object;
+      const uri = decisionUriTriple.subject;
+      const title = triples.filter(
+        (t) =>
+          t.predicate === 'http://data.europa.eu/eli/ontology#title' &&
+          t.subject === uri
+      )[0].object;
       return {
         uri,
-        title
+        title,
       };
     });
     return decisions;

--- a/app/services/edit-stemming.js
+++ b/app/services/edit-stemming.js
@@ -1,8 +1,8 @@
-import { inject as service } from "@ember/service";
-import Service from "@ember/service";
-import { tracked } from "@glimmer/tracking";
-import { task } from "ember-concurrency";
-import { action } from "@ember/object";
+import { inject as service } from '@ember/service';
+import Service from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { task } from 'ember-concurrency';
+import { action } from '@ember/object';
 /** @typedef {import("../models/stemming").default} Stemming */
 
 export default class EditStemmingService extends Service {
@@ -33,13 +33,13 @@ export default class EditStemmingService extends Service {
     const voorstanders = [];
     const tegenstanders = [];
     for (let [voter, vote] of this.votingMap) {
-      if (vote !== "zalNietStemmen") {
+      if (vote !== 'zalNietStemmen') {
         stemmers.push(voter);
-        if (vote === "voor") {
+        if (vote === 'voor') {
           voorstanders.push(voter);
-        } else if (vote === "tegen") {
+        } else if (vote === 'tegen') {
           tegenstanders.push(voter);
-        } else if (vote === "onthouding") {
+        } else if (vote === 'onthouding') {
           onthouders.push(voter);
         }
       }
@@ -60,23 +60,26 @@ export default class EditStemmingService extends Service {
   }
   @task
   *fetchVoters() {
-    if(this._stemming.isNew) {
-      const aanwezigen = yield Promise.all(this._stemming.aanwezigen.map(async (aanwezige) => {
-        const queryResult = await this.store.query('mandataris', {
-          "filter[:id:]": aanwezige.id,
-          include: "is-bestuurlijke-alias-van",
-        });
-        return queryResult.firstObject;
-      }));
+    if (this._stemming.isNew) {
+      const aanwezigen = yield Promise.all(
+        this._stemming.aanwezigen.map(async (aanwezige) => {
+          const queryResult = await this.store.query('mandataris', {
+            'filter[:id:]': aanwezige.id,
+            include: 'is-bestuurlijke-alias-van',
+          });
+          return queryResult.firstObject;
+        })
+      );
       aanwezigen.forEach((aanwezige) =>
-        this.votingMap.set(aanwezige, "zalStemmen")
+        this.votingMap.set(aanwezige, 'zalStemmen')
       );
     } else {
       const stemmingId = this._stemming.id;
       const stemming = (yield this.store.query('stemming', {
-        "filter[:id:]": stemmingId,
-        include: "aanwezigen.is-bestuurlijke-alias-van,stemmers.is-bestuurlijke-alias-van,onthouders.is-bestuurlijke-alias-van,voorstanders.is-bestuurlijke-alias-van,tegenstanders.is-bestuurlijke-alias-van",
-        page: { size: 100 }
+        'filter[:id:]': stemmingId,
+        include:
+          'aanwezigen.is-bestuurlijke-alias-van,stemmers.is-bestuurlijke-alias-van,onthouders.is-bestuurlijke-alias-van,voorstanders.is-bestuurlijke-alias-van,tegenstanders.is-bestuurlijke-alias-van',
+        page: { size: 100 },
       })).firstObject;
 
       const aanwezigen = stemming.aanwezigen;
@@ -90,23 +93,24 @@ export default class EditStemmingService extends Service {
       const tegenstanders = stemming.tegenstanders;
 
       aanwezigen.forEach((aanwezige) =>
-        this.votingMap.set(aanwezige, "zalNietStemmen")
+        this.votingMap.set(aanwezige, 'zalNietStemmen')
       );
       stemmers.forEach((aanwezige) =>
-        this.votingMap.set(aanwezige, "zalStemmen")
+        this.votingMap.set(aanwezige, 'zalStemmen')
       );
       onthouders.forEach((aanwezige) =>
-        this.votingMap.set(aanwezige, "onthouding")
+        this.votingMap.set(aanwezige, 'onthouding')
       );
-      voorstanders.forEach((aanwezige) => this.votingMap.set(aanwezige, "voor"));
+      voorstanders.forEach((aanwezige) =>
+        this.votingMap.set(aanwezige, 'voor')
+      );
       tegenstanders.forEach((aanwezige) =>
-        this.votingMap.set(aanwezige, "tegen")
+        this.votingMap.set(aanwezige, 'tegen')
       );
     }
 
     this.refreshMap();
   }
-
 
   refreshMap() {
     // eslint-disable-next-line no-self-assign
@@ -125,8 +129,8 @@ export default class EditStemmingService extends Service {
   @action
   setUnaniemVoorstander() {
     for (let key of this.votingMap.keys()) {
-      if (this.votingMap.get(key) !== "zalNietStemmen") {
-        this.votingMap.set(key, "voor");
+      if (this.votingMap.get(key) !== 'zalNietStemmen') {
+        this.votingMap.set(key, 'voor');
       }
     }
     this.refreshMap();
@@ -134,8 +138,8 @@ export default class EditStemmingService extends Service {
   @action
   setUnaniemTegenstander() {
     for (let key of this.votingMap.keys()) {
-      if (this.votingMap.get(key) !== "zalNietStemmen") {
-        this.votingMap.set(key, "tegen");
+      if (this.votingMap.get(key) !== 'zalNietStemmen') {
+        this.votingMap.set(key, 'tegen');
       }
     }
     this.refreshMap();
@@ -143,8 +147,8 @@ export default class EditStemmingService extends Service {
   @action
   setUnaniemOnthouder() {
     for (let key of this.votingMap.keys()) {
-      if (this.votingMap.get(key) !== "zalNietStemmen") {
-        this.votingMap.set(key, "onthouding");
+      if (this.votingMap.get(key) !== 'zalNietStemmen') {
+        this.votingMap.set(key, 'onthouding');
       }
     }
     this.refreshMap();

--- a/app/services/mu-task.js
+++ b/app/services/mu-task.js
@@ -1,14 +1,17 @@
 import Service from '@ember/service';
 import { task, timeout } from 'ember-concurrency';
 
-const TASK_ENDPOINT = "/publication-tasks";
-export const TASK_STATUS_FAILURE =  "http://lblod.data.gift/besluit-publicatie-melding-statuses/failure";
-export const TASK_STATUS_CREATED =  "http://lblod.data.gift/besluit-publicatie-melding-statuses/created";
-export const TASK_STATUS_SUCCESS =  "http://lblod.data.gift/besluit-publicatie-melding-statuses/success";
-export const TASK_STATUS_RUNNING = "http://lblod.data.gift/besluit-publicatie-melding-statuses/ongoing";
+const TASK_ENDPOINT = '/publication-tasks';
+export const TASK_STATUS_FAILURE =
+  'http://lblod.data.gift/besluit-publicatie-melding-statuses/failure';
+export const TASK_STATUS_CREATED =
+  'http://lblod.data.gift/besluit-publicatie-melding-statuses/created';
+export const TASK_STATUS_SUCCESS =
+  'http://lblod.data.gift/besluit-publicatie-melding-statuses/success';
+export const TASK_STATUS_RUNNING =
+  'http://lblod.data.gift/besluit-publicatie-melding-statuses/ongoing';
 
 export default class MuTaskService extends Service {
-
   fetchMuTask(taskId) {
     // TODO do this with ember-data and mu-cl-resource
     return fetch(`${TASK_ENDPOINT}/${taskId}`);
@@ -20,35 +23,38 @@ export default class MuTaskService extends Service {
    * @param {number} [timeoutMs] maximum time to wait before throwing
    * */
   @task
-  * waitForMuTaskTask(taskId, pollDelayMs = 1000, timeoutMs = 300000) {
+  *waitForMuTaskTask(taskId, pollDelayMs = 1000, timeoutMs = 300000) {
     let resp;
     let currentStatus;
     const startTime = Date.now();
     do {
       yield timeout(pollDelayMs);
       resp = yield this.fetchMuTask(taskId);
-      if(resp.ok) {
+      if (resp.ok) {
         currentStatus = (yield resp.json()).data.status;
       } else {
         currentStatus = null;
       }
-    } while(resp.ok
-            && (currentStatus === TASK_STATUS_RUNNING || currentStatus === TASK_STATUS_CREATED)
-            && Date.now() - startTime < timeoutMs);
+    } while (
+      resp.ok &&
+      (currentStatus === TASK_STATUS_RUNNING ||
+        currentStatus === TASK_STATUS_CREATED) &&
+      Date.now() - startTime < timeoutMs
+    );
 
-    if(!resp.ok) {
+    if (!resp.ok) {
       const reason = yield resp.text();
       throw new Error(reason);
     }
 
-    if(currentStatus === TASK_STATUS_SUCCESS) {
+    if (currentStatus === TASK_STATUS_SUCCESS) {
       return task;
-    } else if(currentStatus === TASK_STATUS_FAILURE) {
-      throw new Error("Task failed.");
+    } else if (currentStatus === TASK_STATUS_FAILURE) {
+      throw new Error('Task failed.');
     } else if (currentStatus === TASK_STATUS_RUNNING) {
-      throw new Error("Task timed out.");
+      throw new Error('Task timed out.');
     } else {
-      throw new Error("Task in unexpected state");
+      throw new Error('Task in unexpected state');
     }
   }
 
@@ -60,6 +66,5 @@ export default class MuTaskService extends Service {
     } else {
       throw new Error(await res.text());
     }
-
   }
 }

--- a/app/services/publish.js
+++ b/app/services/publish.js
@@ -51,7 +51,7 @@ export default class PublishService extends Service {
    * @param {string} jobUrl
    * @param {string} statusUrl*/
   @task
-  * fetchJobTask(jobUrl, pollingDelayMs = 1000, maxIterations = 600 ) {
+  *fetchJobTask(jobUrl, pollingDelayMs = 1000, maxIterations = 600) {
     const job = yield fetch(jobUrl);
     const jobData = yield job.json();
     const jobId = jobData.data.attributes.jobId;
@@ -68,7 +68,6 @@ export default class PublishService extends Service {
     } else {
       return yield resp.json();
     }
-
   }
 
   /**
@@ -148,21 +147,24 @@ export default class PublishService extends Service {
   async fetchExtract(treatment) {
     const agendapoint = await treatment.get('onderwerp');
     const meeting = await agendapoint.get('zitting');
-    const versionedTreatments = await this.store.query('versioned-behandeling',
-                                                       {
-                                                         filter: { behandeling: {":id:": treatment.id}},
-                                                         include: 'behandeling.onderwerp,signed-resources,published-resource'
-                                                       });
-    if (versionedTreatments.length > 0 ) {
+    const versionedTreatments = await this.store.query(
+      'versioned-behandeling',
+      {
+        filter: { behandeling: { ':id:': treatment.id } },
+        include: 'behandeling.onderwerp,signed-resources,published-resource',
+      }
+    );
+    if (versionedTreatments.length > 0) {
       return new Extract(
         treatment.id,
         agendapoint.get('position'),
         versionedTreatments.get('firstObject'),
         []
       );
-    }
-    else {
-      const extractPreview = this.store.createRecord('extract-preview', {treatment});
+    } else {
+      const extractPreview = this.store.createRecord('extract-preview', {
+        treatment,
+      });
       await extractPreview.save();
       const versionedTreatment = this.store.createRecord(
         'versioned-behandeling',

--- a/app/utils/classification-utils.js
+++ b/app/utils/classification-utils.js
@@ -1,27 +1,44 @@
-const BURGEMEESTER = 'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/4955bd72cd0e4eb895fdbfab08da0284';
-const COLLEGE_VAN_BURGEMEESTER_EN_SCHEPENEN = 'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000006';
-const VOORZITTER_VAN_DE_RAAD_VOOR_MAATSCHAPPELIJK_WELZIJN = 'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/e14fe683-e061-44a2-b7c8-e10cab4e6ed9';
-const GEMEENTERAAD = 'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000005';
-const RAAD_VOOR_MAATSCHAPPELIJK_WELZIJN = 'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000007';
-const VOORZITTER_VAN_DE_GEMEENTERAAD = 'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/4c38734d-2cc1-4d33-b792-0bd493ae9fc2';
-const BIJZONDER_COMITE_VOOR_DE_SOCIALE_DIENST = 'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000009';
-const DEPUTATIE = 'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000d';
-const GOUVERNEUR = 'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/180a2fba-6ca9-4766-9b94-82006bb9c709';
-const PROVINCIERAAD = 'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000c';
-const VOORZITTER_VAN_HET_BIJZONDER_COMITE_VOOR_DE_SOCIALE_DIENST = 'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/53c0d8cd-f3a2-411d-bece-4bd83ae2bbc9';
-const VAST_BUREAU = 'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000008';
+const BURGEMEESTER =
+  'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/4955bd72cd0e4eb895fdbfab08da0284';
+const COLLEGE_VAN_BURGEMEESTER_EN_SCHEPENEN =
+  'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000006';
+const VOORZITTER_VAN_DE_RAAD_VOOR_MAATSCHAPPELIJK_WELZIJN =
+  'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/e14fe683-e061-44a2-b7c8-e10cab4e6ed9';
+const GEMEENTERAAD =
+  'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000005';
+const RAAD_VOOR_MAATSCHAPPELIJK_WELZIJN =
+  'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000007';
+const VOORZITTER_VAN_DE_GEMEENTERAAD =
+  'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/4c38734d-2cc1-4d33-b792-0bd493ae9fc2';
+const BIJZONDER_COMITE_VOOR_DE_SOCIALE_DIENST =
+  'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000009';
+const DEPUTATIE =
+  'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000d';
+const GOUVERNEUR =
+  'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/180a2fba-6ca9-4766-9b94-82006bb9c709';
+const PROVINCIERAAD =
+  'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000c';
+const VOORZITTER_VAN_HET_BIJZONDER_COMITE_VOOR_DE_SOCIALE_DIENST =
+  'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/53c0d8cd-f3a2-411d-bece-4bd83ae2bbc9';
+const VAST_BUREAU =
+  'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000008';
 
 export const articlesBasedOnClassifcationMap = {
   [BURGEMEESTER]: 'meetingForm.meetingHeadingArticleGendered',
-  [COLLEGE_VAN_BURGEMEESTER_EN_SCHEPENEN]: 'meetingForm.meetingHeadingArticleUngendered',
-  [VOORZITTER_VAN_DE_RAAD_VOOR_MAATSCHAPPELIJK_WELZIJN]: 'meetingForm.meetingHeadingArticleGendered',
+  [COLLEGE_VAN_BURGEMEESTER_EN_SCHEPENEN]:
+    'meetingForm.meetingHeadingArticleUngendered',
+  [VOORZITTER_VAN_DE_RAAD_VOOR_MAATSCHAPPELIJK_WELZIJN]:
+    'meetingForm.meetingHeadingArticleGendered',
   [GEMEENTERAAD]: 'meetingForm.meetingHeadingArticleGendered',
-  [RAAD_VOOR_MAATSCHAPPELIJK_WELZIJN]: 'meetingForm.meetingHeadingArticleGendered',
+  [RAAD_VOOR_MAATSCHAPPELIJK_WELZIJN]:
+    'meetingForm.meetingHeadingArticleGendered',
   [VOORZITTER_VAN_DE_GEMEENTERAAD]: 'meetingForm.meetingHeadingArticleGendered',
-  [BIJZONDER_COMITE_VOOR_DE_SOCIALE_DIENST]: 'meetingForm.meetingHeadingArticleUngendered',
+  [BIJZONDER_COMITE_VOOR_DE_SOCIALE_DIENST]:
+    'meetingForm.meetingHeadingArticleUngendered',
   [DEPUTATIE]: 'meetingForm.meetingHeadingArticleGendered',
   [GOUVERNEUR]: 'meetingForm.meetingHeadingArticleGendered',
   [PROVINCIERAAD]: 'meetingForm.meetingHeadingArticleGendered',
-  [VOORZITTER_VAN_HET_BIJZONDER_COMITE_VOOR_DE_SOCIALE_DIENST]: 'meetingForm.meetingHeadingArticleGendered',
-  [VAST_BUREAU]: 'meetingForm.meetingHeadingArticleUngendered'
+  [VOORZITTER_VAN_HET_BIJZONDER_COMITE_VOOR_DE_SOCIALE_DIENST]:
+    'meetingForm.meetingHeadingArticleGendered',
+  [VAST_BUREAU]: 'meetingForm.meetingHeadingArticleUngendered',
 };

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -1,13 +1,13 @@
 //document status
-export const DRAFT_STATUS_ID = "a1974d071e6a47b69b85313ebdcef9f7";
-export const SCHEDULED_STATUS_ID = "7186547b61414095aa2a4affefdcca67";
-export const PUBLISHED_STATUS_ID = "ef8e4e331c31430bbdefcdb2bdfbcc06";
-export const TRASH_STATUS_ID = "5A8304E8C093B00009000010";
-export const PLANNED_STATUS_ID = "7186547b61414095aa2a4affefdcca67";
-export const DRAFT_FOLDER_ID = "ae5feaed-7b70-4533-9417-10fbbc480a4c";
+export const DRAFT_STATUS_ID = 'a1974d071e6a47b69b85313ebdcef9f7';
+export const SCHEDULED_STATUS_ID = '7186547b61414095aa2a4affefdcca67';
+export const PUBLISHED_STATUS_ID = 'ef8e4e331c31430bbdefcdb2bdfbcc06';
+export const TRASH_STATUS_ID = '5A8304E8C093B00009000010';
+export const PLANNED_STATUS_ID = '7186547b61414095aa2a4affefdcca67';
+export const DRAFT_FOLDER_ID = 'ae5feaed-7b70-4533-9417-10fbbc480a4c';
 //intermission position
-export const BEFORE_POS_ID = "9c9be842-236f-4738-b642-f4064c86db51";
-export const DURING_POS_ID = "4790eec5-acd2-4c1d-8e91-90bb2998f87c";
-export const AFTER_POS_ID = "267a09cc-5380-492d-93ad-697b9e99f032";
+export const BEFORE_POS_ID = '9c9be842-236f-4738-b642-f4064c86db51';
+export const DURING_POS_ID = '4790eec5-acd2-4c1d-8e91-90bb2998f87c';
+export const AFTER_POS_ID = '267a09cc-5380-492d-93ad-697b9e99f032';
 //attachment types
-export const REGULATORY_TYPE_ID = "14e264b4-92db-483f-9dd1-3e806ad6d26c";
+export const REGULATORY_TYPE_ID = '14e264b4-92db-483f-9dd1-3e806ad6d26c';

--- a/app/utils/generate-export-from-editor-document.js
+++ b/app/utils/generate-export-from-editor-document.js
@@ -1,8 +1,10 @@
 export default function generateExportFromEditorDocument(editorDocument) {
   const context = JSON.parse(editorDocument.context);
-  let prefixes = Object.entries(context.prefix).map(([key, value]) => {
-    return `${key}: ${value}`;
-  }).join(' ');
+  let prefixes = Object.entries(context.prefix)
+    .map(([key, value]) => {
+      return `${key}: ${value}`;
+    })
+    .join(' ');
   const body = `
       <div vocab="${context.vocab}" prefix="${prefixes}" typeof="foaf:Document" resource="#">
         ${editorDocument.content}
@@ -10,7 +12,10 @@ export default function generateExportFromEditorDocument(editorDocument) {
   `;
   const title = editorDocument.title;
   var element = document.createElement('a');
-  element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(body));
+  element.setAttribute(
+    'href',
+    'data:text/plain;charset=utf-8,' + encodeURIComponent(body)
+  );
   element.setAttribute('download', `${title}.html`);
 
   element.style.display = 'none';

--- a/app/utils/is-valid-mandatee-for-meeting.js
+++ b/app/utils/is-valid-mandatee-for-meeting.js
@@ -2,16 +2,20 @@ import { isEmpty } from '@ember/utils';
 const statusEffectief = '21063a5b-912c-4241-841c-cc7fb3c73e75';
 const statusWaarnemend = 'e1ca6edd-55e1-4288-92a5-53f4cf71946a';
 
-
 /**
  * checks whether a mandatee can be a member of the meeting
  * this means the meeting date should be between the mandatee's start and end
  * the mandatee needs to have a "acting" (waarnemend) or "effective" (effectief) status
  */
 export default function isValidMandateeForMeeting(mandatee, meeting) {
-  const startOfMeeting = meeting.gestartOpTijdstip ? meeting.gestartOpTijdstip : meeting.geplandeStart;
+  const startOfMeeting = meeting.gestartOpTijdstip
+    ? meeting.gestartOpTijdstip
+    : meeting.geplandeStart;
   const hasValidStartDate = mandatee.start <= startOfMeeting;
-  const hasValidEndDate = isEmpty(mandatee.einde) || mandatee.einde > startOfMeeting;
-  const hasValidStatus = [statusEffectief, statusWaarnemend].includes(mandatee.get("status.id"));
+  const hasValidEndDate =
+    isEmpty(mandatee.einde) || mandatee.einde > startOfMeeting;
+  const hasValidStatus = [statusEffectief, statusWaarnemend].includes(
+    mandatee.get('status.id')
+  );
   return hasValidStartDate && hasValidEndDate && hasValidStatus;
 }

--- a/config/dependency-lint.js
+++ b/config/dependency-lint.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-  generateTests: false
+  generateTests: false,
 };

--- a/config/ember-intl.js
+++ b/config/ember-intl.js
@@ -1,6 +1,6 @@
 /*jshint node:true*/
 
-module.exports = function(/* environment */) {
+module.exports = function (/* environment */) {
   return {
     /**
      * Merges the fallback locale's translations into all other locales as a
@@ -24,7 +24,6 @@ module.exports = function(/* environment */) {
      * @default "'translations'"
      */
     inputPath: 'translations',
-
 
     /**
      * Prevents the translations from being bundled with the application code.
@@ -88,6 +87,6 @@ module.exports = function(/* environment */) {
      */
     requiresTranslation(/* key, locale */) {
       return true;
-    }
+    },
   };
 };

--- a/config/environment.js
+++ b/config/environment.js
@@ -18,74 +18,77 @@ module.exports = function (environment) {
     },
     APP: {
       '@lblod/ember-rdfa-editor-date-plugin': {
-        allowedInputDateFormats: ['DD/MM/YYYY', 'DD-MM-YYYY',  'DD.MM.YYYY'],
-        outputDateFormat: 'D MMMM YYYY'
+        allowedInputDateFormats: ['DD/MM/YYYY', 'DD-MM-YYYY', 'DD.MM.YYYY'],
+        outputDateFormat: 'D MMMM YYYY',
       },
       analytics: {
-        appDomain: "{{ANALYTICS_APP_DOMAIN}}",
-        plausibleScript: "{{ANALYTICS_PLAUSIBLE_SCRIPT}}"
-      }
+        appDomain: '{{ANALYTICS_APP_DOMAIN}}',
+        plausibleScript: '{{ANALYTICS_PLAUSIBLE_SCRIPT}}',
+      },
     },
     roadsignRegulationPlugin: {
-      endpoint: "{{MOW_REGISTRY_ENDPOINT}}"
+      endpoint: '{{MOW_REGISTRY_ENDPOINT}}',
     },
     templateVariablePlugin: {
-      endpoint: "{{MOW_REGISTRY_ENDPOINT}}"
+      endpoint: '{{MOW_REGISTRY_ENDPOINT}}',
     },
     manual: {
-      baseUrl: "{{MANUAL_BASE_URL}}",
-      notuleren: "{{MANUAL_NOTULEREN}}",
-      signing: "{{MANUAL_SIGNING}}",
-      publish: "{{MANUAL_PUBLISH}}",
-      mandatees: "{{MANUAL_MANDATEES}}",
-      signee: "{{MANUAL_SIGNEE}}",
-      publisher: "{{MANUAL_PUBLISHER}}",
-      print: "{{MANUAL_PRINT}}"
+      baseUrl: '{{MANUAL_BASE_URL}}',
+      notuleren: '{{MANUAL_NOTULEREN}}',
+      signing: '{{MANUAL_SIGNING}}',
+      publish: '{{MANUAL_PUBLISH}}',
+      mandatees: '{{MANUAL_MANDATEES}}',
+      signee: '{{MANUAL_SIGNEE}}',
+      publisher: '{{MANUAL_PUBLISHER}}',
+      print: '{{MANUAL_PRINT}}',
     },
     featureFlags: {
       'language-select': false,
       'editor-html-paste': true,
       'editor-extended-html-paste': true,
       'acmidm-switch': true,
-      'attachments': true
+      attachments: true,
     },
     browserUpdate: {
-      vs: {f:-3,c:-3},
+      vs: { f: -3, c: -3 },
       style: 'corner',
       l: 'nl',
-      shift_page_down: false
+      shift_page_down: false,
     },
     torii: {
       disableRedirectInitializer: true,
       providers: {
         'acmidm-oauth2': {
-          apiKey: "{{OAUTH_API_KEY}}",
-          baseUrl: "{{OAUTH_BASE_URL}}",
+          apiKey: '{{OAUTH_API_KEY}}',
+          baseUrl: '{{OAUTH_BASE_URL}}',
           scope: 'openid rrn vo profile abb_gelinktNotuleren',
-          redirectUri: "{{OAUTH_REDIRECT_URL}}",
-          logoutUrl: "{{OAUTH_LOGOUT_URL}}",
-          returnUrl: "{{OAUTH_SWITCH_URL}}"
-        }
-      }
+          redirectUri: '{{OAUTH_REDIRECT_URL}}',
+          logoutUrl: '{{OAUTH_LOGOUT_URL}}',
+          returnUrl: '{{OAUTH_SWITCH_URL}}',
+        },
+      },
     },
-    environmentName: "{{ENVIRONMENT_NAME}}",
+    environmentName: '{{ENVIRONMENT_NAME}}',
     publication: {
-      baseUrl: "{{PUBLICATION_BASE_URL}}"
-    }
+      baseUrl: '{{PUBLICATION_BASE_URL}}',
+    },
   };
 
   if (environment === 'development') {
-    ENV.manual.baseUrl="https://abb-vlaanderen.gitbook.io/gelinkt-notuleren-handleiding/";
-    ENV.manual.notuleren="#notuleren";
-    ENV.manual.signing="#ondertekenen-en-publiceren";
-    ENV.manual.publish="#ondertekenen-en-publiceren";
-    ENV.manual.mandatees="#mandatenbeheer";
-    ENV.manual.signee="#gebruikersbeheer";
-    ENV.manual.publisher="#gebruikersbeheer";
-    ENV.manual.print="";
+    ENV.manual.baseUrl =
+      'https://abb-vlaanderen.gitbook.io/gelinkt-notuleren-handleiding/';
+    ENV.manual.notuleren = '#notuleren';
+    ENV.manual.signing = '#ondertekenen-en-publiceren';
+    ENV.manual.publish = '#ondertekenen-en-publiceren';
+    ENV.manual.mandatees = '#mandatenbeheer';
+    ENV.manual.signee = '#gebruikersbeheer';
+    ENV.manual.publisher = '#gebruikersbeheer';
+    ENV.manual.print = '';
     ENV.featureFlags.attachments = true;
-    ENV.roadsignRegulationPlugin.endpoint = "https://dev.roadsigns.lblod.info/sparql";
-    ENV.templateVariablePlugin.endpoint = "https://dev.roadsigns.lblod.info/sparql";
+    ENV.roadsignRegulationPlugin.endpoint =
+      'https://dev.roadsigns.lblod.info/sparql';
+    ENV.templateVariablePlugin.endpoint =
+      'https://dev.roadsigns.lblod.info/sparql';
     // ENV.APP.LOG_RESOLVER = true;
     // ENV.APP.LOG_ACTIVE_GENERATION = true;
     // ENV.APP.LOG_TRANSITIONS = true;

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
-const envIsProduction = (process.env.EMBER_ENV === 'production');
+const envIsProduction = process.env.EMBER_ENV === 'production';
 
 module.exports = function (defaults) {
   let app = new EmberApp(defaults, {
@@ -9,16 +9,16 @@ module.exports = function (defaults) {
       useSessionSetupMethod: true,
     },
     'ember-cli-babel': {
-      includePolyfill: false
+      includePolyfill: false,
     },
     minifyCSS: {
-      enabled: envIsProduction
+      enabled: envIsProduction,
     },
     'ember-cli-terser': {
       exclude: ['vendor.js', 'assets/vendor.js'],
       terser: {
         compress: {
-          collapse_vars: false
+          collapse_vars: false,
         },
       },
     },
@@ -29,14 +29,14 @@ module.exports = function (defaults) {
     autoprefixer: {
       enabled: true,
       cascade: true,
-      sourcemap: !envIsProduction
+      sourcemap: !envIsProduction,
     },
     sourcemaps: {
       enabled: !envIsProduction,
-      extensions: ['js', 'css']
+      extensions: ['js', 'css'],
     },
     babel: {
-      sourceMaps: 'inline'
+      sourceMaps: 'inline',
     },
   });
 

--- a/tests/helpers/resolver.js
+++ b/tests/helpers/resolver.js
@@ -5,7 +5,7 @@ const resolver = Resolver.create();
 
 resolver.namespace = {
   modulePrefix: config.modulePrefix,
-  podModulePrefix: config.podModulePrefix
+  podModulePrefix: config.podModulePrefix,
 };
 
 export default resolver;

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -4,7 +4,7 @@ import * as QUnit from 'qunit';
 import { setApplication } from '@ember/test-helpers';
 import { setup } from 'qunit-dom';
 import { start } from 'ember-qunit';
-import "qunit-dom";
+import 'qunit-dom';
 
 setApplication(Application.create(config.APP));
 

--- a/tests/unit/models/ember-data-sanity-test.js
+++ b/tests/unit/models/ember-data-sanity-test.js
@@ -1,14 +1,14 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Model | ember-data-sanity', function(hooks) {
+module('Unit | Model | ember-data-sanity', function (hooks) {
   setupTest(hooks);
 
   // Replace this with your real tests.
-  test('nested model saving new relationship', async function(assert) {
+  test('nested model saving new relationship', async function (assert) {
     const store = this.owner.lookup('service:store');
-    const documentContainer = store.createRecord("document-container");
-    const behandeling = store.createRecord("behandeling-van-agendapunt");
+    const documentContainer = store.createRecord('document-container');
+    const behandeling = store.createRecord('behandeling-van-agendapunt');
     behandeling.documentContainer = documentContainer;
 
     assert.ok(documentContainer.isNew);
@@ -20,10 +20,12 @@ module('Unit | Model | ember-data-sanity', function(hooks) {
     assert.notOk(behandeling.isNew);
   });
 
-  test('nested model saving to relationship edits', async function(assert) {
+  test('nested model saving to relationship edits', async function (assert) {
     const store = this.owner.lookup('service:store');
-    const agendaItem = store.createRecord("agendapunt");
-    const treatment = store.createRecord("behandeling-van-agendapunt", {openbaar: false});
+    const agendaItem = store.createRecord('agendapunt');
+    const treatment = store.createRecord('behandeling-van-agendapunt', {
+      openbaar: false,
+    });
     agendaItem.behandeling = treatment;
 
     assert.ok(agendaItem.isNew);
@@ -31,7 +33,7 @@ module('Unit | Model | ember-data-sanity', function(hooks) {
 
     await treatment.save();
     await agendaItem.save();
-    const treatmentId = treatment.get("id");
+    const treatmentId = treatment.get('id');
 
     assert.notOk(treatment.isNew);
     assert.notOk(agendaItem.isNew);
@@ -48,11 +50,12 @@ module('Unit | Model | ember-data-sanity', function(hooks) {
     store.unloadAll();
 
     // fetch the relation ship again
-    const treatmentAfterUnload = await store.findRecord("behandeling-van-agendapunt", treatmentId);
+    const treatmentAfterUnload = await store.findRecord(
+      'behandeling-van-agendapunt',
+      treatmentId
+    );
 
     // ember-data does not recursively save relationships!
     assert.notOk(treatmentAfterUnload.openbaar);
-
   });
-
 });


### PR DESCRIPTION
After the upgrade to Ember v3.28, Eslint/Prettier was re-enabled. This PR is the result of beautifying the code with these tools on their default mostly settings according to ember new.