### PR TITLE
Feature: prevent the duplicate inclusion of regulatory statements in a decision

### DIFF
--- a/app/components/editor-plugins/regulatory-statements/search-modal.hbs
+++ b/app/components/editor-plugins/regulatory-statements/search-modal.hbs
@@ -29,7 +29,7 @@
                       (fn this.selectStatement statement)}}>
                       {{statement.currentVersion.title}}
                       {{#if (this.isInserted statement)}}
-                        <AuPill @skin="border" @icon="info-circle">Already Attached</AuPill>
+                        <AuPill @skin="border" @icon="info-circle">{{t "regulatoryStatementsPlugin.alreadyAttached"}}</AuPill>
                       {{/if}}
                     </AuButton>
                   </li>
@@ -39,7 +39,7 @@
                   <AuButton
                       class="au-u-padding au-u-1-1" {{on "click"
                       (perform this.fetchNextPage)}} @loading={{this.fetchNextPage.isRunning}}>
-                      Load More
+                      {{t "regulatoryStatementsPlugin.loadMore"}}
                   </AuButton>
                 </li>
                 {{/if}}

--- a/app/components/editor-plugins/regulatory-statements/search-modal.hbs
+++ b/app/components/editor-plugins/regulatory-statements/search-modal.hbs
@@ -3,7 +3,7 @@
          @size="large" 
          @padding="none" 
          @closeModal={{@closeModal}}
-         {{did-insert (perform this.fetchNextPage)}}
+         {{did-insert this.didInsert}}
   as |modal|>
   <modal.Body>
     <AuMainContainer class="citaten--main-container" as |mc|>
@@ -28,6 +28,9 @@
                       class="au-c-list-navigation__link au-u-padding au-u-1-1 {{if (eq this.selectedStatement statement) 'active'}}" {{on "click"
                       (fn this.selectStatement statement)}}>
                       {{statement.currentVersion.title}}
+                      {{#if (this.isInserted statement)}}
+                        <AuPill @skin="border" @icon="info-circle">Already Attached</AuPill>
+                      {{/if}}
                     </AuButton>
                   </li>
                 {{/each}}
@@ -84,7 +87,7 @@
                 <AuButton @skin="link" {{on "click" @closeModal}}>{{t "regulatoryStatementsPlugin.cancel"}}</AuButton>
               </AuToolbarGroup>
               <AuToolbarGroup>
-                <AuButton @disabled={{not this.selectedStatement}} {{on "click" (fn @insertStatement
+                <AuButton @disabled={{or (not this.selectedStatement) (this.isInserted this.selectedStatement)}} {{on "click" (fn @insertStatement
                   this.selectedStatement)}}>
                   {{t "regulatoryStatementsPlugin.insertStatement"}}
                 </AuButton>

--- a/app/components/editor-plugins/regulatory-statements/search-modal.js
+++ b/app/components/editor-plugins/regulatory-statements/search-modal.js
@@ -7,6 +7,7 @@ import { restartableTask } from 'ember-concurrency';
 
 export default class RegulatoryStatementsSearchModalComponent extends Component {
   @service store;
+  @service documentService;
 
   @tracked page = 0;
   @tracked pageSize = 10;
@@ -17,7 +18,18 @@ export default class RegulatoryStatementsSearchModalComponent extends Component 
   @tracked showLoadMore = true;
 
   @tracked regulatoryStatements = tracked([]);
+  @tracked includedStatements = [];
   @tracked debounceTime = 2000;
+
+  @action
+  didInsert() {
+    this.fetchNextPage.perform();
+    const editorDocument = this.store.createRecord('editor-document', {
+      content: this.args.controller.htmlContent ?? '',
+    });
+    this.includedStatements =
+      this.documentService.getDocumentparts(editorDocument);
+  }
 
   @restartableTask
   *fetchNextPage() {
@@ -48,7 +60,6 @@ export default class RegulatoryStatementsSearchModalComponent extends Component 
     this.searchValue = input;
     this.regulatoryStatements = tracked([]);
     this._selectedStatement = null;
-
     this.page = 0;
     yield this.fetchNextPage.perform();
   }
@@ -61,4 +72,6 @@ export default class RegulatoryStatementsSearchModalComponent extends Component 
   get selectedStatement() {
     return this._selectedStatement ?? this.regulatoryStatements?.firstObject;
   }
+
+  isInserted = (statement) => this.includedStatements.includes(statement.uri);
 }

--- a/app/components/editor-plugins/regulatory-statements/sidebar-insert.hbs
+++ b/app/components/editor-plugins/regulatory-statements/sidebar-insert.hbs
@@ -4,5 +4,5 @@
   </AuButton>
 </AuList::Item>
 {{#if this.modalEnabled}}
-<EditorPlugins::RegulatoryStatements::SearchModal @closeModal={{this.toggleModal}} @insertStatement={{this.insertRegulatoryStatement}}/>
+<EditorPlugins::RegulatoryStatements::SearchModal @closeModal={{this.toggleModal}} @insertStatement={{this.insertRegulatoryStatement}} @controller={{@controller}}/>
 {{/if}}

--- a/app/services/document-service.js
+++ b/app/services/document-service.js
@@ -70,6 +70,19 @@ export default class DocumentService extends Service {
     return decisions;
   }
 
+  getDocumentparts(editorDocument) {
+    const triples = this.extractTriplesFromDocument(editorDocument);
+    const documentpartUris = triples
+      .filter(
+        (t) =>
+          t.predicate === 'a' &&
+          t.object ===
+            'https://data.vlaanderen.be/doc/applicatieprofiel/besluit-publicatie#Documentonderdeel'
+      )
+      .map((triple) => triple.subject);
+    return documentpartUris;
+  }
+
   @task
   *createEditorDocument(title, content, documentContainer, previousDocument) {
     if (!title || !documentContainer) {
@@ -92,19 +105,6 @@ export default class DocumentService extends Service {
       yield documentContainer.save();
       return editorDocument;
     }
-  }
-
-  getDocumentparts(editorDocument) {
-    const triples = this.extractTriplesFromDocument(editorDocument);
-    const documentpartUris = triples
-      .filter(
-        (t) =>
-          t.predicate === 'a' &&
-          t.object ===
-            'https://data.vlaanderen.be/doc/applicatieprofiel/besluit-publicatie#Documentonderdeel'
-      )
-      .map((triple) => triple.subject);
-    return documentpartUris;
   }
 
   async updateLinkedDocuments(previousDocument, newDocument) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
         "ember-export-application-global": "^2.0.1",
         "ember-feature-flags": "^6.0.0",
         "ember-fetch": "^8.1.1",
+        "ember-functions-as-helper-polyfill": "^2.1.1",
         "ember-intl": "^5.7.2",
         "ember-load": "0.0.17",
         "ember-load-initializers": "^2.1.2",
@@ -18726,6 +18727,115 @@
       },
       "engines": {
         "node": "12.* || >= 14"
+      }
+    },
+    "node_modules/ember-functions-as-helper-polyfill": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ember-functions-as-helper-polyfill/-/ember-functions-as-helper-polyfill-2.1.1.tgz",
+      "integrity": "sha512-vZ2w9G/foohwtPm99Jos1m6bhlXyyyiJ4vhLbxyjWB4wh7bcpRzXPgCewDRrwefZQ2BwtHg3c9zvVMlI0g+o2Q==",
+      "dev": true,
+      "dependencies": {
+        "ember-cli-babel": "^7.26.11",
+        "ember-cli-typescript": "^5.0.0",
+        "ember-cli-version-checker": "^5.1.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      },
+      "peerDependencies": {
+        "ember-source": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/ember-functions-as-helper-polyfill/node_modules/ember-cli-typescript": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz",
+      "integrity": "sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-to-html": "^0.6.15",
+        "broccoli-stew": "^3.0.0",
+        "debug": "^4.0.0",
+        "execa": "^4.0.0",
+        "fs-extra": "^9.0.1",
+        "resolve": "^1.5.0",
+        "rsvp": "^4.8.1",
+        "semver": "^7.3.2",
+        "stagehand": "^1.0.0",
+        "walk-sync": "^2.2.0"
+      },
+      "engines": {
+        "node": ">= 12.*"
+      }
+    },
+    "node_modules/ember-functions-as-helper-polyfill/node_modules/execa": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "get-stream": "^5.0.0",
+        "human-signals": "^1.1.1",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.0",
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/ember-functions-as-helper-polyfill/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ember-functions-as-helper-polyfill/node_modules/human-signals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.12.0"
+      }
+    },
+    "node_modules/ember-functions-as-helper-polyfill/node_modules/rsvp": {
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || >= 7.*"
+      }
+    },
+    "node_modules/ember-functions-as-helper-polyfill/node_modules/walk-sync": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
+      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
+      "dev": true,
+      "dependencies": {
+        "@types/minimatch": "^3.0.3",
+        "ensure-posix-path": "^1.1.0",
+        "matcher-collection": "^2.0.0",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": "8.* || >= 10.*"
       }
     },
     "node_modules/ember-get-config": {
@@ -53935,6 +54045,87 @@
       "requires": {
         "@embroider/addon-shim": "^1.0.0",
         "focus-trap": "^6.7.1"
+      }
+    },
+    "ember-functions-as-helper-polyfill": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ember-functions-as-helper-polyfill/-/ember-functions-as-helper-polyfill-2.1.1.tgz",
+      "integrity": "sha512-vZ2w9G/foohwtPm99Jos1m6bhlXyyyiJ4vhLbxyjWB4wh7bcpRzXPgCewDRrwefZQ2BwtHg3c9zvVMlI0g+o2Q==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^7.26.11",
+        "ember-cli-typescript": "^5.0.0",
+        "ember-cli-version-checker": "^5.1.2"
+      },
+      "dependencies": {
+        "ember-cli-typescript": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz",
+          "integrity": "sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==",
+          "dev": true,
+          "requires": {
+            "ansi-to-html": "^0.6.15",
+            "broccoli-stew": "^3.0.0",
+            "debug": "^4.0.0",
+            "execa": "^4.0.0",
+            "fs-extra": "^9.0.1",
+            "resolve": "^1.5.0",
+            "rsvp": "^4.8.1",
+            "semver": "^7.3.2",
+            "stagehand": "^1.0.0",
+            "walk-sync": "^2.2.0"
+          }
+        },
+        "execa": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+          "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "human-signals": "^1.1.1",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.0",
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "human-signals": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+          "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+          "dev": true
+        },
+        "rsvp": {
+          "version": "4.8.5",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+          "dev": true
+        },
+        "walk-sync": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
+          "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
+          "dev": true,
+          "requires": {
+            "@types/minimatch": "^3.0.3",
+            "ensure-posix-path": "^1.1.0",
+            "matcher-collection": "^2.0.0",
+            "minimatch": "^3.0.4"
+          }
+        }
       }
     },
     "ember-get-config": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "ember-export-application-global": "^2.0.1",
     "ember-feature-flags": "^6.0.0",
     "ember-fetch": "^8.1.1",
+    "ember-functions-as-helper-polyfill": "^2.1.1",
     "ember-intl": "^5.7.2",
     "ember-load": "0.0.17",
     "ember-load-initializers": "^2.1.2",

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -433,6 +433,8 @@ regulatoryStatementsPlugin:
   noStatementSelected: No regulatory statement selected
   editStatement: Edit
   detachStatement: Detach
+  loadMore: Load more
+  alreadyAttached: Already attached
 utils:
   save: Save
   fileOptions: File options

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -436,6 +436,8 @@ regulatoryStatementsPlugin:
   noStatementSelected: Geen reglement geselecteerd
   editStatement: Bewerk
   detachStatement: Loskoppelen
+  loadMore: Meer laden
+  alreadyAttached: Reeds gekoppeld
 utils:
   save: Bewaar
   fileOptions: Bestand acties


### PR DESCRIPTION
This PR does two things:
- It adds an `already attached` indication to regulatory statements which are already included.
- It disables the `insert` button when a statement is already coupled.

This PR solves https://binnenland.atlassian.net/jira/software/c/projects/GN/boards/4?modal=detail&selectedIssue=GN-3810