### PR TITLE
fix attachments number in the agendapoints screen

### DIFF
--- a/app/components/attachments-number.js
+++ b/app/components/attachments-number.js
@@ -16,6 +16,6 @@ export default class AttachmentsNumberComponent extends Component {
   @restartableTask
   *getAttachmentsNumber() {
     const attachments = yield this.args.documentContainer.attachments;
-    this.attachmentsNumber = attachments.meta.count;
+    this.attachmentsNumber = attachments.length;
   }
 }


### PR DESCRIPTION
Fixes https://binnenland.atlassian.net/browse/GN-3396, basically the meta count is not updated but the length of the attachments is.
Maybe also something we should check with Aad