### PR TITLE
Update internal regulatory statement to support new editor API

### DIFF
--- a/app/components/editor-plugins/regulatory-statements/search-modal.hbs
+++ b/app/components/editor-plugins/regulatory-statements/search-modal.hbs
@@ -60,41 +60,39 @@
         </div>
       </mc.sidebar>
       <mc.content>
-        <AuBodyContainer @scroll={{false}}>
-          <div class="say-container">
-            {{#if this.selectedStatement}}
-              <div class="say-container__main">
-                <div class="say-editor">
-                  <div class="say-editor__inner say-content">
-                    {{this.selectedStatement.currentVersion.htmlSafeContent}}
-                  </div>
+        <AuBodyContainer @scroll={{true}}>
+          {{#if this.selectedStatement}}
+            <div class="say-container__main">
+              <div class="say-editor">
+                <div class="say-editor__inner say-content">
+                  {{this.selectedStatement.currentVersion.htmlSafeContent}}
                 </div>
               </div>
-            {{else}}
-              <AuAlert
-                @title="{{t "regulatory-statements-plugin.no-statement-selected"}}"
-                @skin="info"
-                @icon="info-circle"
-                @size="default"
-                @closable={{false}}
-                class="au-u-margin-small">
-              </AuAlert>
-            {{/if}}
-          </div>
-          <div class="au-c-modal__footer">
-            <AuToolbar>
-              <AuToolbar::Group>
-                <AuButton @skin="link" {{on "click" @closeModal}}>{{t "regulatory-statements-plugin.cancel"}}</AuButton>
-              </AuToolbar::Group>
-              <AuToolbar::Group>
-                <AuButton @disabled={{or (not this.selectedStatement) (this.isInserted this.selectedStatement)}} {{on "click" (fn @insertStatement
-                  this.selectedStatement)}}>
-                  {{t "regulatory-statements-plugin.insert-statement"}}
-                </AuButton>
-              </AuToolbar::Group>
-            </AuToolbar>
-          </div>
+            </div>
+          {{else}}
+            <AuAlert
+              @title="{{t "regulatory-statements-plugin.no-statement-selected"}}"
+              @skin="info"
+              @icon="info-circle"
+              @size="default"
+              @closable={{false}}
+              class="au-u-margin-small">
+            </AuAlert>
+          {{/if}}
         </AuBodyContainer>
+        <div class="au-c-modal__footer">
+          <AuToolbar>
+            <AuToolbar::Group>
+              <AuButton @skin="link" {{on "click" @closeModal}}>{{t "regulatory-statements-plugin.cancel"}}</AuButton>
+            </AuToolbar::Group>
+            <AuToolbar::Group>
+              <AuButton @disabled={{or (not this.selectedStatement) (this.isInserted this.selectedStatement)}} {{on "click" (fn @insertStatement
+                this.selectedStatement)}}>
+                {{t "regulatory-statements-plugin.insert-statement"}}
+              </AuButton>
+            </AuToolbar::Group>
+          </AuToolbar>
+        </div>
       </mc.content>
     </AuMainContainer>
   </modal.Body>

--- a/app/components/editor-plugins/regulatory-statements/search-modal.hbs
+++ b/app/components/editor-plugins/regulatory-statements/search-modal.hbs
@@ -46,10 +46,10 @@
               </ul>
             {{else}}
               <AuAlert
-                @alertTitle="No statements found"
-                @alertSkin="warning"
-                @alertIcon="cross"
-                @alertSize="small"
+                @title={{t 'regulatory-statements-plugin.no-statement-found'}}
+                @skin="warning"
+                @icon="cross"
+                @size="small"
                 @closable={{false}}>
               </AuAlert>
             {{/if}}
@@ -72,10 +72,10 @@
               </div>
             {{else}}
               <AuAlert
-                @alertTitle="{{t "regulatory-statements-plugin.no-statement-selected"}}"
-                @alertSkin="info"
-                @alertIcon="info-circle"
-                @alertSize="default"
+                @title="{{t "regulatory-statements-plugin.no-statement-selected"}}"
+                @skin="info"
+                @icon="info-circle"
+                @size="default"
                 @closable={{false}}
                 class="au-u-margin-small">
               </AuAlert>

--- a/app/components/editor-plugins/regulatory-statements/sidebar-insert.js
+++ b/app/components/editor-plugins/regulatory-statements/sidebar-insert.js
@@ -11,7 +11,7 @@ export default class RegulatoryStatementsSidebarInsertComponent extends Componen
   }
 
   get insertRange() {
-    const selection = this.controller.state.selection;
+    const selection = this.controller.mainEditorState.selection;
     const besluit = findParentNodeOfType(this.controller.schema.nodes.besluit)(
       selection
     );
@@ -37,15 +37,18 @@ export default class RegulatoryStatementsSidebarInsertComponent extends Componen
     this.modalEnabled = false;
     if (this.insertRange) {
       const { schema } = this.controller;
-      this.controller.withTransaction((tr) => {
-        return tr.replaceRangeWith(
-          this.insertRange.from,
-          this.insertRange.to,
-          schema.node('regulatoryStatementNode', {
-            resource: statement.uri,
-          })
-        );
-      });
+      this.controller.withTransaction(
+        (tr) => {
+          return tr.replaceRangeWith(
+            this.insertRange.from,
+            this.insertRange.to,
+            schema.node('regulatoryStatementNode', {
+              resource: statement.uri,
+            })
+          );
+        },
+        { view: this.controller.mainEditorView }
+      );
     }
   }
 }

--- a/app/components/editor-plugins/regulatory-statements/view.hbs
+++ b/app/components/editor-plugins/regulatory-statements/view.hbs
@@ -14,8 +14,8 @@
       </Group>
       <Group>
         <AuButtonGroup>
-          {{#if this.documentContainer}}
-          <RegulatoryStatementLink @icon="pencil" @documentContainer={{this.documentContainer}} @label={{t "regulatory-statements-plugin.edit-statement"}}/>
+          {{#if this.regulatoryStatementContainer}}
+          <RegulatoryStatementLink @icon="pencil" @documentContainer={{this.regulatoryStatementContainer}} @label={{t "regulatory-statements-plugin.edit-statement"}}/>
           {{/if}}
           <AuButton @skin="naked" @icon="link-broken" @alert="true" {{on "click" this.detach}}>
             {{t "regulatory-statements-plugin.detach-statement"}}

--- a/app/components/editor-plugins/regulatory-statements/view.js
+++ b/app/components/editor-plugins/regulatory-statements/view.js
@@ -53,11 +53,14 @@ export default class ReadOnlyContentSectionComponent extends Component {
 
   @action
   detach() {
-    this.controller.withTransaction((tr) => {
-      return tr.delete(
-        this.args.getPos(),
-        this.args.getPos() + this.args.node.nodeSize
-      );
-    });
+    this.controller.withTransaction(
+      (tr) => {
+        return tr.delete(
+          this.args.getPos(),
+          this.args.getPos() + this.args.node.nodeSize
+        );
+      },
+      { view: this.controller.mainEditorView }
+    );
   }
 }

--- a/app/templates/agendapoints/edit.hbs
+++ b/app/templates/agendapoints/edit.hbs
@@ -91,6 +91,7 @@
         />
         <RoadsignRegulationPlugin::RoadsignRegulationCard @controller={{this.controller}}/>
         <StandardTemplatePlugin::Card @controller={{this.controller}}/>
+        <EditorPlugins::RegulatoryStatements::SidebarInsert @controller={{this.controller}}/>
     </:sidebar-collapsible>
     <:sidebar>
       <ArticleStructurePlugin::StructureCard 

--- a/app/templates/agendapoints/edit.hbs
+++ b/app/templates/agendapoints/edit.hbs
@@ -91,7 +91,9 @@
         />
         <RoadsignRegulationPlugin::RoadsignRegulationCard @controller={{this.controller}}/>
         <StandardTemplatePlugin::Card @controller={{this.controller}}/>
-        <EditorPlugins::RegulatoryStatements::SidebarInsert @controller={{this.controller}}/>
+        {{#if (feature-flag 'regulatoryStatements')}}
+          <EditorPlugins::RegulatoryStatements::SidebarInsert @controller={{this.controller}}/>
+        {{/if}}
     </:sidebar-collapsible>
     <:sidebar>
       <ArticleStructurePlugin::StructureCard 

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -514,6 +514,7 @@ regulatory-statements-plugin:
   last-modification: Last modified
   loading: Loading
   no-statement-selected: No regulatory statement selected
+  no-statement-found: No regulatory statements found
   edit-statement: Edit
   detach-statement: Detach
   load-more: Load more

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -513,6 +513,7 @@ regulatory-statements-plugin:
   last-modification: Laatst aangepast
   loading: Aan het laden
   no-statement-selected: Geen reglement geselecteerd
+  no-statement-found: Geen reglementen gevonden
   edit-statement: Bewerk
   detach-statement: Loskoppelen
   load-more: Meer laden


### PR DESCRIPTION
This PR includes the following fixes/updates:
- Update of `AuAlert` components in regulatory-statement search-modal
- Fix issue with document content overflowing in regulatory-statement search-modal
- Fix issue with edit button not showing on regulatory-statement view
- Update regulatory-statement plugin to use the new editor API