### PR TITLE
GN-4509: only prefill address municipality if logged in user is part of a municipality/OCMW

### DIFF
--- a/.changeset/proud-bats-yell.md
+++ b/.changeset/proud-bats-yell.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Only prefill address municipality if logged in user is part of a municipality/OCMW

--- a/app/controllers/agendapoints/edit.js
+++ b/app/controllers/agendapoints/edit.js
@@ -93,6 +93,10 @@ import { color } from '@lblod/ember-rdfa-editor/plugins/color/marks/color';
 import ENV from 'frontend-gelinkt-notuleren/config/environment';
 import { validation } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/validation';
 import { atLeastOneArticleContainer } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/decision-plugin/utils/validation-rules';
+import {
+  GEMEENTE,
+  OCMW,
+} from '../../utils/bestuurseenheid-classificatie-codes';
 
 export default class AgendapointsEditController extends Controller {
   @service store;
@@ -198,8 +202,14 @@ export default class AgendapointsEditController extends Controller {
       structures: structureSpecs,
     };
   }
+
   get defaultMunicipality() {
-    return this.currentSession.group.naam;
+    const classificatie = this.currentSession.classificatie;
+    if (classificatie.uri === GEMEENTE || classificatie.uri === OCMW) {
+      return this.currentSession.group.naam;
+    } else {
+      return null;
+    }
   }
 
   get codelistEditOptions() {

--- a/app/controllers/regulatory-statements/edit.js
+++ b/app/controllers/regulatory-statements/edit.js
@@ -89,6 +89,10 @@ import { document_title } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/d
 import { highlight } from '@lblod/ember-rdfa-editor/plugins/highlight/marks/highlight';
 import { color } from '@lblod/ember-rdfa-editor/plugins/color/marks/color';
 import ENV from 'frontend-gelinkt-notuleren/config/environment';
+import {
+  GEMEENTE,
+  OCMW,
+} from '../../utils/bestuurseenheid-classificatie-codes';
 
 export default class RegulatoryStatementsRoute extends Controller {
   @service documentService;
@@ -264,9 +268,17 @@ export default class RegulatoryStatementsRoute extends Controller {
       nonZonalLocationCodelistUri: ENV.nonZonalLocationCodelistUri,
     };
   }
+
   get defaultMunicipality() {
-    return this.currentSession.group.naam;
+    const classificatie = this.currentSession.classificatie;
+
+    if (classificatie.uri === GEMEENTE || classificatie.uri === OCMW) {
+      return this.currentSession.group.naam;
+    } else {
+      return null;
+    }
   }
+
   @action
   download() {
     this.editorDocument.content = this.controller.htmlContent;

--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -9,6 +9,7 @@ export default class CurrentSessionService extends Service {
   @tracked user;
   @tracked group;
   @tracked roles = [];
+  @tracked classificatie;
 
   get canRead() {
     return this.hasRole('GelinktNotuleren-lezer');
@@ -39,6 +40,7 @@ export default class CurrentSessionService extends Service {
       this.group = await this.store.findRecord('bestuurseenheid', groupId, {
         include: 'classificatie',
       });
+      this.classificatie = await this.group.classificatie;
       this.roles = this.session.data.authenticated.data.attributes.roles;
     }
   }

--- a/app/utils/bestuurseenheid-classificatie-codes.js
+++ b/app/utils/bestuurseenheid-classificatie-codes.js
@@ -1,0 +1,4 @@
+export const GEMEENTE =
+  'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001';
+export const OCMW =
+  'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000002';


### PR DESCRIPTION
### Overview
This PR ensures that the municipality field of the `edit-address` card is only prefilled when the current user is part of a municipality or OCMW. The code in this PR checks if the currently logged in user has one of the two following classification codes:
- http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001 (Gemeente)
- http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000002 (OCMW)

##### connected issues and PRs:
[GN-4509](https://binnenland.atlassian.net/browse/GN-4509?atlOrigin=eyJpIjoiYTRmNjJlZjg4ZTJjNDM5MmI4YTZkNGVjYWU2ZGE5OTEiLCJwIjoiaiJ9)

### How to test/reproduce
- Log in as a municipality/OCMW (e.g. Aalst)
- Notice that when trying to edit a newly inserted address, the municipality field is prefilled with the municipality name

- Log in as as an administrative unit which is not linked to a municipality (e.g. Vlaams-Brabant)
- Notice that when trying to edit a newly inserted address, the municipality field is empty

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
