### PR TITLE
Add case insensitive sorting to all text-based/title columns

### DIFF
--- a/app/components/agenda-manager/agenda-item-form/select-draft.js
+++ b/app/components/agenda-manager/agenda-item-form/select-draft.js
@@ -27,7 +27,7 @@ export default class AgendaManagerAgendaItemFormSelectDraftComponent extends Com
       include: 'current-version,status',
       'filter[status][:id:]': DRAFT_STATUS_ID,
       'filter[folder][:id:]': FOLDER_ID,
-      sort: 'current-version.title',
+      sort: ':no-case:current-version.title',
     };
     if (searchParams.length > 1) {
       query['filter[current-version][title]'] = searchParams;

--- a/app/components/editor-plugins/regulatory-statements/search-modal.js
+++ b/app/components/editor-plugins/regulatory-statements/search-modal.js
@@ -43,7 +43,7 @@ export default class RegulatoryStatementsSearchModalComponent extends Component 
         size: this.pageSize,
         number: this.page,
       },
-      sort: 'current-version.title',
+      sort: ':no-case:current-version.title',
     });
     this.regulatoryStatements.push(...regulatoryStatements.toArray());
     if (regulatoryStatements.meta.count <= this.regulatoryStatements.length) {

--- a/app/templates/inbox/agendapoints.hbs
+++ b/app/templates/inbox/agendapoints.hbs
@@ -27,9 +27,9 @@
   </table.menu>
   <table.content as |c|>
     <c.header>
-      <AuDataTableThSortable @field="currentVersion.title" @currentSorting={{this.sort}} @label={{t 'inbox.agendapoints.titleLabel'}} />
+      <AuDataTableThSortable @field=":no-case:currentVersion.title" @currentSorting={{this.sort}} @label={{t 'inbox.agendapoints.titleLabel'}} />
       <AuDataTableThSortable @field="currentVersion.updatedOn" @currentSorting={{this.sort}} @label={{t 'inbox.agendapoints.updatedOnLabel'}} />
-      <AuDataTableThSortable @field="status.label" @currentSorting={{this.sort}} @label={{t 'inbox.agendapoints.statusLabel'}} />
+      <AuDataTableThSortable @field=":no-case:status.label" @currentSorting={{this.sort}} @label={{t 'inbox.agendapoints.statusLabel'}} />
       <th><span class="au-c-data-table__header-title au-c-data-table__header-title--sortable">{{t 'inbox.meetings.type'}}</span></th>
       <th><span class="au-c-data-table__header-title au-c-data-table__header-title--sortable">{{t 'inbox.agendapoints.attachmentsLabel'}}</span></th>
     </c.header>

--- a/app/templates/inbox/irg-archive.hbs
+++ b/app/templates/inbox/irg-archive.hbs
@@ -20,7 +20,7 @@
   </table.menu>
   <table.content as |c|>
     <c.header>
-      <AuDataTableThSortable @field="currentVersion.title" @currentSorting={{this.sort}} @label={{t 'inbox.irgArchive.titleLabel'}} />
+      <AuDataTableThSortable @field=":no-case:currentVersion.title" @currentSorting={{this.sort}} @label={{t 'inbox.irgArchive.titleLabel'}} />
       <AuDataTableThSortable @field="currentVersion.type.label" @currentSorting={{this.sort}} @label={{t 'inbox.irgArchive.typeLabel'}} />
       <AuDataTableThSortable @field ="currentVersion.identifier" @currentSorting={{this.sort}} @label={{t 'inbox.irgArchive.identifierLabel'}} />
     </c.header>

--- a/app/templates/inbox/meetings.hbs
+++ b/app/templates/inbox/meetings.hbs
@@ -24,9 +24,9 @@
   <table.content as |c|>
     <c.header>
       <th><span class="au-c-data-table__header-title au-c-data-table__header-title--sortable">{{t 'inbox.meetings.type'}}</span></th>
-      <AuDataTableThSortable @field="bestuursorgaan.isTijdsspecialisatieVan.naam" @currentSorting={{this.sort}} @label={{t 'inbox.meetings.administrativeBody'}} />
+      <AuDataTableThSortable @field=":no-case:bestuursorgaan.isTijdsspecialisatieVan.naam" @currentSorting={{this.sort}} @label={{t 'inbox.meetings.administrativeBody'}} />
       <AuDataTableThSortable @field="geplandeStart" @currentSorting={{this.sort}} @label={{t 'inbox.meetings.time'}} />
-      <AuDataTableThSortable @field="opLocatie" @currentSorting={{this.sort}} @label={{t 'inbox.meetings.location'}} />
+      <AuDataTableThSortable @field=":no-case:opLocatie" @currentSorting={{this.sort}} @label={{t 'inbox.meetings.location'}} />
     </c.header>
     <c.body as |meeting|>
       <td>

--- a/app/templates/inbox/regulatory-statements.hbs
+++ b/app/templates/inbox/regulatory-statements.hbs
@@ -37,11 +37,11 @@
   </table.menu>
   <table.content as |c|>
     <c.header>
-      <AuDataTableThSortable @field="currentVersion.title" @currentSorting={{this.sort}} @label={{t
+      <AuDataTableThSortable @field=":no-case:currentVersion.title" @currentSorting={{this.sort}} @label={{t
         'inbox.regulatoryStatements.titleLabel'}} />
       <AuDataTableThSortable @field="currentVersion.updatedOn" @currentSorting={{this.sort}} @label={{t
         'inbox.regulatoryStatements.updatedOnLabel'}} />
-      <AuDataTableThSortable @field="currentVersion.status.label" @currentSorting={{this.sort}} @label={{t
+      <AuDataTableThSortable @field=":no-case:currentVersion.status.label" @currentSorting={{this.sort}} @label={{t
         'inbox.regulatoryStatements.statusLabel'}} />
     </c.header>
     <c.body as |container|>

--- a/app/templates/inbox/trash.hbs
+++ b/app/templates/inbox/trash.hbs
@@ -41,7 +41,7 @@
    </table.menu>
    <table.content as |c|>
     <c.header>
-      <AuDataTableThSortable @field="currentVersion.title" @currentSorting={{this.sort}} @label="Titel" />
+      <AuDataTableThSortable @field=":no-case:currentVersion.title" @currentSorting={{this.sort}} @label="Titel" />
       <AuDataTableThSortable @field="currentVersion.createdOn" @currentSorting={{this.sort}} @label="Aangemaakt" />
       <AuDataTableThSortable @field="currentVersion.updatedOn" @currentSorting={{this.sort}} @label="Aangepast" />
     </c.header>

--- a/app/templates/meetings/publish/uittreksels/index.hbs
+++ b/app/templates/meetings/publish/uittreksels/index.hbs
@@ -21,7 +21,7 @@
   <table.content as |c|>
     <c.header>
       <AuDataTableThSortable @field="position" @currentSorting={{this.sort}} @label={{t 'publish.position'}} />
-      <AuDataTableThSortable @field="titel" @currentSorting={{this.sort}} @label={{t 'publish.agendapoint'}} />
+      <AuDataTableThSortable @field=":no-case:titel" @currentSorting={{this.sort}} @label={{t 'publish.agendapoint'}} />
       <AuDataTableThSortable @field="behandeling.documentContainer.status" @currentSorting={{this.sort}} @label={{t 'publish.statusLabel'}} />
       <th></th>
     </c.header>


### PR DESCRIPTION
This PR ensures that most text-attributes (such as titles) are sorted in a case-insensitive way.
To be tested in combination with https://github.com/lblod/app-gelinkt-notuleren/pull/140.

Solves https://binnenland.atlassian.net/jira/software/c/projects/GN/boards/4?modal=detail&selectedIssue=GN-3912