### PR TITLE
GN-4416: add document title config (and bump editor v3.10.0 and plugins v8.4.0)

### DIFF
--- a/app/controllers/regulatory-statements/edit.js
+++ b/app/controllers/regulatory-statements/edit.js
@@ -74,6 +74,7 @@ import {
   tableOfContentsView,
   table_of_contents,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/table-of-contents-plugin/nodes';
+import { document_title } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/document-title-plugin/nodes';
 
 import { highlight } from '@lblod/ember-rdfa-editor/plugins/highlight/marks/highlight';
 import { color } from '@lblod/ember-rdfa-editor/plugins/color/marks/color';
@@ -94,9 +95,10 @@ export default class RegulatoryStatementsRoute extends Controller {
     nodes: {
       doc: {
         content:
-          'table_of_contents? ((chapter|block)+|(title|block)+|(article|block)+)',
+          'table_of_contents? document_title? ((chapter|block)+|(title|block)+|(article|block)+)',
       },
       paragraph,
+      document_title,
       table_of_contents: table_of_contents(this.config.tableOfContents),
       repaired_block,
       list_item,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@curvenote/prosemirror-utils": "^1.0.5",
-        "ember-resources": "^5.4.0",
+        "ember-resources": "^6.1.1",
         "tracked-toolbox": "^2.0.0"
       },
       "devDependencies": {
@@ -26,7 +26,7 @@
         "@lblod/ember-environment-banner": "^0.2.0",
         "@lblod/ember-mock-login": "0.7.0",
         "@lblod/ember-rdfa-editor": "^3.10.0",
-        "@lblod/ember-rdfa-editor-lblod-plugins": "^8.2.2",
+        "@lblod/ember-rdfa-editor-lblod-plugins": "^8.4.0",
         "@release-it-plugins/lerna-changelog": "^5.0.0",
         "broccoli-asset-rev": "^3.0.0",
         "broccoli-plugin": "^4.0.7",
@@ -2889,7 +2889,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@ember/test-waiters/-/test-waiters-3.0.2.tgz",
       "integrity": "sha512-H8Q3Xy9rlqhDKnQpwt2pzAYDouww4TZIGSI1pZJhM7mQIGufQKuB0ijzn/yugA6Z+bNdjYp1HioP8Y4hn2zazQ==",
-      "devOptional": true,
       "dependencies": {
         "calculate-cache-key-for-tree": "^2.0.0",
         "ember-cli-babel": "^7.26.6",
@@ -3312,20 +3311,6 @@
       "integrity": "sha512-HS2dEbJ3CgXn56wk/5QdudM7rE3vtNMvPIoG7Rrg+GhkGMNxBCIRxOeEF2g520j9rwlA2LAZFpc7MCDMFbTjNA==",
       "dependencies": {
         "babel-plugin-debug-macros": "^0.3.4"
-      }
-    },
-    "node_modules/@glint/config": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/@glint/config/-/config-0.9.7.tgz",
-      "integrity": "sha512-XkWIZ3fuOlcofUJUaJmRS57mVVNi+Af2HtrZkBXEOCh4+BNz2wclxv2WKvkhmtvLhEUOhHb5eU3gwI58SuwgXQ==",
-      "deprecated": "Now a part of @glint/core",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "escape-string-regexp": "^4.0.0",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.17.0",
-        "silent-error": "^1.1.1"
       }
     },
     "node_modules/@glint/environment-ember-loose": {
@@ -4032,9 +4017,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor-lblod-plugins": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-8.2.2.tgz",
-      "integrity": "sha512-j+my0VZzK2jsL0XSQZ6mooIMLf33uOu3g1Lsm0DpqI45HgLm2zRblF6Wy3UYjs9YGr/S25KBfOVqRKc5vnr6aQ==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-8.4.0.tgz",
+      "integrity": "sha512-6iXQVqq6DvaHsin+StRoWjDzd+RDprnRxKOUOm4iRi7AL3uwUXvrYWZQh6sM0VSrvvk4SzWItqYvFI0t0M1vPQ==",
       "dev": true,
       "dependencies": {
         "@codemirror/lang-html": "^6.4.3",
@@ -4057,8 +4042,8 @@
         "ember-concurrency": "^2.3.7",
         "ember-mu-transform-helpers": "^2.0.0",
         "ember-power-select": "^6.0.1",
-        "ember-resources": "^5.6.2",
-        "ember-velcro": "^1.1.0",
+        "ember-resources": "^6.1.1",
+        "ember-velcro": "^2.1.0",
         "fetch-sparql-endpoint": "^3.0.0",
         "n2words": "^1.16.4",
         "process": "0.11.10",
@@ -4074,42 +4059,8 @@
       },
       "peerDependencies": {
         "@appuniversum/ember-appuniversum": "^2.4.2",
-        "@lblod/ember-rdfa-editor": "^3.8.0",
+        "@lblod/ember-rdfa-editor": "^3.10.0",
         "ember-concurrency": "^2.3.7"
-      }
-    },
-    "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/@glint/environment-ember-loose": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/@glint/environment-ember-loose/-/environment-ember-loose-0.9.7.tgz",
-      "integrity": "sha512-MlCGZtB1Clp4vQWIm2APSnCm7nL8wVhFMOhVy2qzpV0nfLyg3pcN9CQHNpfdJvCydBB72cA4/ahPj7VEFL6xsg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@glint/config": "^0.9.7",
-        "@glint/template": "^0.9.7"
-      },
-      "peerDependencies": {
-        "@glimmer/component": "^1.1.2",
-        "ember-cli-htmlbars": "^6.0.1",
-        "ember-modifier": "^3.2.7"
-      },
-      "peerDependenciesMeta": {
-        "ember-cli-htmlbars": {
-          "optional": true
-        },
-        "ember-modifier": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/@glint/template": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/@glint/template/-/template-0.9.7.tgz",
-      "integrity": "sha512-MCp8GxQDIbH8ZzfNxHhVqCSKlydBgQfBEwJLDpN81lgFRCldSDPueIbk8sz3EhpGiZJVdNQbpGeYIDsUXe1ocg==",
-      "dev": true,
-      "peer": true,
-      "peerDependencies": {
-        "@glimmer/component": "^1.1.2"
       }
     },
     "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/ember-basic-dropdown": {
@@ -4250,25 +4201,6 @@
       },
       "engines": {
         "node": "14.* || >= 16"
-      }
-    },
-    "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/ember-velcro": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ember-velcro/-/ember-velcro-1.1.0.tgz",
-      "integrity": "sha512-oZxcQvd39o0Miv4C4a44BMkzSuS5X684eVLX2Ct4qh7ofAvqSWpEGF9dUDwzCOq5hk4WS8DMsXa0azonv6tP7Q==",
-      "dev": true,
-      "dependencies": {
-        "@embroider/addon-shim": "^1.0.0",
-        "@floating-ui/dom": "^1.0.1",
-        "ember-functions-as-helper-polyfill": "^2.1.1",
-        "ember-modifier": "^3.2.7"
-      },
-      "engines": {
-        "node": "14.* || >= 16"
-      },
-      "peerDependencies": {
-        "@glint/environment-ember-loose": "^0.9.4",
-        "@glint/template": "^0.9.5"
       }
     },
     "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/execa": {
@@ -12348,6 +12280,18 @@
         "node": ">= 12"
       }
     },
