### PR TITLE
Replace this.model.behandeldeAgendapunten by this.model.agendapunten when creating agenda objects

### DIFF
--- a/app/controllers/meetings/publish/agenda.js
+++ b/app/controllers/meetings/publish/agenda.js
@@ -96,7 +96,7 @@ export default class MeetingsPublishAgendaController extends Controller {
       const rslt = await this.store.createRecord('agenda', {
         agendaType: type,
         zitting: this.model,
-        agendapunten: this.model.behandeldeAgendapunten,
+        agendapunten: this.model.agendapunten,
         renderedContent: prePublish,
       });
       return rslt;


### PR DESCRIPTION
`this.model.behandeldeAgendapunten` is always empty and non-existant. This PR replaces it by `this.model.agendapunten`