### PR TITLE
chore(deps): bump editor and plugins to newest bugfix releases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@lblod/ember-rdfa-editor-rdfa-date-plugin": "^0.3.1",
         "@lblod/ember-rdfa-editor-roadsign-regulation-plugin": "^0.9.3",
         "@lblod/ember-rdfa-editor-standard-template-plugin": "^0.13.1",
-        "@lblod/ember-rdfa-editor-template-variable-plugin": "git+http://github.com/lblod/ember-rdfa-editor-template-variable-plugin.git#489c980885abbb65c849f8471f62caf5860c8b34",
+        "@lblod/ember-rdfa-editor-template-variable-plugin": "^0.7.1",
         "@release-it-plugins/lerna-changelog": "^5.0.0",
         "babel-eslint": "^10.1.0",
         "broccoli-asset-rev": "^3.0.0",
@@ -42822,7 +42822,7 @@
     "@lblod/ember-rdfa-editor-template-variable-plugin": {
       "version": "git+http://github.com/lblod/ember-rdfa-editor-template-variable-plugin.git#489c980885abbb65c849f8471f62caf5860c8b34",
       "dev": true,
-      "from": "@lblod/ember-rdfa-editor-template-variable-plugin@git+http://github.com/lblod/ember-rdfa-editor-template-variable-plugin.git#489c980885abbb65c849f8471f62caf5860c8b34",
+      "from": "@lblod/ember-rdfa-editor-template-variable-plugin@^0.7.1",
       "requires": {
         "@glimmer/component": "^1.0.4",
         "@glimmer/tracking": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@lblod/ember-rdfa-editor-roadsign-regulation-plugin": "^0.9.3",
     "@lblod/ember-rdfa-editor-standard-template-plugin": "^0.13.1",
     "@lblod/ember-rdfa-editor-template-variable-plugin": "git+http://github.com/lblod/ember-rdfa-editor-template-variable-plugin.git#489c980885abbb65c849f8471f62caf5860c8b34",
+    "@lblod/ember-rdfa-editor-template-variable-plugin": "^0.7.1",
     "@release-it-plugins/lerna-changelog": "^5.0.0",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",


### PR DESCRIPTION
Roadsign-regulation plugin added as a github dep until [this PR](https://github.com/lblod/ember-rdfa-editor-roadsign-regulation-plugin/pull/47) is merged. This way this pr still fully builds correctly without having to wait on a release.
(But it would still be better to wait before merging.)

More context: this bump is actually quite important, since it fixes compat with the 0.63.3 release. It would be easy to end up with that release accidentally since it's within semver range of the package.json

EDIT: plugin version released and package.json updated
