### PR TITLE
When the notulen is published disable the editing

### DIFF
--- a/app/components/meeting-form.hbs
+++ b/app/components/meeting-form.hbs
@@ -22,6 +22,11 @@
   <AuToolbar @size="small" class="au-u-padding-top-none" as |Group|>
     <Group>
       <h1 class="au-c-app-chrome__title">{{t "meetingForm.scheduledText"}} {{plain-date @zitting.geplandeStart}}</h1>
+      {{#if this.isPublished}}
+        <AuPill @skin="success">
+          {{t "meetingForm.notulenPublished"}}
+        </AuPill>
+      {{/if}}
     </Group>
     <Group>
       {{#unless this.readOnly}}
@@ -108,11 +113,6 @@
           <AuIcon @icon="info-circle"/>
           {{t "meetingForm.firstSectionNotFilledWarning"}}
         </span>
-        {{#if this.isPublished}}
-          <AuPill @skin="success">
-            {{t "meetingForm.notulenPublished"}}
-          </AuPill>
-        {{/if}}
       </AuHeading>
       <Zitting::ManageZittingsdata
         @zitting={{@zitting}}
@@ -138,11 +138,6 @@
               <AuIcon @icon="info-circle"/>
               {{t "meetingForm.secondSectionNotFilledWarning"}}
             </span>
-            {{#if this.isPublished}}
-              <AuPill @skin="success">
-                {{t "meetingForm.notulenPublished"}}
-              </AuPill>
-            {{/if}}
           </AuHeading>
           <ParticipationList
             @chairman={{this.voorzitter}}
@@ -165,11 +160,6 @@
               <AuIcon @icon="info-circle"/>
               {{t "meetingForm.thirdSectionNotFilledWarning"}}
             </span>
-            {{#if this.isPublished}}
-              <AuPill @skin="success">
-                {{t "meetingForm.notulenPublished"}}
-              </AuPill>
-            {{/if}}
           </AuHeading>
           <AgendaManager @zittingId={{@zitting.id}} @onSave={{perform this.fetchTreatments}} @readOnly={{this.readOnly}}/>
           {{!-- Start of meeting --}}
@@ -179,11 +169,6 @@
               <AuIcon @icon="info-circle"/>
                 {{t 'manageFreeText.before'}}
             </span>
-            {{#if this.isPublished}}
-              <AuPill @skin="success">
-                {{t "meetingForm.notulenPublished"}}
-              </AuPill>
-            {{/if}}
           </AuHeading>
         <ReadonlyTextBox @title={{t "behandelingVanAgendapunten.contentTitle"}}>
           {{html-safe @zitting.intro}}
@@ -200,11 +185,6 @@
               <AuIcon @icon="info-circle"/>
               {{t "meetingForm.fifthSectionNotFilledWarning"}}
             </span>
-            {{#if this.isPublished}}
-              <AuPill @skin="success">
-                {{t "meetingForm.notulenPublished"}}
-              </AuPill>
-            {{/if}}
           </AuHeading>
           {{#if this.fetchTreatments.isRunning}}
             <AuLoader @padding="small" />
@@ -233,11 +213,6 @@
               <AuIcon @icon="info-circle"/>
                 {{t 'manageFreeText.after'}}
               </span>
-              {{#if this.isPublished}}
-                <AuPill @skin="success">
-                  {{t "meetingForm.notulenPublished"}}
-                </AuPill>
-              {{/if}}
           </AuHeading>
           <ReadonlyTextBox @title={{t "behandelingVanAgendapunten.contentTitle"}}>
             {{html-safe @zitting.outro}}

--- a/app/components/meeting-form.hbs
+++ b/app/components/meeting-form.hbs
@@ -108,6 +108,11 @@
           <AuIcon @icon="info-circle"/>
           {{t "meetingForm.firstSectionNotFilledWarning"}}
         </span>
+        {{#if this.isPublished}}
+          <AuPill @skin="success">
+            {{t "meetingForm.notulenPublished"}}
+          </AuPill>
+        {{/if}}
       </AuHeading>
       <Zitting::ManageZittingsdata
         @zitting={{@zitting}}
@@ -133,6 +138,11 @@
               <AuIcon @icon="info-circle"/>
               {{t "meetingForm.secondSectionNotFilledWarning"}}
             </span>
+            {{#if this.isPublished}}
+              <AuPill @skin="success">
+                {{t "meetingForm.notulenPublished"}}
+              </AuPill>
+            {{/if}}
           </AuHeading>
           <ParticipationList
             @chairman={{this.voorzitter}}
@@ -155,6 +165,11 @@
               <AuIcon @icon="info-circle"/>
               {{t "meetingForm.thirdSectionNotFilledWarning"}}
             </span>
+            {{#if this.isPublished}}
+              <AuPill @skin="success">
+                {{t "meetingForm.notulenPublished"}}
+              </AuPill>
+            {{/if}}
           </AuHeading>
           <AgendaManager @zittingId={{@zitting.id}} @onSave={{perform this.fetchTreatments}} @readOnly={{this.readOnly}}/>
           {{!-- Start of meeting --}}
@@ -164,6 +179,11 @@
               <AuIcon @icon="info-circle"/>
                 {{t 'manageFreeText.before'}}
             </span>
+            {{#if this.isPublished}}
+              <AuPill @skin="success">
+                {{t "meetingForm.notulenPublished"}}
+              </AuPill>
+            {{/if}}
           </AuHeading>
         <ReadonlyTextBox @title={{t "behandelingVanAgendapunten.contentTitle"}}>
           {{html-safe @zitting.intro}}
@@ -180,6 +200,11 @@
               <AuIcon @icon="info-circle"/>
               {{t "meetingForm.fifthSectionNotFilledWarning"}}
             </span>
+            {{#if this.isPublished}}
+              <AuPill @skin="success">
+                {{t "meetingForm.notulenPublished"}}
+              </AuPill>
+            {{/if}}
           </AuHeading>
           {{#if this.fetchTreatments.isRunning}}
             <AuLoader @padding="small" />
@@ -208,6 +233,11 @@
               <AuIcon @icon="info-circle"/>
                 {{t 'manageFreeText.after'}}
               </span>
+              {{#if this.isPublished}}
+                <AuPill @skin="success">
+                  {{t "meetingForm.notulenPublished"}}
+                </AuPill>
+              {{/if}}
           </AuHeading>
           <ReadonlyTextBox @title={{t "behandelingVanAgendapunten.contentTitle"}}>
             {{html-safe @zitting.outro}}

--- a/app/components/meeting-form.js
+++ b/app/components/meeting-form.js
@@ -18,12 +18,16 @@ export default class MeetingForm extends Component {
   @tracked possibleParticipants;
   @tracked behandelingen;
   @tracked headerArticleTranslationString = '';
+  @tracked isPublished = false;
   @service store;
   @service currentSession;
   @service router;
 
   get readOnly() {
-    return !this.currentSession.canWrite && this.currentSession.canRead;
+    return (
+      (!this.currentSession.canWrite && this.currentSession.canRead) ||
+      this.isPublished
+    );
   }
 
   constructor() {
@@ -46,6 +50,12 @@ export default class MeetingForm extends Component {
       const classification = yield specialisedBestuursorgaan.get(
         'classificatie'
       );
+      const versionedNotulen = yield this.store.query('versioned-notulen', {
+        'filter[zitting][id]': this.zitting.get('id'),
+      });
+      if (versionedNotulen.firstObject) {
+        this.isPublished = true;
+      }
       this.headerArticleTranslationString =
         articlesBasedOnClassifcationMap[classification.get('uri')];
       this.secretaris = yield this.zitting.get('secretaris');

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -120,6 +120,7 @@ meetingForm:
   fifthSectionNotFilledWarning: Manage your decision and votes.
   sixthSectionNotFilledWarning: Fill outFree text (meeting outro).
   bestuursorganNotSelectedWarning: Alvorens u verder kan gaan, dient de zitting eerst informatie te hebben over het bestuursorgaan.
+  notulenPublished: Meeting is published
 manageZittingsData:
   startNotSet: "start date has not been set"
   endNotSet: "end date has not been set"

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -255,6 +255,7 @@ meetingForm:
   fifthSectionNotFilledWarning: Manage your decision and votes.
   sixthSectionNotFilledWarning: Fill outFree text (meeting outro).
   bestuursorganNotSelectedWarning: Alvorens u verder kan gaan, dient de zitting eerst informatie te hebben over het bestuursorgaan.
+  notulenPublished: Meeting is published
 
 meetings:
   delete:

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -257,6 +257,7 @@ meetingForm:
   fifthSectionNotFilledWarning: Bewerk je besluiten en beheer de stemmingen
   sixthSectionNotFilledWarning: Vull in vrie tekst (zitting outro).
   bestuursorganNotSelectedWarning: Alvorens u verder kan gaan, dient de zitting eerst informatie te hebben over het bestuursorgaan.
+  notulenPublished: Notulen gepubliceerd
 
 meetings:
   delete:

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -122,6 +122,7 @@ meetingForm:
   fifthSectionNotFilledWarning: Bewerk je besluiten en beheer de stemmingen
   sixthSectionNotFilledWarning: Vull in vrie tekst (zitting outro).
   bestuursorganNotSelectedWarning: Alvorens u verder kan gaan, dient de zitting eerst informatie te hebben over het bestuursorgaan.
+  notulenPublished: Notulen gepubliceerd
 manageZittingsData:
   startNotSet: "Start van de zitting werd nog niet ingesteld."
   endNotSet: "Einde van de zitting werd nog niet ingesteld."


### PR DESCRIPTION
Solves https://binnenland.atlassian.net/browse/GN-3640, I saw the issue and was simple so I implemented it, this has to be revisited if we implement the ability to republish a meeting, but for the moment it prevents confusion by the user.
@Dietr I used a simple design to show the user that a notulen has been published, just a pill on every heading, maybe you want to modify that
<img width="1552" alt="Screen Shot 2022-11-08 at 13 41 28" src="https://user-images.githubusercontent.com/17006446/200566272-96ee25e6-2f25-4cbc-af27-b5e34d1dea27.png">
