### PR TITLE
Fix weird title behaviour in regulatory statements edit page.

### DIFF
--- a/app/controllers/regulatory-statements/edit.js
+++ b/app/controllers/regulatory-statements/edit.js
@@ -1,5 +1,7 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
 import { PLUGIN_CONFIGS } from 'frontend-gelinkt-notuleren/config/constants';
 import { task } from 'ember-concurrency';
 import generateExportFromEditorDocument from 'frontend-gelinkt-notuleren/utils/generate-export-from-editor-document';
@@ -7,6 +9,7 @@ import { inject as service } from '@ember/service';
 
 export default class RegulatoryStatementsRoute extends Controller {
   @service documentService;
+  @tracked _editorDocument;
   editor;
   plugins = [
     'article-structure',


### PR DESCRIPTION
This PR ensures that the _editorDocument property is tracked in the regulatory statements edit page.
Fixes https://binnenland.atlassian.net/jira/software/c/projects/GN/boards/4?modal=detail&selectedIssue=GN-3826.