### PR TITLE
Addition of not-found route

### DIFF
--- a/app/components/application-header.hbs
+++ b/app/components/application-header.hbs
@@ -1,0 +1,21 @@
+
+
+
+<AuMainHeader @brandLink="https://www.vlaanderen.be/nl" @homeRoute="index" @appTitle="Gelinkt Notuleren" @contactRoute="contact">
+  {{#if this.session.isAuthenticated}}
+  <AuDropdown @title="{{this.currentSession.user.voornaam}} {{this.currentSession.user.achternaam}} - {{this.currentSession.group.classificatie.label}} {{this.currentSession.group.naam}}" @buttonLabel="Account settings" @alignment="right">
+    <Acmidm::Switch as |acmidm|>
+      <AuButton @loading={{acmidm.isSwitching}} class="au-c-button au-c-button--tertiary" role="menuitem" {{on "click" acmidm.switch}}>
+        <AuIcon @icon="switch" @alignment="left" />Wissel van bestuurseenheid
+      </AuButton>
+    </Acmidm::Switch>
+    <button type="button" class="au-c-button au-c-button--tertiary" role="menuitem" {{on "click" this.logout}}>
+      <AuIcon @icon="logout" @alignment="left" />Afmelden
+    </button>
+  </AuDropdown>
+  {{else}}
+  <AcmidmLoginCompact @styles="au-c-button au-c-button--tertiary">
+    <AuIcon @icon="login" @alignment="left" />Aanmelden
+  </AcmidmLoginCompact>
+  {{/if}}
+</AuMainHeader>

--- a/app/components/application-header.js
+++ b/app/components/application-header.js
@@ -1,0 +1,12 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+
+export default class ApplicationHeaderComponent extends Component {
+  @service currentSession;
+  @service session;
+  @action
+  logout() {
+    this.session.invalidate();
+  }
+}

--- a/app/components/vo-page.hbs
+++ b/app/components/vo-page.hbs
@@ -1,9 +1,4 @@
-<AuMainHeader @brandLink="https://www.vlaanderen.be/nl" @homeRoute="index" @appTitle="Gelinkt Notuleren" @contactRoute="contact">
-  <AcmidmLoginCompact @styles="au-c-button au-c-button--tertiary">
-    <AuIcon @icon="login" @alignment="left" />Aanmelden
-  </AcmidmLoginCompact>
-</AuMainHeader>
-
+<ApplicationHeader/>
 {{!-- Refocus after page navigation --}}
 <NavigationNarrator />
 

--- a/app/router.js
+++ b/app/router.js
@@ -33,9 +33,6 @@ Router.map(function () {
   this.route('print', function () {
     this.route('uittreksel', { path: 'uittreksel/:meeting_id/:treatment_id' });
   });
-  this.route('route-not-found', {
-    path: '/*wildcard',
-  });
 
   this.route('import', function () {
     this.route('new');
@@ -83,4 +80,5 @@ Router.map(function () {
       }
     );
   });
+  this.route('not-found', { path: '/*path' });
 });

--- a/app/templates/inbox.hbs
+++ b/app/templates/inbox.hbs
@@ -1,15 +1,4 @@
-<AuMainHeader @homeRoute="index" @appTitle="Gelinkt Notuleren" @contactRoute="contact">
-  <AuDropdown @title="{{this.currentSession.user.voornaam}} {{this.currentSession.user.achternaam}} - {{this.currentSession.group.classificatie.label}} {{this.currentSession.group.naam}}" @buttonLabel="Account settings" @alignment="right">
-    <Acmidm::Switch as |acmidm|>
-      <AuButton @loading={{acmidm.isSwitching}} class="au-c-button au-c-button--tertiary" role="menuitem" {{on "click" acmidm.switch}}>
-        <AuIcon @icon="switch" @alignment="left" />Wissel van bestuurseenheid
-      </AuButton>
-    </Acmidm::Switch>
-    <button type="button" class="au-c-button au-c-button--tertiary" role="menuitem" {{on "click" this.logout}}>
-      <AuIcon @icon="logout" @alignment="left" />Afmelden
-    </button>
-  </AuDropdown>
-</AuMainHeader>
+<ApplicationHeader/>
 
 <AuMainContainer as |maincontainer|>
   <maincontainer.sidebar>

--- a/app/templates/not-found.hbs
+++ b/app/templates/not-found.hbs
@@ -1,0 +1,11 @@
+<VoPage>
+  <section class="au-o-region-large">
+    <div class="au-o-layout">
+        <AuAlert @title={{t "not-found.title"}} @icon="link-broken" @skin="warning">
+          <p>{{t "not-found.body.explanation"}}</p>
+          <p>{{t "not-found.body.contact-message"}} <AuLink @route="contact">{{t "not-found.body.contact-link"}}</AuLink></p>
+          <p>{{t "not-found.body.email-message"}} <a href="mailto:gelinktnotuleren@vlaanderen.be" class="au-c-link">GelinktNotuleren@vlaanderen.be</a></p>
+        </AuAlert>
+    </div>
+  </section>
+</VoPage>

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -296,6 +296,14 @@ meetings:
       saveAndQuit: Save and Quit
       cancel: Cancel
 
+not-found:
+  title: Page not found
+  body:
+    explanation: Our apologies, but we could not find this page.
+    contact-message: If you think this is a mistake, you can always contact us on our
+    contact-link: contact page
+    email-message: Or send a mail to
+
 participation:
   presentLabel: "Present mandatees:"
 

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -297,6 +297,14 @@ meetings:
       saveAndQuit: Opslaan en afsluiten
       cancel: Annuleren
 
+not-found:
+  title: Pagina niet gevonden
+  body:
+    explanation: Onze excuses, maar we slaagden er niet in om deze pagina terug te vinden.
+    contact-message: Indien u denk dat dit een fout is, kan u ons steeds contacteren op onze
+    contact-link: contact-pagina
+    email-message: Of stuur een mail naar
+
 participation:
   presentLabel: "Aanwezige mandatarissen:"
 

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -301,7 +301,7 @@ not-found:
   title: Pagina niet gevonden
   body:
     explanation: Onze excuses, maar we slaagden er niet in om deze pagina terug te vinden.
-    contact-message: Indien u denk dat dit een fout is, kan u ons steeds contacteren op onze
+    contact-message: Indien u denkt dat dit een fout is, kan u ons steeds contacteren op onze
     contact-link: contact-pagina
     email-message: Of stuur een mail naar
 


### PR DESCRIPTION
This PR does two things:
- Addition of an application-header component which either shows a login button, or the status of the currently logged in user, if there is one.
- Addition of a not-found route which matches either non-defined route path. It shows a message to a user and a link to the contact-page.

Partial solution to https://binnenland.atlassian.net/browse/GN-3989?atlOrigin=eyJpIjoiMmI3MmY1NmQxYWRkNDY4ODlkZTVmOGJkNGIyMGRjOWUiLCJwIjoiaiJ9.