### PR TITLE
Add error routes to agendapoints, regulatory statements, meetings and the irg-archive

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -18,7 +18,7 @@ async function retryOnError(ajax, ajaxArgs, retryCount = 0) {
       await sleep(250 * (retryCount + 1));
       return retryOnError(ajax, ajaxArgs, retryCount + 1);
     } else {
-      throw new Error(error);
+      throw error;
     }
   }
 }

--- a/app/components/not-found-warning.hbs
+++ b/app/components/not-found-warning.hbs
@@ -1,0 +1,13 @@
+<VoPage @showBanner={{false}}>
+  <section class="au-o-region-large">
+    <div class="au-o-layout">
+      <AuAlert @title={{@title}} @icon={{this.icon}} @skin={{this.skin}}>
+        <p>{{yield}}</p>
+        <p>{{t "not-found.body.contact-message"}} <AuLink @route="contact">{{t "not-found.body.contact-link"}}</AuLink>
+        </p>
+        <p>{{t "not-found.body.email-message"}} <a href="mailto:gelinktnotuleren@vlaanderen.be"
+            class="au-c-link">GelinktNotuleren@vlaanderen.be</a></p>
+      </AuAlert>
+    </div>
+  </section>
+</VoPage>

--- a/app/components/not-found-warning.js
+++ b/app/components/not-found-warning.js
@@ -1,0 +1,11 @@
+import Component from '@glimmer/component';
+
+export default class NotFoundWarningComponent extends Component {
+  get icon() {
+    return this.args.icon ?? 'link-broken';
+  }
+
+  get skin() {
+    return this.args.skin ?? 'warning';
+  }
+}

--- a/app/components/vo-page.hbs
+++ b/app/components/vo-page.hbs
@@ -6,10 +6,12 @@
   <div class="au-c-main-container__content au-c-main-container__content--scroll">
     <div class="page">
       <main id="content">
