### PR TITLE
Disable closing the edit agendapoint modal when saving

### DIFF
--- a/app/components/agenda-manager/edit.hbs
+++ b/app/components/agenda-manager/edit.hbs
@@ -5,11 +5,11 @@
   <AuModal @title={{t "manageAgendaZittingModal.modalTitle"}}
           @modalOpen={{@visible}}
           @size="default"
-          @closeModal={{this.cancel}}
+          @closeModal={{unless this.isSubmitting this.cancel}}
           as |Modal|
   >
     <Modal.Body>
-      {{#if this.submitTask.isRunning}}
+      {{#if this.isSubmitting}}
         <AuLoader />
         <AuHelpText>{{t "participationList.loadingLoader"}}</AuHelpText>
       {{else}}
@@ -63,7 +63,7 @@
       <AuToolbar>
       <AuButtonGroup>
         <Form.Submit>{{t "manageAgendaZittingModal.saveButton"}}</Form.Submit>
-        <AuButton @skin="secondary" {{on "click" this.cancel}}>
+        <AuButton @skin="secondary" {{on "click" this.cancel}} @disabled={{this.isSubmitting}}>
           {{t "manageAgendaZittingModal.cancelButton"}}
         </AuButton>
       </AuButtonGroup>
@@ -74,7 +74,8 @@
           @loading={{this.deleteTask.isRunning}}
           @icon="bin"
           @iconAlignment="left"
-          {{on "click" (perform this.deleteTask @itemToEdit)}} >
+          {{on "click" (perform this.deleteTask @itemToEdit)}}
+          @disabled={{this.isSubmitting}} >
             {{t "manageAgendaZittingModalDelete.deleteButton"}}
         </AuButton>
       {{/unless}}

--- a/app/components/agenda-manager/edit.js
+++ b/app/components/agenda-manager/edit.js
@@ -14,7 +14,7 @@ export default class AgendaManagerEditComponent extends Component {
     return this.args.itemToEdit && this.args.itemToEdit.isNew;
   }
 
-  get isSubmitting(){
+  get isSubmitting() {
     return this.submitTask.isRunning;
   }
 

--- a/app/components/agenda-manager/edit.js
+++ b/app/components/agenda-manager/edit.js
@@ -13,6 +13,11 @@ export default class AgendaManagerEditComponent extends Component {
   get isNew() {
     return this.args.itemToEdit && this.args.itemToEdit.isNew;
   }
+
+  get isSubmitting(){
+    return this.submitTask.isRunning;
+  }
+
   @task
   *submitTask(item) {
     yield this.args.saveTask.unlinked().perform(item);


### PR DESCRIPTION
This PR disables the cancel and delete buttons when saving an agendapoint, as well as disabling closing the modal altogether.
https://binnenland.atlassian.net/jira/software/c/projects/GN/boards/4?modal=detail&selectedIssue=GN-3527