### PR TITLE
Fixing production builds "out of memory" problems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci
 COPY . .
-ENV NODE_OPTIONS="--max-old-space-size=5000"
 RUN ember build -prod
 
 FROM semtech/ember-proxy-service:1.5.1

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -15,12 +15,9 @@ module.exports = function (defaults) {
       enabled: envIsProduction
     },
     'ember-cli-terser': {
+      enabled: envIsProduction,
       exclude: ['vendor.js', 'assets/vendor.js'],
-      terser: {
-        compress: {
-          collapse_vars: false
-        },
-      },
+      hiddenSourceMap: envIsProduction,
     },
     sassOptions: {
       sourceMap: !envIsProduction,


### PR DESCRIPTION
The option `collapse_vars` was disabled on Terser and this caused the RAM usage to spike for some reason, failing the build due to out of memory problems. Removing this option leaves Terser with its own defaults and that seems to produce correct builds.