### PR TITLE
hotfix: remove empty decisions from document on save

### DIFF
--- a/app/controllers/agendapoints/edit.js
+++ b/app/controllers/agendapoints/edit.js
@@ -93,14 +93,32 @@ export default class AgendapointsEditController extends Controller {
     } else {
       this.hasDocumentValidationErrors = false;
       const html = this.editor.htmlContent;
+      const cleanedHtml = this.removeEmptyDivs(html);
+
       const editorDocument =
         yield this.documentService.createEditorDocument.perform(
           this.editorDocument.title,
-          html,
+          cleanedHtml,
           this.documentContainer,
           this.editorDocument
         );
       this._editorDocument = editorDocument;
     }
+  }
+
+  removeEmptyDivs(html) {
+    const parserInstance = new DOMParser();
+    const parsedHtml = parserInstance.parseFromString(html, 'text/html');
+    const body = parsedHtml.body.childNodes;
+
+    for (const child of body) {
+      if (child.attributes?.typeof?.textContent.includes('besluit:Besluit')) {
+        if (child.textContent.trim() === '') {
+          child.remove();
+        }
+      }
+    }
+
+    return parsedHtml.documentElement.lastChild.innerHTML;
   }
 }

--- a/app/controllers/agendapoints/edit.js
+++ b/app/controllers/agendapoints/edit.js
@@ -109,21 +109,18 @@ export default class AgendapointsEditController extends Controller {
   removeEmptyDivs(html) {
     const parserInstance = new DOMParser();
     const parsedHtml = parserInstance.parseFromString(html, 'text/html');
-    const body = parsedHtml.body.childNodes;
     const besluitIdentifiers = {
-      prefix: 'besluit:Besluit',
-      uri: 'https://data.vlaanderen.be/id/concept/BesluitType/',
+      prefixed: 'besluit:Besluit',
+      full: 'http://data.vlaanderen.be/ns/besluit#Besluit',
     };
-
-    for (const child of body) {
-      const textContent = child.attributes?.typeof?.textContent;
-      const { prefix, uri } = besluitIdentifiers;
-      if (textContent?.includes(prefix) && textContent?.includes(uri)) {
-        if (child.textContent.trim() === '') {
-          child.remove();
-        }
+    const besluitDivs = parsedHtml.querySelectorAll(
+      `div[typeof~="${besluitIdentifiers.prefixed}"], div[typeof~="${besluitIdentifiers.full}"]`
+    );
+    besluitDivs.forEach((besluitDiv) => {
+      if (besluitDiv.textContent.trim() === '') {
+        besluitDiv.remove();
       }
-    }
+    });
 
     return parsedHtml.body.innerHTML;
   }

--- a/app/controllers/agendapoints/edit.js
+++ b/app/controllers/agendapoints/edit.js
@@ -110,15 +110,21 @@ export default class AgendapointsEditController extends Controller {
     const parserInstance = new DOMParser();
     const parsedHtml = parserInstance.parseFromString(html, 'text/html');
     const body = parsedHtml.body.childNodes;
+    const besluitIdentifiers = {
+      prefix: 'besluit:Besluit',
+      uri: 'https://data.vlaanderen.be/id/concept/BesluitType/',
+    };
 
     for (const child of body) {
-      if (child.attributes?.typeof?.textContent.includes('besluit:Besluit')) {
+      const textContent = child.attributes?.typeof?.textContent;
+      const { prefix, uri } = besluitIdentifiers;
+      if (textContent?.includes(prefix) && textContent?.includes(uri)) {
         if (child.textContent.trim() === '') {
           child.remove();
         }
       }
     }
 
-    return parsedHtml.documentElement.lastChild.innerHTML;
+    return parsedHtml.body.innerHTML;
   }
 }


### PR DESCRIPTION
In order to prevent users from being able to create “faulty” documents by copy pasting etc, we would remove decisions that don’t have any content from the document when saving.