### PR TITLE
Place the date on the right of the signer

### DIFF
--- a/app/components/signatures/signed-resource.hbs
+++ b/app/components/signatures/signed-resource.hbs
@@ -1,4 +1,4 @@
-<p>
+<p class="au-u-flex">
 {{@signature.gebruiker.voornaam}} {{@signature.gebruiker.achternaam}} <br>
 {{#if @signature.deleted}}
     <AuPill
@@ -7,7 +7,7 @@
       {{t "publish.deleted"}}
     </AuPill>
 {{else}}
-  <AuHelpText @size="large" @skin="secondary" class="au-u-margin-top-none">
+  <AuHelpText @size="large" @skin="secondary" class="au-u-margin-top-none au-u-margin-left-small">
     <AuIcon @icon="calendar"/>
     {{detailed-date @signature.createdOn}}
   </AuHelpText>


### PR DESCRIPTION
### Overview
Changed the date on the signed resource to be placed on the left of the signer instead of the bottom

##### connected issues and PRs:
[jira ticket](https://binnenland.atlassian.net/browse/GN-4361)
Depends on #493 just because it was easier to style without the hash block


### Setup
No setup needed

### How to test/reproduce
Go to a meeting, go to publish, sign whichever document you want see that the date is now placed on the left of the signer

https://github.com/lblod/frontend-gelinkt-notuleren/assets/17006446/3bd3f603-9c66-4680-b58f-6dd12c5ec7ad

### Challenges/uncertainties
I'm happy with the responsive behaviour but maybe we want to put the date below in certain cases seen in the video, open for discussion



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [x] npm lint
- [x] no new deprecations
