### PR TITLE
GN-4358: addition of a document-type filter to the publication actions page

### DIFF
--- a/app/components/publishing-log-document-name.js
+++ b/app/components/publishing-log-document-name.js
@@ -60,7 +60,7 @@ export default class PublishingLogDocumentNameComponent extends Component {
           const versionedBehandeling = logResource.versionedBehandeling;
           if (versionedBehandeling) {
             documentName = this.intl.t(
-              'meetings.publish.publication-actions.treatment'
+              'meetings.publish.publication-actions.extract'
             );
             versionedResource = await logResource.versionedBehandeling;
             const behandeling = await versionedResource.behandeling;

--- a/app/controllers/meetings/publish/publication-actions/index.js
+++ b/app/controllers/meetings/publish/publication-actions/index.js
@@ -1,11 +1,49 @@
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
+import { action } from '@ember/object';
+
 export default class MeetingsPublishPublicationActionsController extends Controller {
+  queryParams = ['type'];
   @service intl;
+
+  types = [
+    {
+      value: 'agenda',
+      label: this.intl.t('meetings.publish.agenda.title'),
+    },
+    {
+      value: 'versioned-besluiten-lijst',
+      label: this.intl.t('meetings.publish.decision-list.title'),
+    },
+    {
+      value: 'versioned-behandeling',
+      label: this.intl.t('meetings.publish.extracts.title'),
+    },
+    {
+      value: 'versioned-notulen',
+      label: this.intl.t('meetings.publish.document.title'),
+    },
+  ];
+
   sort = '-date';
   @tracked page = 0;
   @tracked pageSize = 20;
+  @tracked type = null;
+
+  @action
+  updateType(type) {
+    if (type) {
+      this.type = type.value;
+      this.page = 0;
+    } else {
+      this.type = null;
+    }
+  }
+
+  get selectedType() {
+    return this.types.find((type) => type.value === this.type);
+  }
 
   actionLabel = (log) => {
     return this.intl.t(

--- a/app/routes/meetings/publish/publication-actions/index.js
+++ b/app/routes/meetings/publish/publication-actions/index.js
@@ -12,17 +12,30 @@ export default class MeetingsPublishPublicationActionsIndexRoute extends Route {
     page: { refreshModel: true },
     size: { refreshModel: true },
     sort: { refreshModel: true },
-    filter: { refreshModel: true },
+    type: { refreshModel: true },
     // filter params
   };
 
   model(params) {
+    const { sort, size, page, type } = params;
     const query = {
-      filter: { zitting: { ':id:': this.meetingId } },
-      sort: params.sort,
+      filter: {
+        zitting: { ':id:': this.meetingId },
+        ...(type && {
+          ':or:': {
+            'signed-resource': {
+              [`:has:${type}`]: 'yes',
+            },
+            'published-resource': {
+              [`:has:${type}`]: 'yes',
+            },
+          },
+        }),
+      },
+      sort,
       page: {
-        size: params.size,
-        number: params.page,
+        size,
+        number: page,
       },
     };
 

--- a/app/routes/meetings/publish/publication-actions/index.js
+++ b/app/routes/meetings/publish/publication-actions/index.js
@@ -41,4 +41,12 @@ export default class MeetingsPublishPublicationActionsIndexRoute extends Route {
 
     return this.store.query('publishing-log', query);
   }
+
+  resetController(controller, isExiting) {
+    if (isExiting) {
+      controller.set('type', null);
+      controller.set('sort', '-date');
+      controller.set('page', 0);
+    }
+  }
 }

--- a/app/templates/meetings/publish/publication-actions/index.hbs
+++ b/app/templates/meetings/publish/publication-actions/index.hbs
@@ -14,6 +14,20 @@
             {{t 'meetings.publish.publication-actions.title'}}
           </AuHeading>
         </Group>
+        <Group>
+          <AuLabel>
+            {{t "meetings.publish.publication-actions.document-type-filter.label"}}
+          </AuLabel>
+          <PowerSelect
+            @allowClear={{true}}
+            @options={{this.types}}
+            @selected={{this.selectedType}}
+            @onChange={{this.updateType}}
+            @placeholder={{t "meetings.publish.publication-actions.document-type-filter.placeholder"}}
+            as |category|>
+            {{category.label}}
+          </PowerSelect>
+        </Group>
       </AuToolbar>
     </menu.general>
   </table.menu>

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -404,8 +404,11 @@ meetings:
       urgent-agenda: Urgent Agenda
       notulen: Document
       decision-list: Decision list
-      treatment: Treatment
+      extract: Extract
       deleted: Deleted
+      document-type-filter:
+        label: Document type
+        placeholder: Select an option
       return: Back to all publication actions
       details: Details
   delete:

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -403,8 +403,11 @@ meetings:
       urgent-agenda: Spoedeisende Agenda
       notulen: Notulen
       decision-list: BesluitenLijst
-      treatment: Uitreksel
+      extract: Uitreksel
       deleted: verwijderd
+      document-type-filter:
+        label: Type document
+        placeholder: Selecteer een optie
       return: Terug naar alle publicatie acties
       details: Details
   delete:


### PR DESCRIPTION
### Overview
This PR adds a dropdown component to the publication actions page which allows users to filter on document type.
The values a user can select between are:
- Agenda
- Decision list
- Extract
- Document/Notulen


##### connected issues and PRs:
Jira ticket: https://binnenland.atlassian.net/browse/GN-4358?atlOrigin=eyJpIjoiOTViNmRjMzcwN2ExNGJkY2E5YTMyZTNkZDc2MzY1ODMiLCJwIjoiaiJ9
Design: https://www.figma.com/file/pW370BHe4ES5eN0vHhArA5/GN-4022?type=design&node-id=0-1&t=Ncms3NPhRgxXECZW-0


### How to test/reproduce
Visit the publication actions page and select a document type using the dropdown. Only the selected document type should be shown and the pagination should reset to page 0.


### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint

