### PR TITLE
Fix: prevent the confirm dialog to show up twice when exiting without saving

### DIFF
--- a/app/components/confirm-route-leave.js
+++ b/app/components/confirm-route-leave.js
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
+import isLoadingRoute from '../utils/is-loading-route';
 
 export default class ConfirmRouteLeaveComponent extends Component {
   @service router;
@@ -32,7 +33,7 @@ export default class ConfirmRouteLeaveComponent extends Component {
   }
 
   confirm(transition) {
-    if (transition.isAborted) {
+    if (transition.isAborted || isLoadingRoute(transition.to)) {
       return;
     }
     if (this.args.enabled) {

--- a/app/utils/is-loading-route.js
+++ b/app/utils/is-loading-route.js
@@ -1,0 +1,4 @@
+export default function isLoadingRoute(routeInfo) {
+  const regex = new RegExp('^(.+-loading|loading)$');
+  return regex.test(routeInfo.localName);
+}


### PR DESCRIPTION
This PR checks if a transition target is a loading route when trying to show a confirm dialog. When it is a loading route, the dialog isn't shown.