### PR TITLE
update package version of citaten-plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4424,9 +4424,9 @@
       }
     },
     "@lblod/ember-rdfa-editor-citaten-plugin": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-citaten-plugin/-/ember-rdfa-editor-citaten-plugin-0.17.0.tgz",
-      "integrity": "sha512-DLaircmaex5ufFqX9vmj0pC9empSkyggG9f6Sl1kyVK7tkYXi9SiSUaZ1LF5TRLrpQ/P7DFQcRhmmd3JR2/kpw==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-citaten-plugin/-/ember-rdfa-editor-citaten-plugin-0.17.1.tgz",
+      "integrity": "sha512-0J//6jrpmutk04JqarIaAMc6d9drXwbYlHUIwaJLrJdNyB2SYQoWj2sONpKDFGaHG5by+z0SJmN9L+EE03S4DA==",
       "dev": true,
       "requires": {
         "ember-auto-import": "^2.0.2",
@@ -4436,7 +4436,7 @@
         "ember-cli-string-helpers": "^6.1.0",
         "ember-fetch": "^8.1.1",
         "ember-intl": "^5.7.2",
-        "ember-resources": "^4.6.3",
+        "ember-resources": "^4.9.0",
         "sass": "^1.49.4"
       }
     },
@@ -16506,9 +16506,9 @@
       }
     },
     "ember-resources": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/ember-resources/-/ember-resources-4.8.2.tgz",
-      "integrity": "sha512-Ni4zkadhhPsIAGM974pK7gBaaajeFJmjrigKtPIFSaTdeCuNdDn99Cs0NVCZ22QSmh2L5/4tYQh8/nLHggZlaQ==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/ember-resources/-/ember-resources-4.9.0.tgz",
+      "integrity": "sha512-pmHK44RMo+DEqmhAYXL1zjqSVzYxl4SlKvggwumpbcWUYrk2s2+AIHJUKSPcIh0L/7GEpvKzn15Tn8IBO13wGQ==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.17.8",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@lblod/ember-rdfa-editor": "^0.59.1",
     "@lblod/ember-rdfa-editor-besluit-plugin": "^0.4.0",
     "@lblod/ember-rdfa-editor-besluit-type-plugin": "^0.7.0",
-    "@lblod/ember-rdfa-editor-citaten-plugin": "^0.17.0",
+    "@lblod/ember-rdfa-editor-citaten-plugin": "^0.17.1",
     "@lblod/ember-rdfa-editor-import-snippet-plugin": "^0.8.0",
     "@lblod/ember-rdfa-editor-rdfa-date-plugin": "^0.1.1",
     "@lblod/ember-rdfa-editor-roadsign-regulation-plugin": "^0.8.0",


### PR DESCRIPTION
This update fixes an issue with willDestroy-hooks not being triggered as the previous version of this package caused an exception.