### PR TITLE
reset back to the url you were on after cancelling redirect

### DIFF
--- a/app/components/confirm-route-leave.js
+++ b/app/components/confirm-route-leave.js
@@ -29,6 +29,10 @@ export default class ConfirmRouteLeaveComponent extends Component {
       this.args.onCancel(transition);
     } else {
       transition.abort();
+
+      if (window.history) {
+        window.history.forward();
+      }
     }
   }
 


### PR DESCRIPTION
When cancelling the "are you sure you want to leave without saving" prompt when you click the browser back button, it should reset back to the url you were on.

https://user-images.githubusercontent.com/115715476/203875573-ce534561-dcf9-48b8-beb6-a5a548e2c62c.mp4


This fix is because of this issue: https://github.com/emberjs/ember.js/issues/18620 .

I also included a video, in which I tested every case I could think of. 