### PR TITLE
avoid saving editor document title without changes

### DIFF
--- a/app/components/editor-document-title.hbs
+++ b/app/components/editor-document-title.hbs
@@ -26,6 +26,7 @@
           @skin="secondary"
           @icon="check"
           @hideText={{true}}
+          @disabled={{not this.titleModified}}
         >{{t "editor-document-title.change-title"}}</AuButton>
       </div>
     </form>

--- a/app/components/editor-document-title.hbs
+++ b/app/components/editor-document-title.hbs
@@ -35,6 +35,14 @@
       {{limit-content this.title 70}} 
       <AuButton {{on "click" this.toggleActive}} @icon="pencil" @skin="tertiary" @hideText={{true}} >{{t "editor-document-title.change-title"}}</AuButton>
     </h1>
+    {{#if this.showSaved}}
+      <AuPill
+        @skin="success"
+        @icon="check"
+      >
+        {{t "editor-document-title.saved"}}
+      </AuPill>
+    {{/if}}
   {{/if}}
 
 {{/if}}

--- a/app/components/editor-document-title.hbs
+++ b/app/components/editor-document-title.hbs
@@ -40,7 +40,7 @@
         @skin="success"
         @icon="check"
       >
-        {{t "editor-document-title.saved"}}
+        {{t "editor-document-title.title-saved"}}
       </AuPill>
     {{/if}}
   {{/if}}

--- a/app/components/editor-document-title.js
+++ b/app/components/editor-document-title.js
@@ -6,6 +6,7 @@ export default class EditorDocumentTitleComponent extends Component {
   @tracked active = false;
   @tracked error = false;
   @tracked _title;
+  @tracked showSaved = false;
   constructor() {
     super(...arguments);
     this.active = this.args.editActive;
@@ -41,6 +42,8 @@ export default class EditorDocumentTitleComponent extends Component {
     event.preventDefault();
     this.args.onSubmit?.(this.title);
     this.toggleActive();
+    this.showSaved = true;
+    setTimeout(() => (this.showSaved = false), 30000);
     return false;
   }
 

--- a/app/components/editor-document-title.js
+++ b/app/components/editor-document-title.js
@@ -1,11 +1,15 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
 
 export default class EditorDocumentTitleComponent extends Component {
   @tracked active = false;
   @tracked error = false;
   @tracked _title;
+  @service toaster;
+  @service intl;
+
   constructor() {
     super(...arguments);
     this.active = this.args.editActive;
@@ -40,6 +44,11 @@ export default class EditorDocumentTitleComponent extends Component {
   submit(event) {
     event.preventDefault();
     this.args.onSubmit?.(this.title);
+    this.toaster.success(
+      this.intl.t('editor-document-title.title-saved'),
+      'Success',
+      { timeOut: 3000 }
+    );
     this.toggleActive();
     return false;
   }

--- a/app/components/editor-document-title.js
+++ b/app/components/editor-document-title.js
@@ -1,15 +1,11 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
 
 export default class EditorDocumentTitleComponent extends Component {
   @tracked active = false;
   @tracked error = false;
   @tracked _title;
-  @service toaster;
-  @service intl;
-
   constructor() {
     super(...arguments);
     this.active = this.args.editActive;
@@ -44,11 +40,6 @@ export default class EditorDocumentTitleComponent extends Component {
   submit(event) {
     event.preventDefault();
     this.args.onSubmit?.(this.title);
-    this.toaster.success(
-      this.intl.t('editor-document-title.title-saved'),
-      'Success',
-      { timeOut: 3000 }
-    );
     this.toggleActive();
     return false;
   }

--- a/app/components/editor-document-title.js
+++ b/app/components/editor-document-title.js
@@ -19,6 +19,13 @@ export default class EditorDocumentTitleComponent extends Component {
     }
   }
 
+  get titleModified() {
+    if (!this._title) {
+      return false;
+    }
+    return this.args.title !== this._title;
+  }
+
   @action
   setTitle(event) {
     let title = event.target.value;

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -11,5 +11,6 @@
       @applicationName='Gelinkt Notuleren'
     />
   {{/if}}
+  <AuToaster @position="top" />
   {{outlet}}
 </AuApp> 

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -11,6 +11,5 @@
       @applicationName='Gelinkt Notuleren'
     />
   {{/if}}
-  <AuToaster @position="top" />
   {{outlet}}
 </AuApp> 

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -111,7 +111,8 @@ editor-document-title:
   placeholder: Untitled document
   agendapoint-title: agendapoint title
   change-title: Change title
-  saved: Saved
+  title-saved: Title saved
+
 inbox:
   loading: Loading
   patience-text: Thank you for your patience.

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -111,7 +111,7 @@ editor-document-title:
   placeholder: Untitled document
   agendapoint-title: agendapoint title
   change-title: Change title
-
+  saved: Saved
 inbox:
   loading: Loading
   patience-text: Thank you for your patience.

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -111,6 +111,7 @@ editor-document-title:
   placeholder: Untitled document
   agendapoint-title: agendapoint title
   change-title: Change title
+  title-saved: Title saved
 
 inbox:
   loading: Loading

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -111,7 +111,6 @@ editor-document-title:
   placeholder: Untitled document
   agendapoint-title: agendapoint title
   change-title: Change title
-  title-saved: Title saved
 
 inbox:
   loading: Loading

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -111,6 +111,7 @@ editor-document-title:
   placeholder: Naamloos document
   agendapoint-title: agendapunt titel
   change-title: Titel wijzigen
+  title-saved: Titel opgeslagen
 
 inbox:
   loading: Aan het laden

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -111,7 +111,8 @@ editor-document-title:
   placeholder: Naamloos document
   agendapoint-title: agendapunt titel
   change-title: Titel wijzigen
-  saved: Gered
+  title-saved: Titel opgeslagen
+
 inbox:
   loading: Aan het laden
   patience-text: Bedankt voor uw geduld.

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -111,7 +111,6 @@ editor-document-title:
   placeholder: Naamloos document
   agendapoint-title: agendapunt titel
   change-title: Titel wijzigen
-  title-saved: Titel opgeslagen
 
 inbox:
   loading: Aan het laden

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -111,7 +111,7 @@ editor-document-title:
   placeholder: Naamloos document
   agendapoint-title: agendapunt titel
   change-title: Titel wijzigen
-
+  saved: Gered
 inbox:
   loading: Aan het laden
   patience-text: Bedankt voor uw geduld.


### PR DESCRIPTION
Solves https://binnenland.atlassian.net/browse/GN-4208, I couldn't reproduce the issue on local while I can easily do it on dev and qa, so it must have been fixed by other PR in the meantime.
I solved the issue where you could save a title even if it was unchanged