### PR TITLE
Fix chrome print bug

### DIFF
--- a/app/styles/project/_u-print.scss
+++ b/app/styles/project/_u-print.scss
@@ -113,6 +113,7 @@
   // App container
   .au-c-app,
   .au-c-main-container {
+    margin: 2rem !important;
     overflow: auto !important;
     height: auto !important;
   }
@@ -167,7 +168,7 @@
   }
 
   .au-c-meeting-chrome .au-c-button {
-    display: none !important;
+    opacity: 0 !important;
   }
 
   .au-c-meeting-chrome strong {


### PR DESCRIPTION
Buttons with display none made tables do weird things in print view and crashes the print preview.
Fix: hide buttons with opacity seems to fix this. No clear idea why this is happening though.