### PR TITLE
Fix schema of zitting-text component

### DIFF
--- a/app/components/zitting-text-document-container.js
+++ b/app/components/zitting-text-document-container.js
@@ -8,7 +8,11 @@ import {
   strikethrough,
   strong,
   underline,
+  subscript,
+  superscript,
 } from '@lblod/ember-rdfa-editor/plugins/text-style';
+import { highlight } from '@lblod/ember-rdfa-editor/plugins/highlight/marks/highlight';
+import { color } from '@lblod/ember-rdfa-editor/plugins/color/marks/color';
 import {
   block_rdfa,
   hard_break,
@@ -66,6 +70,46 @@ export default class ZittingTextDocumentContainerComponent extends Component {
     showSidebar: true,
   };
 
+  schema = new Schema({
+    nodes: {
+      doc,
+      paragraph,
+      repaired_block,
+      list_item,
+      ordered_list,
+      bullet_list,
+      placeholder,
+      ...tableNodes({ tableGroup: 'block', cellContent: 'block+' }),
+      date: date({
+        placeholder: {
+          insertDate: this.intl.t('date-plugin.insert.date'),
+          insertDateTime: this.intl.t('date-plugin.insert.datetime'),
+        },
+      }),
+      heading,
+      blockquote,
+      horizontal_rule,
+      code_block,
+      text,
+      image,
+      hard_break,
+      invisible_rdfa,
+      block_rdfa,
+      link: link(this.config.link),
+    },
+    marks: {
+      inline_rdfa,
+      em,
+      strong,
+      underline,
+      strikethrough,
+      subscript,
+      superscript,
+      highlight,
+      color,
+    },
+  });
+
   get text() {
     const zitting = this.args.zitting;
     if (this.type === 'ext:intro') {
@@ -93,44 +137,6 @@ export default class ZittingTextDocumentContainerComponent extends Component {
     editor.setHtmlContent(this.text);
     this.editor = editor;
     this.args.onEditorInit(editor);
-  }
-
-  get schema() {
-    return new Schema({
-      nodes: {
-        doc,
-        paragraph,
-        repaired_block,
-        list_item,
-        ordered_list,
-        bullet_list,
-        placeholder,
-        ...tableNodes({ tableGroup: 'block', cellContent: 'block+' }),
-        date: date({
-          placeholder: {
-            insertDate: this.intl.t('date-plugin.insert.date'),
-            insertDateTime: this.intl.t('date-plugin.insert.datetime'),
-          },
-        }),
-        heading,
-        blockquote,
-        horizontal_rule,
-        code_block,
-        text,
-        image,
-        hard_break,
-        invisible_rdfa,
-        block_rdfa,
-        link: link(this.config.link),
-      },
-      marks: {
-        inline_rdfa,
-        em,
-        strong,
-        underline,
-        strikethrough,
-      },
-    });
   }
 
   get config() {


### PR DESCRIPTION
This PR adds a few different missing marks to the `zitting-text-document-container` component. These missing marks were causing errors when opening the meeting `intro` or `outro` modals. The toolbar tried to display widgets which used marks which were not included in the schema. Maybe an idea: we could check for the existing of the node_spec/mark_spec a widget uses inside the widget itself, so it disables itself when the mark/node spec is not defined.

Additionally this PR converts the dynamic `schema` getter of the  `zitting-text-document-container` component to a normal property to prevent duplicate instantiation of the schema object. This also solves https://binnenland.atlassian.net/browse/GN-4206?atlOrigin=eyJpIjoiYjRjYTU2ZDhiMzYzNDgwNDgyY2UxNjMyNjFmOTA5ZDkiLCJwIjoiaiJ9.