+    "node_modules/ember-async-data": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ember-async-data/-/ember-async-data-1.0.1.tgz",
+      "integrity": "sha512-R9nBxCZ9WDPMJpuGBODs8wV1PHXUbkSbrzVmL34R4aOWbx237yLBllJghQOwfJs1+D72wdzgxg/+J3DY43xz3g==",
+      "dependencies": {
+        "@ember/test-waiters": "^3.0.0",
+        "@embroider/addon-shim": "^1.8.4"
+      },
+      "peerDependencies": {
+        "ember-source": "^4.8.4"
+      }
+    },
     "node_modules/ember-auto-import": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/ember-auto-import/-/ember-auto-import-2.6.3.tgz",
@@ -16935,6 +16879,36 @@
         "node": ">= 12.*"
       }
     },
+    "node_modules/ember-data-resources/node_modules/ember-resources": {
+      "version": "5.6.4",
+      "resolved": "https://registry.npmjs.org/ember-resources/-/ember-resources-5.6.4.tgz",
+      "integrity": "sha512-ShdosnruPm37jPpzPOgPVelymEDJT/27Jz/j5AGPVAfCaUhRIocTxNMtPx13ox890A2babuPF5M3Ur8UFidqtw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.17.8",
+        "@embroider/addon-shim": "^1.2.0",
+        "@embroider/macros": "^1.2.0"
+      },
+      "peerDependencies": {
+        "@ember/test-waiters": "^3.0.0",
+        "@glimmer/component": "^1.1.2",
+        "@glimmer/tracking": "^1.1.2",
+        "@glint/template": ">= 0.8.3",
+        "ember-concurrency": "^2.0.0",
+        "ember-source": ">= 3.28.0"
+      },
+      "peerDependenciesMeta": {
+        "@ember/test-waiters": {
+          "optional": true
+        },
+        "@glimmer/component": {
+          "optional": true
+        },
+        "ember-concurrency": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ember-data-resources/node_modules/execa": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
@@ -21032,21 +21006,22 @@
       }
     },
     "node_modules/ember-resources": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/ember-resources/-/ember-resources-5.6.4.tgz",
