### PR TITLE
Addition of an environment banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ Plausible analytics is handled by the [ember-plausible addon](https://github.com
 * `EMBER_OAUTH_LOGOUT_URL`
 * `EMBER_OAUTH_SWITCH_URL`
 
+### environment banner
+
+When in a testing or development environment, a banner is shown containing the versions of the application, editor and editor-plugins. This banner is disabled on production.
+
+* `EMBER_ENVIRONMENT_NAME`: name of the environment, appended to the document title. If this string is non-empty, the environment banner is shown. When this string is empty (such as on production), the banner is not shown.
 ### other
 * `EMBER_PUBLICATION_BASE_URL`: url of the linked [publication platform](https://github.com/lblod/app-gn-publicatie/), e.g. "https://publicatie.gelinkt-notuleren.vlaanderen.be/"
-* `EMBER_ENVIRONMENT_NAME`: name of the environment, appended to the document title.
+

--- a/app/components/environment-banner.hbs
+++ b/app/components/environment-banner.hbs
@@ -5,6 +5,9 @@
       Environment
       {{@environmentName}}
     </p>
+    <p>
+      Gelinkt Notuleren {{this.applicationVersion}}
+    </p>
     <VersionInformationOverview/>
   </AuToolbarGroup>
 </AuToolbar>

--- a/app/components/environment-banner.hbs
+++ b/app/components/environment-banner.hbs
@@ -1,0 +1,11 @@
+<div class="au-c-environment-banner">
+<AuToolbar @size='medium'>
+  <AuToolbarGroup>
+    <p>
+      Environment
+      {{@environmentName}}
+    </p>
+    <VersionInformationOverview/>
+  </AuToolbarGroup>
+</AuToolbar>
+</div>

--- a/app/components/environment-banner.js
+++ b/app/components/environment-banner.js
@@ -1,0 +1,8 @@
+import Component from '@glimmer/component';
+import config from '../config/environment';
+
+export default class EnvironmentBannerComponent extends Component {
+  get applicationVersion() {
+    return config.APP.packages['frontend-gelinkt-notuleren'].version;
+  }
+}

--- a/app/components/version-information-overview.hbs
+++ b/app/components/version-information-overview.hbs
@@ -20,7 +20,13 @@
       <:body>
         {{#each-in this.packages as |key value|}}
           <tr>
-            <td><AuLinkExternal href={{value.url}}>{{key}}</AuLinkExternal></td>
+            <td>
+              {{#if value.url}}
+              <AuLinkExternal href={{value.url}}>{{key}}</AuLinkExternal>
+              {{else}}
+              {{key}}
+              {{/if}}
+            </td>
             <td>{{value.version}}</td>
             
           </tr>

--- a/app/components/version-information-overview.hbs
+++ b/app/components/version-information-overview.hbs
@@ -1,0 +1,31 @@
+<AuButton @skin='link-secondary' onclick={{this.toggleModal}}>
+  <AuIcon @icon='info-circle' @alignment='left' />
+  Package versions
+</AuButton>
+<AuModal
+  @modalOpen={{this.showModal}}
+  @closeModal={{this.toggleModal}}
+  @title='Package versions'
+  as |Modal|
+>
+
+  <Modal.Body>
+    <AuTable>
+      <:header>
+        <tr>
+          <th>Package name</th>
+          <th>Version</th>
+        </tr>
+      </:header>
+      <:body>
+        {{#each-in this.packages as |key value|}}
+          <tr>
+            <td><AuLinkExternal href={{value.url}}>{{key}}</AuLinkExternal></td>
+            <td>{{value.version}}</td>
+            
+          </tr>
+        {{/each-in}}
+      </:body>
+    </AuTable>
+  </Modal.Body>
+</AuModal>

--- a/app/components/version-information-overview.js
+++ b/app/components/version-information-overview.js
@@ -1,0 +1,17 @@
+import Component from '@glimmer/component';
+import config from '../config/environment';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class VersionInformationOverviewComponent extends Component {
+  @tracked
+  showModal = false;
+  get packages() {
+    return config.APP.packages;
+  }
+
+  @action
+  toggleModal() {
+    this.showModal = !this.showModal;
+  }
+}

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -28,6 +28,7 @@
 @import "project/c-onboarding";
 @import 'project/c-editor-preview';
 @import "project/c-template";
+@import "project/c-environment-banner";
 
 
 // PLUGINS

--- a/app/styles/project/_c-environment-banner.scss
+++ b/app/styles/project/_c-environment-banner.scss
@@ -1,0 +1,11 @@
+/* ==================================
+   #ENVIRONMENT BANNER
+   ================================== */
+
+.au-c-environment-banner {
+  background-color: #FFA10A;
+
+  .au-c-button {
+    color: $au-gray-1000;
+  }
+}

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -5,8 +5,12 @@
     "Gelinkt Notuleren"
     (if environmentName (concat " - " environmentName))
   )}}
-{{/let}}
-
-<AuApp>
+  <AuApp>
+  {{#if environmentName}}
+  <EnvironmentBanner @environmentName={{environmentName}}/>
+  {{/if}}
   {{outlet}}
 </AuApp>
+{{/let}}
+
+

--- a/config/environment.js
+++ b/config/environment.js
@@ -5,8 +5,11 @@ const fs = require('fs');
 
 function extractRepoUrl(pjson) {
   const repo = pjson.repository;
-  let repo_url = repo?.url?.replace('git+', '');
-  return repo_url;
+  if (typeof repo === 'string') {
+    return repo.replace('git+', '');
+  } else if (typeof repo === 'object') {
+    return repo?.url?.replace('git+', '');
+  }
 }
 function getPackages() {
   const packages = {

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,6 +1,36 @@
 'use strict';
 
+const mainPjson = require('../package.json');
+const fs = require('fs');
+
+function extractRepoUrl(pjson) {
+  const repo = pjson.repository;
+  let repo_url = repo?.url?.replace('git+', '');
+  return repo_url;
+}
+function getPackages() {
+  const packages = {
+    [mainPjson.name]: {
+      version: mainPjson.version,
+      url: extractRepoUrl(mainPjson),
+    },
+  };
+  const dirs = fs
+    .readdirSync('node_modules/@lblod')
+    .filter((dir) => dir.startsWith('ember-rdfa-editor'));
+  dirs.forEach((dir) => {
+    const file = `../node_modules/@lblod/${dir}/package.json`;
+    const pjson = require(file);
+    packages[pjson.name] = {
+      version: pjson.version,
+      url: extractRepoUrl(pjson),
+    };
+  });
+  return packages;
+}
+
 module.exports = function (environment) {
+  const editorDeps = getPackages();
   let ENV = {
     modulePrefix: 'frontend-gelinkt-notuleren',
     environment,
@@ -20,6 +50,9 @@ module.exports = function (environment) {
       '@lblod/ember-rdfa-editor-date-plugin': {
         allowedInputDateFormats: ['DD/MM/YYYY', 'DD-MM-YYYY', 'DD.MM.YYYY'],
         outputDateFormat: 'D MMMM YYYY',
+      },
+      packages: {
+        ...editorDeps,
       },
     },
     roadsignRegulationPlugin: {

--- a/config/environment.js
+++ b/config/environment.js
@@ -3,12 +3,25 @@
 const mainPjson = require('../package.json');
 const fs = require('fs');
 
+function isUrl(string) {
+  try {
+    const url = new URL(string);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch (e) {
+    return false;
+  }
+}
+
 function extractRepoUrl(pjson) {
   const repo = pjson.repository;
+  let url;
   if (typeof repo === 'string') {
-    return repo.replace('git+', '');
+    url = repo.replace('git+', '');
   } else if (typeof repo === 'object') {
-    return repo?.url?.replace('git+', '');
+    url = repo?.url?.replace('git+', '');
+  }
+  if (url && isUrl(url)) {
+    return url;
   }
 }
 function getPackages() {


### PR DESCRIPTION
This PR adds an environment banner which includes the environment name and application version. Additionally it provides a button which leads to an overview of the editor version and the versions of the editor-plugins installed.
It is still to be seen if the way how the environment is populated with the package versions is a desirable one.