### PR TITLE
GN-4354: Remove text "irriversible" from sign modal

### DIFF
--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -578,7 +578,7 @@ regulatory-statement:
 signature-confirmation:
   modal-title: "Confirm signing of "
   sign-label: Sign
-  sign-warning-title: Signing is binding and irreversible
+  sign-warning-title: Signing is binding.
   sign-warning-text: Check the contents of the document carefully. Only authorized persons may sign the document.
   metadata-label: Signing Metadata
   signer-label: Signer

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -577,7 +577,7 @@ regulatory-statement:
 signature-confirmation:
   modal-title: "Bevestig ondertekenen van "
   sign-label: Ondertekenen
-  sign-warning-title: Ondertekenen is bindend en onomkeerbaar
+  sign-warning-title: Ondertekenen is bindend.
   sign-warning-text: Kijk de inhoud van het document goed na. Enkel bevoegde personen mogen het document ondertekenen.
   metadata-label: Metagegevens bij ondertekenen
   signer-label: Ondertekenaar


### PR DESCRIPTION
### Overview
This removes the text "signing is irreversible" from the modals, as signing can now be reversed by deleting a signature.

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-4354

### How to test/reproduce
Sign anything, see the confirmation dialog box. Jira ticket has a video showing it.

### reviewing notes
I checked any other instances where this might be mentioned, but found nothing.