### PR TITLE
Hide empty voter divs in notulen preview

### DIFF
--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -671,3 +671,12 @@ div.table-of-contents {
     background-color: var(--au-blue-200);
   }
 }
+
+div[typeof="besluit:Zitting"] {
+  div[property="besluit:heeftStemming"] {
+    div[property="besluit:heeftVoorstander"], div[property="besluit:heeftTegenstander"], div[property="besluit:heeftOnthouder"] {
+      display: none;
+    }
+  }
+}
+


### PR DESCRIPTION
This PR adds some CSS (similar to the CSS on the publication environment) in order to hide empty voter divs included in the notulen preview.