### PR TITLE
GN-4384: Convert deleted text in publication actions to a pill

### DIFF
--- a/app/components/publishing-log-document-name.hbs
+++ b/app/components/publishing-log-document-name.hbs
@@ -1,8 +1,15 @@
-<span>
+<span class="au-u-flex">
   {{#if this.data.value.deleted}}
     <AuLink @route="meetings.publish.publication-actions.detail" @model={{@log.id}}>
-      {{this.data.value.documentName}} {{#if this.data.value.deleted}}({{t "meetings.publish.publication-actions.deleted"}}){{/if}}
+      {{this.data.value.documentName}} 
     </AuLink>
+    {{#if this.data.value.deleted}}
+      <span class="au-u-margin-left-small">
+        <AuPill @skin="error" @icon="trash">
+          {{t "meetings.publish.publication-actions.deleted"}}
+        </AuPill>
+      </span>
+    {{/if}}
   {{else}}
     <AuLink @route={{this.data.value.route}}>
       {{this.data.value.documentName}}


### PR DESCRIPTION
### Overview
Convert the deleted text that appeared when you deleted a versioned resource to a pill so it doesn't look like we change the title of the document

##### connected issues and PRs:
[jira ticket](https://binnenland.atlassian.net/browse/GN-4384)


### Setup
None, you only will need to have deleted versioned resources in your system

### How to test/reproduce
- Create a new meeting
- Fill the details
- Sign an agenda
- Delete that signature
- Go to publication actions
- You should see the deleted text is now a pill

### Challenges/uncertainties
none



### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
