### PR TITLE
Hide hash on signed resource

### DIFF
--- a/app/components/signatures/signed-resource.hbs
+++ b/app/components/signatures/signed-resource.hbs
@@ -7,13 +7,10 @@
       {{t "publish.deleted"}}
     </AuPill>
 {{else}}
-    <AuHelpText @size="large" @skin="secondary" class="au-u-margin-top-none">
-      <AuIcon @icon="calendar"/>
-      {{detailed-date @signature.createdOn}}
-    </AuHelpText>
-  <p class="au-u-margin-top-tiny">
-    <AuPill class="au-u-word-break-all">{{@signature.hashValue}}</AuPill>
-  </p>
+  <AuHelpText @size="large" @skin="secondary" class="au-u-margin-top-none">
+    <AuIcon @icon="calendar"/>
+    {{detailed-date @signature.createdOn}}
+  </AuHelpText>
 {{/if}}
 </p>
 {{#if (and this.signedByCurrentUser.value (and (not @signature.deleted) @canDelete))}}


### PR DESCRIPTION
### Overview
<!-- high level overview of changes (not just "implement ticket") + *why* + design document, special notes like ticket partially implemented etc. -->
Removed the hash from the signed resource that appears on the publish screen for all the documents (agenda, decision list, notulen...) as this is no longer needed because it appears on the publication actions screen

##### connected issues and PRs:
[jira ticket](https://binnenland.atlassian.net/browse/GN-4356)


### Setup
No setup needed

### How to test/reproduce
Go to a meeting, go to publish, sign whichever document you want, see that the hash no longer appears

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [x] npm lint
- [x] no new deprecations
