### PR TITLE
GN-4100: House logo POC

### DIFF
--- a/app/components/preview-header-image.hbs
+++ b/app/components/preview-header-image.hbs
@@ -1,0 +1,3 @@
+{{#if this.url}}
+    <img class="au-c-header-image" src="{{this.url}}" alt="{{t "administrative-unit"}}" />
+{{/if}}

--- a/app/components/preview-header-image.js
+++ b/app/components/preview-header-image.js
@@ -1,0 +1,10 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+
+export default class PreviewHeaderImageComponent extends Component {
+  @service currentSession;
+
+  get url() {
+    return this.currentSession.groupLogoUrl;
+  }
+}

--- a/app/controllers/meetings/publish/notulen.js
+++ b/app/controllers/meetings/publish/notulen.js
@@ -5,6 +5,7 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 
 export default class MeetingsPublishNotulenController extends Controller {
+  @service currentSession;
   @service store;
   @service publish;
   @service muTask;
@@ -189,18 +190,39 @@ export default class MeetingsPublishNotulenController extends Controller {
           method: 'POST',
         }
       );
+
+      const headerImageHTML = this.headerImageHTML;
       const previewHtml = json.data.attributes.html;
-      this.preview = previewHtml;
+
+      this.preview = `${headerImageHTML || ''}${previewHtml}`;
     } catch (e) {
       console.error(e);
       this.errors = [JSON.stringify(e)];
     }
   }
 
