### PR TITLE
GN-4430: Don't allow editing agendapoint participants if votings are present

### DIFF
--- a/app/components/behandeling-van-agendapunt.hbs
+++ b/app/components/behandeling-van-agendapunt.hbs
@@ -65,7 +65,8 @@
           @onSave={{this.saveParticipants}}
           @meeting={{@meeting}}
           @modalTitle={{t "behandeling-van-agendapunten.participation-list-button"}}
-          @readOnly={{not this.editable}}
+          @readOnly={{or (not this.editable) (not this.canEditParticipants)}}
+          @readOnlyText={{unless this.canEditParticipants (t "behandeling-van-agendapunten.cannot-edit-participants")}}
   />
 {{/if}}
 

--- a/app/components/behandeling-van-agendapunt.js
+++ b/app/components/behandeling-van-agendapunt.js
@@ -68,6 +68,10 @@ export default class BehandelingVanAgendapuntComponent extends Component {
     return !(this.published || this.args.readOnly);
   }
 
+  get canEditParticipants() {
+    return this.behandeling.stemmingen.length === 0;
+  }
+
   get documentContainer() {
     return this.args.behandeling.documentContainer;
   }

--- a/app/components/participation-list.hbs
+++ b/app/components/participation-list.hbs
@@ -49,6 +49,18 @@
     {{@modalTitle}}
   </AuButton>
 {{/unless}}
+{{#if (and @readOnly @readOnlyText)}}
+  <AuButton
+      @width="block"
+      @skin="secondary"
+      @icon="cross"
+      @iconAlignment="left"
+      class="au-u-margin-top-small"
+      @disabled={{true}}
+    >
+      {{@readOnlyText}}
+    </AuButton>
+{{/if}}
 
 <ParticipationList::Modal
   @chairman={{this.defaultedChairman}}

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -81,6 +81,7 @@ behandeling-van-agendapunten:
   voting-title: "Voting"
   content-title: "Content"
   needs-participants: Please configure the participants to this agenda-item before adding a voting.
+  cannot-edit-participants: Cannot configure participants if votings exist for this agenda item.
   edit-document: "Edit document"
 
 contact:

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -81,6 +81,7 @@ behandeling-van-agendapunten:
   voting-title: "Stemming"
   content-title: "Inhoud"
   needs-participants: Configureer de aanwezigen bij dit agendapunt alvorens een stemming toe te voegen.
+  cannot-edit-participants: Aanwezigen zijn niet aanpasbaar als er al een stemming plaatsvond.
   edit-document: "Bewerk document"
 
 contact:


### PR DESCRIPTION
### Overview
Originally, it was always possible to edit the participants in an agendapoint. However, the votings attached are closely related: only present participants can vote. When creating a vote and then changing the participants, this would create a mismatch between both.
In most cases this gave no bugs, except for the voting making less sense.
In the case of removing *all* participants after adding votes, the votes would be hidden, but still exist. This means that when publishing, the voting would suddenly pop up again. This is the bug mentioned in the ticket.

This fixes this by not allowing participants changes for an agendapoint that has votings.

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-4430

### How to test/reproduce
Getting the bug of a vote showing up when there are no votes in the edit page:
For an agenda: 
1. Add present mandatees 
2. do some votes 
3. change present mandatees to not present 
4. votes will not be shown (votes are only shown if mandatees are present. Votes aren’t removed when changing present mandatees. This is the source of this bug)
5. Now it looks like there are no votes, but they will still appear on all publishing things. 

Besides this being "fixed", you should check that you can never change participants for agendaitems that have a voting.

### Challenges/uncertainties
It was hard to figure out how to show this info without even more "warning" popups.
I decided that a disabled button with explanation text was the most clean. It does not scream attention, but will be read if someone is confused, as it is located on the button that disappears.
Note that a disabled button is used purely for the css looks. The disabled button has no code attached to it. Not sure if this is the cleanest way, but it was the most straightforward (and hence easiest+most clear).