### PR TITLE
fix translation: missing administrative body

### DIFF
--- a/app/controllers/inbox/meetings/new.js
+++ b/app/controllers/inbox/meetings/new.js
@@ -5,6 +5,7 @@ import { service } from '@ember/service';
 
 export default class InboxMeetingsNewController extends Controller {
   @service router;
+  @service intl;
 
   get meeting() {
     return this.model;
@@ -17,7 +18,9 @@ export default class InboxMeetingsNewController extends Controller {
     if (!bestuursorgaan) {
       this.meeting.errors.add(
         'bestuursorgaan',
-        'inbox.meetings.new.meeting.errors.administrativeBody.required'
+        this.intl.t(
+          'inbox.meetings.new.meeting.errors.administrative-body.required'
+        )
       );
     }
 

--- a/app/templates/inbox/meetings/new.hbs
+++ b/app/templates/inbox/meetings/new.hbs
@@ -24,7 +24,7 @@
           />
           {{#each errors as |error|}}
             <AuHelpText @error={{true}}>
-              {{t error.message}}
+              {{error.message}}
             </AuHelpText>
           {{/each}}
         {{/let}}


### PR DESCRIPTION
### Overview
translation key was wrong. It also got passed as a string to the backend, making it hard to realize the mistake. Now it directly uses `intl`.

##### connected issues and PRs:
found during reviewing, so no connected ticket.

### How to test/reproduce
translation missing error came when making a new meeting but not choosing an administrative body.