### PR TITLE
GN-4406: add support for root level articles to regulatory statement documents

### DIFF
--- a/app/controllers/regulatory-statements/edit.js
+++ b/app/controllers/regulatory-statements/edit.js
@@ -93,7 +93,8 @@ export default class RegulatoryStatementsRoute extends Controller {
   schema = new Schema({
     nodes: {
       doc: {
-        content: 'table_of_contents? ((chapter|block)+|(title|block)+)',
+        content:
+          'table_of_contents? ((chapter|block)+|(title|block)+|(article|block)+)',
       },
       paragraph,
       table_of_contents: table_of_contents(this.config.tableOfContents),


### PR DESCRIPTION
### Overview
This PR adapts the schema of regulatory statement documents in order to ensure root-level articles are allowed.

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-4407?atlOrigin=eyJpIjoiYTMyOTdkMzg4MjY0NDUwNWJmMjlkMWM4NzViOThlZjYiLCJwIjoiaiJ9
https://binnenland.atlassian.net/browse/GN-4406?atlOrigin=eyJpIjoiY2E4MGNiZjk3NDIxNDgxNjg5NjYwMzg4NTU0MTZhOWIiLCJwIjoiaiJ9

### How to test/reproduce
- Create a new regulatory statement document based on a template containing root-level articles.
- Check if the articles are correctly parsed
- Check if you can add root-level articles

### Checks PR readiness
- [ ] npm lint
