### PR TITLE
Use file service from regulatory-statements application in order to fetch template

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -7,8 +7,7 @@ module.exports = function (environment) {
     rootURL: '/',
     locationType: 'auto',
     regulatoryStatementEndpoint: '{{REGULATORY_STATEMENT_ENDPOINT}}',
-    regulatoryStatementPreviewEndpoint:
-      '{{REGULATORY_STATEMENT_PREVIEW_ENDPOINT}}',
+    regulatoryStatementFileEndpoint: '{{REGULATORY_STATEMENT_FILE_ENDPOINT}}',
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build
@@ -97,10 +96,8 @@ module.exports = function (environment) {
       'https://dev.roadsigns.lblod.info/sparql';
     ENV.templateVariablePlugin.endpoint =
       'https://dev.roadsigns.lblod.info/sparql';
-    ENV.regulatoryStatementEndpoint =
-      'https://dev.reglementairebijlagen.lblod.info/sparql';
-    ENV.regulatoryStatementPreviewEndpoint =
-      'https://dev.reglementairebijlagen.lblod.info/preview/regulatory-attachment-container';
+    ENV.regulatoryStatementEndpoint = 'http://localhost/sparql';
+    ENV.regulatoryStatementFileEndpoint = 'http://localhost/files';
     // ENV.APP.LOG_RESOLVER = true;
     // ENV.APP.LOG_ACTIVE_GENERATION = true;
     // ENV.APP.LOG_TRANSITIONS = true;


### PR DESCRIPTION
This PR includes changes on how the regulatory statement templates are fetched:
- The SPARQL query used to fetch a template has been modified in order to conform to the new data model.
- The template content is now fetched from the regulatory statements file service instead of the custom preview endpoint.
- The `regulatoryStatementPreviewEndpoint` environment variable has been removed and replaced in favor of `regulatoryStatementFileEndpoint`. Both regulatory-statement endpoint ENV vars have been set to fetch from localhost in order to test this PR.

This PR relies on https://github.com/lblod/app-reglementaire-bijlage/pull/27.
This PR is a solution to https://binnenland.atlassian.net/jira/software/c/projects/GN/boards/4?modal=detail&selectedIssue=GN-3732.

TODO:
- [ ] The SPARQL query should be updated with the correct namespaces (instead of `ext`).
