### PR TITLE
Use paper view for intro and outro editor

### DIFF
--- a/app/components/zitting-text-document-container.js
+++ b/app/components/zitting-text-document-container.js
@@ -17,6 +17,8 @@ export default class ZittingTextDocumentContainerComponent extends Component {
     showRdfa: false,
     showRdfaHighlight: false,
     showRdfaHover: false,
+    showPaper: true,
+    showSidebar: true
   };
 
   get text() {

--- a/app/components/zitting-text-document-container.js
+++ b/app/components/zitting-text-document-container.js
@@ -18,7 +18,7 @@ export default class ZittingTextDocumentContainerComponent extends Component {
     showRdfaHighlight: false,
     showRdfaHover: false,
     showPaper: true,
-    showSidebar: true
+    showSidebar: true,
   };
 
   get text() {


### PR DESCRIPTION
Fixes the issue when it's not clear where the text cursor/area is. Adding the paper view makes this more clear in full screen situations.