### PR TITLE
Filter based on validThrough property

### DIFF
--- a/app/services/regulatory-attachments-fetcher.js
+++ b/app/services/regulatory-attachments-fetcher.js
@@ -28,9 +28,10 @@ export default class RegulatoryAttachmentsFetcher extends Service {
           ext:currentVersion ?container.
         ?container dct:title ?title.
         ?reglement ext:publishedVersion ?publishedContainer.
-        FILTER NOT EXISTS {
+        OPTIONAL { 
           ?reglement schema:validThrough ?validThrough.
         }
+        FILTER( ! BOUND(?validThrough) || ?validThrough < NOW()) 
       }
     `;
     const details = {

--- a/app/services/regulatory-attachments-fetcher.js
+++ b/app/services/regulatory-attachments-fetcher.js
@@ -31,7 +31,7 @@ export default class RegulatoryAttachmentsFetcher extends Service {
         OPTIONAL { 
           ?reglement schema:validThrough ?validThrough.
         }
-        FILTER( ! BOUND(?validThrough) || ?validThrough < NOW()) 
+        FILTER( ! BOUND(?validThrough) || ?validThrough > NOW()) 
       }
     `;
     const details = {

--- a/app/services/regulatory-attachments-fetcher.js
+++ b/app/services/regulatory-attachments-fetcher.js
@@ -21,11 +21,16 @@ export default class RegulatoryAttachmentsFetcher extends Service {
       PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
       PREFIX pav: <http://purl.org/pav/>
       PREFIX dct: <http://purl.org/dc/terms/>
+      PREFIX schema: <http://schema.org/>
       select distinct * where {
         ?publishedContainer a ext:PublishedRegulatoryAttachmentContainer;
           mu:uuid ?uuid;
           ext:currentVersion ?container.
         ?container dct:title ?title.
+        ?reglement ext:publishedVersion ?publishedContainer.
+        FILTER NOT EXISTS {
+          ?reglement schema:validThrough ?validThrough.
+        }
       }
     `;
     const details = {


### PR DESCRIPTION
First of all this depends on https://github.com/lblod/reglement-publish-service/pull/5 so we should wait for that to be merged and deployed, but I created the PR so we can start a little discussion.
I did the most basic thing, if the reglement has an expiration date not show it, I was thinking on filtering based on the ones that are still valid (even thought we don't really set this validthrough date in the future, we just set it to today when we delete in the regulatory statements app). This would be more semantically correct, but also would bring the question: "Do we want to allow the user to include a template that will expire tomorrow, in the next week...?", I think that for the moment is better to leave it like this and improve the flow in the future, but it's open for discussion