+        {{#if this.showBanner}}
         <AuContentHeader @titlePartOne="Vlaanderen" @titlePartTwo="is gelinkt notuleren">
           {{!-- template-lint-disable require-valid-alt-text  --}}
           <img sizes="50vw" src="/assets/images/loket-header-1600.jpg" srcset="/assets/images/loket-header-320.jpg 320w, /assets/images/loket-header-1024.jpg 1024w, /assets/images/loket-header-1600.jpg 1600w" alt="een laptop met daarop het vlaanderen logo.">
         </AuContentHeader>
+        {{/if}}
         {{yield}}
       </main>
     </div>

--- a/app/components/vo-page.js
+++ b/app/components/vo-page.js
@@ -1,0 +1,11 @@
+import Component from '@glimmer/component';
+
+export default class VoPageComponent extends Component {
+  get showBanner() {
+    if (this.args.showBanner === null || this.args.showBanner === undefined) {
+      return true;
+    } else {
+      return this.args.showBanner;
+    }
+  }
+}

--- a/app/routes/agendapoints.js
+++ b/app/routes/agendapoints.js
@@ -1,10 +1,9 @@
-import { action } from '@ember/object';
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
-
 export default class AgendapointsRoute extends Route {
   @service session;
   @service store;
+  @service router;
 
   queryParams = {
     returnToMeeting: { refreshModel: true },
@@ -25,15 +24,5 @@ export default class AgendapointsRoute extends Route {
       documentContainer: container,
       returnToMeeting: params.returnToMeeting,
     };
-  }
-
-  @action
-  error(error /*, transition */) {
-    if (error.errors && error.errors[0].status === '404') {
-      this.router.transitionTo('route-not-found');
-    } else {
-      // Let the route above this handle the error.
-      return true;
-    }
   }
 }

--- a/app/routes/regulatory-statements/edit.js
+++ b/app/routes/regulatory-statements/edit.js
@@ -1,6 +1,5 @@
 import RSVP from 'rsvp';
 import Route from '@ember/routing/route';
-import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 
 export default class RegulatoryStatementsEditRoute extends Route {
@@ -32,15 +31,5 @@ export default class RegulatoryStatementsEditRoute extends Route {
     super.setupController(controller, model);
     controller.uploading = false;
     controller._editorDocument = null;
-  }
-
-  @action
-  error(error /*, transition */) {
-    if (error.errors && error.errors[0].status === '404') {
-      this.router.transitionTo('route-not-found');
-    } else {
-      // Let the route above this handle the error.
-      return true;
-    }
   }
 }

--- a/app/templates/agendapoints-error.hbs
+++ b/app/templates/agendapoints-error.hbs
@@ -1,1 +1,3 @@
-<NotFoundWarning @icon="alert-triangle" @title={{t "agendapoint.not-found"}} />
+<NotFoundWarning @icon="alert-triangle" @title={{t "agendapoint.not-found.title"}}>
+  {{t "agendapoint.not-found.explanation"}}
+</NotFoundWarning>

--- a/app/templates/agendapoints-error.hbs
+++ b/app/templates/agendapoints-error.hbs
@@ -1,0 +1,1 @@
+<NotFoundWarning @icon="alert-triangle" @title={{t "agendapoint.not-found"}} />

--- a/app/templates/irg-archive/error.hbs
+++ b/app/templates/irg-archive/error.hbs
@@ -1,0 +1,1 @@
+<NotFoundWarning @icon="alert-triangle" @title={{t "irg-archive.not-found"}} />

--- a/app/templates/irg-archive/error.hbs
+++ b/app/templates/irg-archive/error.hbs
@@ -1,1 +1,3 @@
-<NotFoundWarning @icon="alert-triangle" @title={{t "irg-archive.not-found"}} />
+<NotFoundWarning @icon="alert-triangle" @title={{t "irg-archive.not-found.title"}}>
+  {{t "irg-archive.not-found.explanation"}}
+</NotFoundWarning>

--- a/app/templates/meetings/error.hbs
+++ b/app/templates/meetings/error.hbs
@@ -1,0 +1,1 @@
+<NotFoundWarning @icon="alert-triangle" @title={{t "meetings.not-found"}} />

--- a/app/templates/meetings/error.hbs
+++ b/app/templates/meetings/error.hbs
@@ -1,1 +1,3 @@
-<NotFoundWarning @icon="alert-triangle" @title={{t "meetings.not-found"}} />
+<NotFoundWarning @icon="alert-triangle" @title={{t "meetings.not-found.title"}}>
+  {{t "meetings.not-found.explanation"}}
+</NotFoundWarning>

--- a/app/templates/not-found.hbs
+++ b/app/templates/not-found.hbs
@@ -1,11 +1,3 @@
-<VoPage>
-  <section class="au-o-region-large">
-    <div class="au-o-layout">
-        <AuAlert @title={{t "not-found.title"}} @icon="link-broken" @skin="warning">
-          <p>{{t "not-found.body.explanation"}}</p>
-          <p>{{t "not-found.body.contact-message"}} <AuLink @route="contact">{{t "not-found.body.contact-link"}}</AuLink></p>
-          <p>{{t "not-found.body.email-message"}} <a href="mailto:gelinktnotuleren@vlaanderen.be" class="au-c-link">GelinktNotuleren@vlaanderen.be</a></p>
-        </AuAlert>
-    </div>
-  </section>
-</VoPage>
+<NotFoundWarning @title={{t "not-found.title" }}>
+  {{t "not-found.body.explanation"}}
+</NotFoundWarning>

--- a/app/templates/regulatory-statements/error.hbs
+++ b/app/templates/regulatory-statements/error.hbs
@@ -1,0 +1,1 @@
+<NotFoundWarning @icon="alert-triangle" @title={{t "regulatory-statements.not-found"}} />

--- a/app/templates/regulatory-statements/error.hbs
+++ b/app/templates/regulatory-statements/error.hbs
@@ -1,1 +1,3 @@
-<NotFoundWarning @icon="alert-triangle" @title={{t "regulatory-statements.not-found"}} />
+<NotFoundWarning @icon="alert-triangle" @title={{t "regulatory-statements.not-found.title"}}>
+  {{t "regulatory-statements.not-found.explanation"}}
+</NotFoundWarning>

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -2,7 +2,10 @@ agendapoint:
   revisions: Revisions
   restore: Restore
   backToMeeting: Return to the meeting of {adminBody} on {date}
-  not-found: Agendapoint not found
+  not-found: 
+    title: Agendapoint not found
+    explanation: It's possible that you don't have access to the agendapoint with this account
+
 
 appChrome:
   copyAgendapoint: Copy Agendapoint
@@ -157,7 +160,9 @@ inbox:
     restoreMessage: Restore selected documents
 
 irg-archive:
-  not-found: Reglement not found
+  not-found: 
+    title: Reglement not found
+    explanation: It's possible that you don't have access to the reglement with this account
 
 manageAgendaZitting:
   titelLabel: Title
@@ -299,7 +304,10 @@ meetings:
       confirmQuitWithoutSaving: Are you sure you want to leave the page without saving your changes?
       saveAndQuit: Save and Quit
       cancel: Cancel
-  not-found: Meeting not found
+  not-found: 
+    title: Meeting not found
+    explanation: It's possible that you don't have access to the meeting with this account
+
 
 
 not-found:
@@ -398,7 +406,10 @@ rdfaEditorContainer:
   makingCopy: Making copy
 
 regulatory-statements:
-  not-found: Regulatory statement not found
+  not-found: 
+    title: Regulatory statement not found
+    explanation: It's possible that you don't have access to the regulatory statement with this account
+
 
 regulatoryStatementsPlugin:
   regulatoryStatement: Regulatory Statement

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -2,6 +2,7 @@ agendapoint:
   revisions: Revisions
   restore: Restore
   backToMeeting: Return to the meeting of {adminBody} on {date}
+  not-found: Agendapoint not found
 
 appChrome:
   copyAgendapoint: Copy Agendapoint
@@ -155,6 +156,9 @@ inbox:
     searchPlaceholder: Type the title of an agendapoint
     restoreMessage: Restore selected documents
 
+irg-archive:
+  not-found: Reglement not found
+
 manageAgendaZitting:
   titelLabel: Title
   beschrijvingLabel: Description
@@ -295,6 +299,8 @@ meetings:
       confirmQuitWithoutSaving: Are you sure you want to leave the page without saving your changes?
       saveAndQuit: Save and Quit
       cancel: Cancel
+  not-found: Meeting not found
+
 
 not-found:
   title: Page not found
@@ -390,6 +396,9 @@ rdfaEditorContainer:
   defaultBusyText: Processing
   saving: Saving
   makingCopy: Making copy
+
+regulatory-statements:
+  not-found: Regulatory statement not found
 
 regulatoryStatementsPlugin:
   regulatoryStatement: Regulatory Statement

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -2,7 +2,9 @@ agendapoint:
   revisions: Versies
   restore: Herstel
   backToMeeting: Terug naar zitting van {adminBody} op {date}
-  not-found: Agendapunt niet gevonden
+  not-found:
+    title: Agendapunt niet gevonden
+    explanation: Het is mogelijk dat u met dit account geen toegang heeft tot het agendapunt.
 
 appChrome:
   copyAgendapoint: Kopieer agendapunt
@@ -157,7 +159,10 @@ inbox:
     restoreMessage: Herstel geselecteerde documenten
 
 irg-archive:
-  not-found: Reglement niet gevonden
+  not-found: 
+    title: Reglement niet gevonden
+    explanation: Het is mogelijk dat u met dit account geen toegang heeft tot het reglement.
+
 
 manageAgendaZitting:
   titelLabel: Titel
@@ -300,7 +305,10 @@ meetings:
       confirmQuitWithoutSaving: Bent u zeker dat u deze pagina wilt verlaten zonder uw wijzigingen op te slaan?
       saveAndQuit: Opslaan en afsluiten
       cancel: Annuleren
-  not-found: Zitting niet gevonden
+  not-found: 
+    title: Zitting niet gevonden
+    explanation: Het is mogelijk dat u met dit account geen toegang heeft tot de zitting.
+
 
 
 not-found:
@@ -399,7 +407,9 @@ rdfaEditorContainer:
   makingCopy: Kopie aan het maken
 
 regulatory-statements:
-  not-found: Reglementaire bijlage niet gevonden
+  not-found: 
+    title: Reglementaire bijlage niet gevonden
+    explanation: Het is mogelijk dat u met dit account geen toegang heeft tot de reglementaire bijlage.
 
 regulatoryStatementsPlugin:
   regulatoryStatement: Reglement

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -2,6 +2,7 @@ agendapoint:
   revisions: Versies
   restore: Herstel
   backToMeeting: Terug naar zitting van {adminBody} op {date}
+  not-found: Agendapunt niet gevonden
 
 appChrome:
   copyAgendapoint: Kopieer agendapunt
@@ -155,6 +156,9 @@ inbox:
     searchPlaceholder: Zoek titel agendapunt
     restoreMessage: Herstel geselecteerde documenten
 
+irg-archive:
+  not-found: Reglement niet gevonden
+
 manageAgendaZitting:
   titelLabel: Titel
   beschrijvingLabel: Beschrijving
@@ -296,6 +300,8 @@ meetings:
       confirmQuitWithoutSaving: Bent u zeker dat u deze pagina wilt verlaten zonder uw wijzigingen op te slaan?
       saveAndQuit: Opslaan en afsluiten
       cancel: Annuleren
+  not-found: Zitting niet gevonden
+
 
 not-found:
   title: Pagina niet gevonden
@@ -391,6 +397,9 @@ rdfaEditorContainer:
   defaultBusyText: Bezig met verwerken
   saving: Bezig met opslaan
   makingCopy: Kopie aan het maken
+
+regulatory-statements:
+  not-found: Reglementaire bijlage niet gevonden
 
 regulatoryStatementsPlugin:
   regulatoryStatement: Reglement


### PR DESCRIPTION
This PR ensures that an error message is shown to the user when a document could not be fetched.
Partial solution to https://binnenland.atlassian.net/browse/GN-3989?atlOrigin=eyJpIjoiNGQ0OTg0ZWNhYjkxNDVhMGE5MmYwN2RjZGVlZjQ1ZTciLCJwIjoiaiJ9.