+  get headerImageHTML() {
+    if (!this.currentSession.groupLogoUrl) {
+      return null;
+    }
+
+    const imageElement = document.createElement('img');
+    imageElement.setAttribute('src', this.currentSession.groupLogoUrl);
+    imageElement.classList.add('au-c-header-image');
+
+    const headerImageHTML = imageElement.outerHTML;
+
+    return headerImageHTML;
+  }
+
+  get notulenContentWithHeaderImage() {
+    return `${this.headerImageHTML || ''}${this.notulen?.content || ''}`;
+  }
+
   get zittingWrapper() {
-    if (this.notulen?.content) {
+    if (this.notulenContentWithHeaderImage) {
       const div = document.createElement('div');
-      div.innerHTML = this.notulen.content;
+      div.innerHTML = this.notulenContentWithHeaderImage;
 
       const bvapContainer = div.querySelector(
         "[property='http://mu.semte.ch/vocabularies/ext/behandelingVanAgendapuntenContainer']"

--- a/app/controllers/meetings/publish/notulen.js
+++ b/app/controllers/meetings/publish/notulen.js
@@ -5,7 +5,6 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 
 export default class MeetingsPublishNotulenController extends Controller {
-  @service currentSession;
   @service store;
   @service publish;
   @service muTask;
@@ -190,39 +189,18 @@ export default class MeetingsPublishNotulenController extends Controller {
           method: 'POST',
         }
       );
-
-      const headerImageHTML = this.headerImageHTML;
       const previewHtml = json.data.attributes.html;
-
-      this.preview = `${headerImageHTML || ''}${previewHtml}`;
+      this.preview = previewHtml;
     } catch (e) {
       console.error(e);
       this.errors = [JSON.stringify(e)];
     }
   }
 
-  get headerImageHTML() {
-    if (!this.currentSession.groupLogoUrl) {
-      return null;
-    }
-
-    const imageElement = document.createElement('img');
-    imageElement.setAttribute('src', this.currentSession.groupLogoUrl);
-    imageElement.classList.add('au-c-header-image');
-
-    const headerImageHTML = imageElement.outerHTML;
-
-    return headerImageHTML;
-  }
-
-  get notulenContentWithHeaderImage() {
-    return `${this.headerImageHTML || ''}${this.notulen?.content || ''}`;
-  }
-
   get zittingWrapper() {
-    if (this.notulenContentWithHeaderImage) {
+    if (this.notulen?.content) {
       const div = document.createElement('div');
-      div.innerHTML = this.notulenContentWithHeaderImage;
+      div.innerHTML = this.notulen.content;
 
       const bvapContainer = div.querySelector(
         "[property='http://mu.semte.ch/vocabularies/ext/behandelingVanAgendapuntenContainer']"

--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -9,6 +9,10 @@ export default class CurrentSessionService extends Service {
   @tracked account;
   @tracked user;
   @tracked group;
+  // Ideally this should be part of `group` itself
+  // I'm just putting it into the `CurrentSessionService` for the POC,
+  // to indicate that this will be the place where we'll be retrieving the logo from
+  @tracked groupLogoUrl;
   @tracked roles = [];
 
   get canRead() {
@@ -40,6 +44,10 @@ export default class CurrentSessionService extends Service {
       this.group = await this.store.findRecord('bestuurseenheid', groupId, {
         include: 'classificatie',
       });
+
+      this.groupLogoUrl =
+        'https://stad.gent/sites/default/files/media/images/logoGent_c100.png';
+
       this.roles = this.session.data.authenticated.data.attributes.roles;
     }
   }

--- a/app/styles/project/_c-template.scss
+++ b/app/styles/project/_c-template.scss
@@ -407,3 +407,7 @@
 .au-c-toolbar__group--vertical {
   flex-direction: column;
 }
+
+.au-c-header-image {
+  height: 90px;
+}

--- a/app/templates/meetings/publish/notulen.hbs
+++ b/app/templates/meetings/publish/notulen.hbs
@@ -12,8 +12,9 @@
       {{#if this.loadNotulen.isIdle}}
         {{!-- cheating with status here, because signing doesn't affect preview --}}
         <PublicationPreview @title="Voorvertoning notulen" @status={{if (eq this.status "published") "published" "concept"}}>
+          <PreviewHeaderImage/>
           {{#if (eq this.status 'published')}}
-            {{html-safe this.notulenContentWithHeaderImage}}
+            {{html-safe this.notulen.content}}
           {{else}}
             {{html-safe this.zittingWrapper}}
           {{/if}}
@@ -58,7 +59,8 @@
               @confirm={{perform this.createSignedResource}}
               @cancel={{fn (mut this.showSigningModal) false}}
             >
-              {{html-safe this.notulenContentWithHeaderImage}}
+              <PreviewHeaderImage/>
+              {{html-safe this.notulen.content}}
             </Signatures::SignatureConfirmation>
           {{/if}}
           {{!-- publish --}}
@@ -77,6 +79,7 @@
               @cancel={{fn (mut this.showPublishingModal) false}}
             >
               {{#if this.createPublishPreview.isIdle}}
+                <PreviewHeaderImage/>
                 {{html-safe this.preview}}
               {{else}}
                 <AuHelpText @size="large">{{t "publish.loading-message"}}</AuHelpText>

--- a/app/templates/meetings/publish/notulen.hbs
+++ b/app/templates/meetings/publish/notulen.hbs
@@ -13,7 +13,7 @@
         {{!-- cheating with status here, because signing doesn't affect preview --}}
         <PublicationPreview @title="Voorvertoning notulen" @status={{if (eq this.status "published") "published" "concept"}}>
           {{#if (eq this.status 'published')}}
-            {{html-safe this.notulen.content}}
+            {{html-safe this.notulenContentWithHeaderImage}}
           {{else}}
             {{html-safe this.zittingWrapper}}
           {{/if}}
@@ -58,7 +58,7 @@
               @confirm={{perform this.createSignedResource}}
               @cancel={{fn (mut this.showSigningModal) false}}
             >
-              {{html-safe this.notulen.content}}
+              {{html-safe this.notulenContentWithHeaderImage}}
             </Signatures::SignatureConfirmation>
           {{/if}}
           {{!-- publish --}}


### PR DESCRIPTION
Adds a House (Government) logo visible in the Notulen part 

* Notulen preview
* Signature view
* Publication preview


https://user-images.githubusercontent.com/769698/219297406-9ec24df6-cdb8-4892-96f8-aacb3a28c08c.mp4



---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>


> 
> #### What changed
> - Added `@service currentSession` to `MeetingsPublishNotulenController`
> - Added `headerImageHTML` method to `MeetingsPublishNotulenController`
> - Added `groupLogoUrl` property to `CurrentSessionService`
> - Added `notulenContentWithHeaderImage` method to `MeetingsPublishNotulenController`
> - Changed `zittingWrapper` method to use `notulenContentWithHeaderImage`
> - Changed `PublicationPreview` to use `notulenContentWithHeaderImage`
> - Added `.au-c-header-image` class to `project/_c-template.scss`
> 
> #### Impact
> This diff adds a header image to the preview and published version of the notulen.
> 
> #### Testing
> This diff could be tested by verifying that the header image is visible in the preview and published version of the notulen.
</details>