### PR TITLE
GN-4427: fix old signatures and publications not being picked up

### DIFF
--- a/app/controllers/meetings/publish/agenda.js
+++ b/app/controllers/meetings/publish/agenda.js
@@ -85,7 +85,8 @@ export default class MeetingsPublishAgendaController extends Controller {
     const agendas = await this.store.query('agenda', {
       'filter[zitting][:id:]': this.meeting.id,
       'filter[agenda-type]': type,
-      'filter[deleted]': false,
+      'filter[:or:][deleted]': false,
+      'filter[:or:][:has-no:deleted]': "yes",
       include: 'signed-resources,published-resource',
     });
     if (agendas.length) {

--- a/app/controllers/meetings/publish/agenda.js
+++ b/app/controllers/meetings/publish/agenda.js
@@ -86,7 +86,7 @@ export default class MeetingsPublishAgendaController extends Controller {
       'filter[zitting][:id:]': this.meeting.id,
       'filter[agenda-type]': type,
       'filter[:or:][deleted]': false,
-      'filter[:or:][:has-no:deleted]': "yes",
+      'filter[:or:][:has-no:deleted]': 'yes',
       include: 'signed-resources,published-resource',
     });
     if (agendas.length) {

--- a/app/controllers/meetings/publish/besluitenlijst.js
+++ b/app/controllers/meetings/publish/besluitenlijst.js
@@ -27,7 +27,9 @@ export default class MeetingsPublishBesluitenlijstController extends Controller 
     try {
       const behandelings = await this.store.query('versioned-besluiten-lijst', {
         'filter[zitting][:id:]': this.model.id,
-        'filter[deleted]': false,
+        'filter[:or:][deleted]': false,
+        'filter[:or:][:has-no:deleted]': 'yes',
+
         include: 'signed-resources,published-resource',
       });
       if (behandelings.length) {
@@ -72,7 +74,8 @@ export default class MeetingsPublishBesluitenlijstController extends Controller 
   reloadBesluitenLijst = task(async () => {
     const behandelings = await this.store.query('versioned-besluiten-lijst', {
       'filter[zitting][:id:]': this.model.id,
-      'filter[deleted]': false,
+      'filter[:or:][deleted]': false,
+      'filter[:or:][:has-no:deleted]': 'yes',
       include: 'signed-resources,published-resource',
     });
     this.besluitenlijst = behandelings.firstObject;

--- a/app/controllers/meetings/publish/notulen.js
+++ b/app/controllers/meetings/publish/notulen.js
@@ -113,7 +113,8 @@ export default class MeetingsPublishNotulenController extends Controller {
 
     const signedDeletedResources = await this.store.query('signed-resource', {
       'filter[versioned-notulen][:id:]': versionedNotulenId,
-      'filter[deleted]': true,
+      'filter[:or:][deleted]': false,
+      'filter[:or:][:has-no:deleted]': 'yes',
       sort: 'created-on',
     });
 
@@ -125,7 +126,8 @@ export default class MeetingsPublishNotulenController extends Controller {
   loadNotulen = task(async () => {
     const versionedNotulens = await this.store.query('versioned-notulen', {
       'filter[zitting][:id:]': this.model.id,
-      'filter[deleted]': false,
+      'filter[:or:][deleted]': false,
+      'filter[:or:][:has-no:deleted]': 'yes',
       include: 'published-resource.gebruiker',
     });
 

--- a/app/routes/meetings/publish/uittreksels/index.js
+++ b/app/routes/meetings/publish/uittreksels/index.js
@@ -44,10 +44,9 @@ export default class MeetingsPublishUittrekselsRoute extends Route {
       const behandeling = await agendapoint.behandeling;
       const versionedBehandeling = (
         await this.store.query('versioned-behandeling', {
-          filter: {
-            behandeling: { ':id:': behandeling.id },
-            deleted: false,
-          },
+          'filter[behandeling][:id:]': behandeling.id,
+          'filter[:or:][deleted]': false,
+          'filter[:or:][:has-no:deleted]': 'yes',
         })
       ).toArray()[0];
       agendapointsToDisplay.push({

--- a/app/services/publish.js
+++ b/app/services/publish.js
@@ -121,7 +121,8 @@ export default class PublishService extends Service {
       }),
       this.store.query('versioned-behandeling', {
         'filter[zitting][:id:]': meetingId,
-        'filter[deleted]': false,
+        'filter[:or:][deleted]': false,
+        'filter[:or:][:has-no:deleted]': false,
         include: 'behandeling.onderwerp,signed-resources,published-resource',
         page: { size: 1000 },
       }),
@@ -183,7 +184,9 @@ export default class PublishService extends Service {
     const versionedTreatments = await this.store.query(
       'versioned-behandeling',
       {
-        filter: { behandeling: { ':id:': treatment.id }, deleted: false },
+        'filter[behandeling][:id:]': treatment.id,
+        'filter[:or:][deleted]': false,
+        'filter[:or:][:has-no:deleted]': 'yes',
         include: 'behandeling.onderwerp,signed-resources,published-resource',
       }
     );


### PR DESCRIPTION
### Overview
<!-- high level overview of changes (not just "implement ticket") + *why* + design document, special notes like ticket partially implemented etc. -->

There were still a few locations where we were filtering only on deleted = false, but this also filtered out all existing signatures/publishedResources, 
because in sparql, deleted=false implies that the triple exists in the first place.

##### connected issues and PRs:
<!-- links to connected jira tickets -->
<!-- Link to PRs that are related (and in what way) -->

https://binnenland.atlassian.net/browse/GN-4427

### Setup
<!-- PR dependencies -->
<!-- override snippets -->

### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

bit difficult as you need signatures that doesn't have the deleted triple. The best way is to 
get a prod backup and test with known published (as per publicatie) documents.

### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->



### Checks PR readiness
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] npm lint
- [x] no new deprecations
