### PR TITLE
Bugfix: only return title property if this._title is null or undefined

### DIFF
--- a/app/components/editor-document-title.js
+++ b/app/components/editor-document-title.js
@@ -12,7 +12,11 @@ export default class EditorDocumentTitleComponent extends Component {
   }
 
   get title() {
-    return this._title || this.args.title;
+    if (this._title === undefined || this._title === null) {
+      return this.args.title;
+    } else {
+      return this._title;
+    }
   }
 
   @action


### PR DESCRIPTION
Solves https://binnenland.atlassian.net/jira/software/c/projects/GN/boards/4?modal=detail&selectedIssue=GN-3826.