### PR TITLE
Fixed off by one errors on adding agendapoints

### DIFF
--- a/app/components/agenda-manager/agenda-item-form/select-location.js
+++ b/app/components/agenda-manager/agenda-item-form/select-location.js
@@ -27,7 +27,7 @@ export default class AgendaManagerAgendaItemFormSelectLocationComponent extends 
     if (value.code === 'start') {
       this.args.model[this.args.for] = 0;
     } else if (value.code === 'end') {
-      this.args.model[this.args.for] = this.args.agendaItems.length - 1;
+      this.args.model[this.args.for] = this.args.agendaItems.length;
     }
   }
 

--- a/app/components/agenda-manager/edit.hbs
+++ b/app/components/agenda-manager/edit.hbs
@@ -51,7 +51,7 @@
             </div>
           </div>
 
-          {{#if (gt @agendaItems.length 1)}}
+          {{#if (gt @agendaItems.length 0)}}
             <Form.SelectLocation @for="position" @agendaItems={{@agendaItems}} @currentItem={{@itemToEdit}}>
               {{t "manageAgendaZittingModalMove.title"}}
             </Form.SelectLocation>


### PR DESCRIPTION
We can now add agendapoints to the beginning or end of the list when there is at least 1 agendapoint (previously 2), and the agendapoints now show correctly at the end of the list when chosen so. These were "off by one" errors on collections.