### PR TITLE
Fix regex which matches for generateUuid() in the template

### DIFF
--- a/app/components/document-creator.js
+++ b/app/components/document-creator.js
@@ -124,7 +124,7 @@ export default class DocumentCreatorComponent extends Component {
 // exact same syntax
 function instantiateUuids(templateString) {
   let generateUuid = uuidv4; // eslint-disable-line no-unused-vars
-  return templateString.replace(/\$\{generateUuid()}/g, (match) => {
+  return templateString.replace(/\$\{generateUuid\(\)\}/g, (match) => {
     //input '${content}' and eval('content')
     return eval(match.substring(2, match.length - 1));
   });


### PR DESCRIPTION
The previous regex did not escape some characters which caused the match to fail. Partly a solution for https://binnenland.atlassian.net/jira/software/c/projects/GN/boards/4?modal=detail&selectedIssue=GN-3682.