### PR TITLE
GN-4362 fix signatures disappearing after publishing

### DIFF
--- a/app/controllers/meetings/publish/notulen.js
+++ b/app/controllers/meetings/publish/notulen.js
@@ -103,13 +103,16 @@ export default class MeetingsPublishNotulenController extends Controller {
             this.notulen = notulen;
             notulenSet = true;
           }
-          this.signedResources = signedResources.toArray();
-          if (!notulenSet) {
-            this.notulen = notulen;
+          if (signedResources.length) {
+            this.signedResources = signedResources.slice();
+            if (!notulenSet) {
+              this.notulen = notulen;
+            }
           }
         })
       );
     } else {
+      console.log("creating new versioned notulen");
       try {
         const { content, errors } =
           await this.createPrePublishedResource.perform();

--- a/app/controllers/meetings/publish/notulen.js
+++ b/app/controllers/meetings/publish/notulen.js
@@ -112,7 +112,6 @@ export default class MeetingsPublishNotulenController extends Controller {
         })
       );
     } else {
-      console.log("creating new versioned notulen");
       try {
         const { content, errors } =
           await this.createPrePublishedResource.perform();


### PR DESCRIPTION
# Overview

For notulen, the VersionedNotulen you sign is not the same as the one
you publish. So I had to revert my earlier change to go back to saving
any non-empty signedresource relationships.


### connected issues and PRs:

<https://binnenland.atlassian.net/browse/GN-4362> 
### Setup


# How to test/reproduce


See ticket, make meeting, sign, then publish before, signature
dissapeared now, it doesnt 
### Challenges/uncertainties


# Checks PR readiness

-   [X] UI: works on smaller screen sizes
-   [X] UI: feedback for any loading/error states
-   [X] Check cancel/go-back flows
-   [X] Check database state correct when deleting/updating (especially
    regarding relationships)
-   [X] changelog
-   [X] npm lint
-   [X] no new deprecations