-      "integrity": "sha512-ShdosnruPm37jPpzPOgPVelymEDJT/27Jz/j5AGPVAfCaUhRIocTxNMtPx13ox890A2babuPF5M3Ur8UFidqtw==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/ember-resources/-/ember-resources-6.1.1.tgz",
+      "integrity": "sha512-Ajx0T+IGQwNG6ilYfBXR52+4+K5Tm5dJYJ6i95DK5ZcP4M39V/OfheEG+uRMOITHL9/S5QfO6Mhacai6xzvBiA==",
       "dependencies": {
         "@babel/runtime": "^7.17.8",
         "@embroider/addon-shim": "^1.2.0",
-        "@embroider/macros": "^1.2.0"
+        "@embroider/macros": "^1.2.0",
+        "ember-async-data": "^1.0.1"
       },
       "peerDependencies": {
         "@ember/test-waiters": "^3.0.0",
         "@glimmer/component": "^1.1.2",
         "@glimmer/tracking": "^1.1.2",
-        "@glint/template": ">= 0.8.3",
-        "ember-concurrency": "^2.0.0",
-        "ember-source": ">= 3.28.0"
+        "@glint/template": "^1.0.0-beta.3 || ^1.0.0",
+        "ember-concurrency": "^2.0.0 || ^3.0.0",
+        "ember-source": "^3.28.0 || ^4.0.0 || ^5.0.0"
       },
       "peerDependenciesMeta": {
         "@ember/test-waiters": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@lblod/ember-environment-banner": "^0.2.0",
     "@lblod/ember-mock-login": "0.7.0",
     "@lblod/ember-rdfa-editor": "^3.10.0",
-    "@lblod/ember-rdfa-editor-lblod-plugins": "^8.2.2",
+    "@lblod/ember-rdfa-editor-lblod-plugins": "^8.4.0",
     "@release-it-plugins/lerna-changelog": "^5.0.0",
     "broccoli-asset-rev": "^3.0.0",
     "broccoli-plugin": "^4.0.7",
@@ -121,7 +121,7 @@
   },
   "dependencies": {
     "@curvenote/prosemirror-utils": "^1.0.5",
-    "ember-resources": "^5.4.0",
+    "ember-resources": "^6.1.1",
     "tracked-toolbox": "^2.0.0"
   }
 }


### PR DESCRIPTION
### Overview
<!-- high level overview of changes (not just "implement ticket") + *why* + design document, special notes like ticket partially implemented etc. -->

Bumps editor and plugins
sets up correct config for document title
This makes regulations that include a document title parse correctly in GN.
##### connected issues and PRs:
<!-- links to connected jira tickets -->
<!-- Link to PRs that are related (and in what way) -->

https://binnenland.atlassian.net/browse/GN-4416

### Setup
<!-- PR dependencies -->
<!-- override snippets -->


### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->
easiest way is to setup a document with a title in the plugin dummy app, copy the html, and use
`__PM.setHtmlContent()` to insert it in gn
verify with PM devtools that the title node is correctly parsed as a `document_title` node (rather than a generic `h4`)

### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->



### Checks PR readiness

- [x] npm lint

