### PR TITLE
Feature: non editable published regulatory statements

### DIFF
--- a/app/components/app-chrome.hbs
+++ b/app/components/app-chrome.hbs
@@ -30,7 +30,7 @@
     <Group>
       <div>
         {{#unless @editorDocument.isNew}}
-          <EditorStatusPill @status={{@documentContainer.status}} />
+          <EditorStatusPill @status={{this.documentStatus}} />
         {{/unless}}
         {{#if @editorDocument.isNew}}
           <AuPill @skin="warning">

--- a/app/components/app-chrome.js
+++ b/app/components/app-chrome.js
@@ -7,7 +7,8 @@ export default class AppChromeComponent extends Component {
   @service features;
 
   get documentStatus() {
-    const status = this.args.documentContainer?.get('status');
+    const status =
+      this.args.documentStatus ?? this.args.documentContainer?.get('status');
     return status;
   }
 

--- a/app/components/editor-plugins/regulatory-statements/view.hbs
+++ b/app/components/editor-plugins/regulatory-statements/view.hbs
@@ -14,12 +14,9 @@
       </Group>
       <Group>
         <AuButtonGroup>
-          <AuLinkExternal
-            @icon="pencil"
-            @skin="naked"
-            href={{this.url}}>
-            {{t "regulatoryStatementsPlugin.editStatement"}}
-          </AuLinkExternal>
+          {{#if this.documentContainer}}
+          <RegulatoryStatementLink @icon="pencil" @documentContainer={{this.documentContainer}} @label={{t "regulatoryStatementsPlugin.editStatement"}}/>
+          {{/if}}
           <AuButton @skin="naked" @icon="link-broken" @alert="true" {{on "click" this.detach}}>
             {{t "regulatoryStatementsPlugin.detachStatement"}}
           </AuButton>

--- a/app/components/editor-plugins/regulatory-statements/view.js
+++ b/app/components/editor-plugins/regulatory-statements/view.js
@@ -1,9 +1,11 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 
 export default class ReadOnlyContentSectionComponent extends Component {
   @service store;
+  @tracked documentContainer;
 
   @action
   didInsert() {
@@ -17,16 +19,13 @@ export default class ReadOnlyContentSectionComponent extends Component {
         include: 'current-version',
       })
     ).firstObject;
+    this.documentContainer = regulatoryStatementContainer;
     const currentVersion = await regulatoryStatementContainer.currentVersion;
     this.componentController.setProperty('title', currentVersion.title);
     this.componentController.setProperty('updatedOn', currentVersion.updatedOn);
     this.componentController.setProperty(
       'content',
       currentVersion.htmlSafeContent
-    );
-    this.componentController.setProperty(
-      'url',
-      `/regulatory-statements/${regulatoryStatementContainer.id}/edit`
     );
   }
 
@@ -44,10 +43,6 @@ export default class ReadOnlyContentSectionComponent extends Component {
 
   get updatedOn() {
     return this.componentController.getProperty('updatedOn');
-  }
-
-  get url() {
-    return this.componentController.getProperty('url');
   }
 
   get uri() {

--- a/app/components/regulatory-statement-link.hbs
+++ b/app/components/regulatory-statement-link.hbs
@@ -1,5 +1,9 @@
 {{#if (or (eq this.editorStatus "published") @readOnly)}}
-  <LinkTo @route="regulatory-statements.show" @model={{@documentContainer.id}} class="au-c-link">{{@documentContainer.currentVersion.title}}</LinkTo>
+<AuLink @icon={{@icon}} @route="regulatory-statements.show" @model={{@documentContainer.id}}>
+  {{this.linkLabel}}
+</AuLink>
 {{else}}
-  <LinkTo @route="regulatory-statements.edit" @model={{@documentContainer.id}} class="au-c-link">{{@documentContainer.currentVersion.title}}</LinkTo>
+<AuLink @icon={{@icon}} @route="regulatory-statements.edit" @model={{@documentContainer.id}}>
+  {{this.linkLabel}}
+</AuLink>
 {{/if}}

--- a/app/components/regulatory-statement-link.hbs
+++ b/app/components/regulatory-statement-link.hbs
@@ -1,0 +1,5 @@
+{{#if (or (eq this.editorStatus "published") @readOnly)}}
+  <LinkTo @route="regulatory-statements.show" @model={{@documentContainer.id}} class="au-c-link">{{@documentContainer.currentVersion.title}}</LinkTo>
+{{else}}
+  <LinkTo @route="regulatory-statements.edit" @model={{@documentContainer.id}} class="au-c-link">{{@documentContainer.currentVersion.title}}</LinkTo>
+{{/if}}

--- a/app/components/regulatory-statement-link.js
+++ b/app/components/regulatory-statement-link.js
@@ -19,4 +19,10 @@ export default class RegulatoryStatementLinkComponent extends Component {
       return 'unknown';
     }
   }
+
+  get linkLabel() {
+    return (
+      this.args.label ?? this.args.documentContainer.currentVersion.get('title')
+    );
+  }
 }

--- a/app/components/regulatory-statement-link.js
+++ b/app/components/regulatory-statement-link.js
@@ -1,0 +1,22 @@
+import Component from '@glimmer/component';
+import {
+  DRAFT_STATUS_ID,
+  PUBLISHED_STATUS_ID,
+  PLANNED_STATUS_ID,
+} from 'frontend-gelinkt-notuleren/utils/constants';
+export default class RegulatoryStatementLinkComponent extends Component {
+  get editorStatus() {
+    const statusId = this.args.documentContainer.currentVersion
+      .get('status')
+      .get('id');
+    if (statusId == DRAFT_STATUS_ID) {
+      return 'draft';
+    } else if (statusId == PLANNED_STATUS_ID) {
+      return 'planned';
+    } else if (statusId == PUBLISHED_STATUS_ID) {
+      return 'published';
+    } else {
+      return 'unknown';
+    }
+  }
+}

--- a/app/routes/inbox/agendapoints.js
+++ b/app/routes/inbox/agendapoints.js
@@ -1,6 +1,11 @@
 import Route from '@ember/routing/route';
 import { EDITOR_FOLDERS } from '../../config/constants';
 import { inject as service } from '@ember/service';
+import {
+  DRAFT_STATUS_ID,
+  SCHEDULED_STATUS_ID,
+  PUBLISHED_STATUS_ID,
+} from '../../utils/constants';
 
 export default class InboxAgendapointsRoute extends Route {
   @service store;
@@ -16,8 +21,7 @@ export default class InboxAgendapointsRoute extends Route {
     const options = {
       sort: params.sort,
       include: 'status,current-version',
-      'filter[status][:id:]':
-        'a1974d071e6a47b69b85313ebdcef9f7,7186547b61414095aa2a4affefdcca67,ef8e4e331c31430bbdefcdb2bdfbcc06', // in voorbereiding, geagendeerd or published
+      'filter[status][:id:]': `${DRAFT_STATUS_ID},${SCHEDULED_STATUS_ID},${PUBLISHED_STATUS_ID}`,
       'filter[folder][:id:]': EDITOR_FOLDERS.DECISION_DRAFTS,
       page: {
         number: params.page,

--- a/app/routes/inbox/regulatory-statements.js
+++ b/app/routes/inbox/regulatory-statements.js
@@ -15,7 +15,7 @@ export default class InboxRegulatoryStatementsRoute extends Route {
   async model(params) {
     const options = {
       sort: params.sort,
-      include: 'status,current-version',
+      include: 'current-version,current-version.status',
       'filter[folder][:id:]': EDITOR_FOLDERS.REGULATORY_STATEMENTS,
       page: {
         number: params.page,

--- a/app/templates/inbox/regulatory-statements.hbs
+++ b/app/templates/inbox/regulatory-statements.hbs
@@ -47,7 +47,7 @@
     <c.body as |container|>
       {{#let container.currentVersion as |row|}}
         <td>
-          <AuLink @route="regulatory-statements.edit" @model={{container.id}}>{{row.title}}</AuLink>
+          <RegulatoryStatementLink @documentContainer={{container}} @readOnly={{this.readOnly}}/>
         </td>
         <td>
           {{human-friendly-date row.updatedOn}}

--- a/app/templates/regulatory-statements/show.hbs
+++ b/app/templates/regulatory-statements/show.hbs
@@ -1,6 +1,7 @@
 <AppChrome
   @editorDocument={{this.model.editorDocument}}
   @documentContainer={{this.model.documentContainer}}
+  @documentStatus={{this.model.documentContainer.currentVersion.status}}
 >
   <:return-link>
   <AuLink @route="inbox.regulatory-statements" @model={{@meetingId}}>
@@ -25,27 +26,12 @@
         {{#unless this.readOnly}}
           <div class="au-o-box au-o-box--small au-u-background-gray-100">
             <AuAlert @icon="info-circle" @title="Niet editeerbaar"  @skin="info" @size="small" class="au-u-margin-bottom-none">
-              <p>Dit artikel is reeds gepubliceerd. Gepubliceerde agendapunten zijn niet editeerbaar.</p>
+              <p>Dit reglement is reeds gepubliceerd. Gepubliceerde reglementaire bijlagen zijn niet editeerbaar.</p>
             </AuAlert>
           </div>
         {{/unless}}
         <div class="say-editor rdfa-annotations rdfa-annotations-hover rdfa-annotations--disabled">
           <div class="say-editor__paper">
-            {{#if this.copyAgendapunt.isRunning}}
-            <div class="au-c-scanner">
-              <div class="au-c-scanner__text">
-                <AuLoader @padding="small" />
-                <AuHelpText @size="large">
-                  {{#if this.saveTask.isRunning}}
-                    Bezig met opslaan
-                  {{else}}
-                    Kopie aan het maken
-                  {{/if}}
-                </AuHelpText>
-              </div>
-              <span class="au-c-scanner__bar"></span>
-            </div>
-            {{/if}}
             <div class="say-editor__inner say-content say-content--disabled">
               {{ this.model.editorDocument.htmlSafeContent }}
             </div>


### PR DESCRIPTION
This PR ensures that published regulatory statements are not editable. It also ensures that logged in, read-only users dont see the editable view.

This PR solves https://binnenland.atlassian.net/browse/GN-3835?atlOrigin=eyJpIjoiYjAzMWJiOGM5ZTBhNGM5OGJkNmI1YWRlNDdlMWYwYWUiLCJwIjoiaiJ9.