### PR TITLE
GN-4528: Fix issues reported by `dependency-lint`

### DIFF
--- a/.changeset/pretty-walls-wonder.md
+++ b/.changeset/pretty-walls-wonder.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': minor
+---
+
+GN-4528: Fix issues reported by `dependency-lint`, require `dependency-lint` CI job to pass

--- a/.woodpecker/.test-pr.yml
+++ b/.woodpecker/.test-pr.yml
@@ -13,7 +13,6 @@ steps:
     group: lint
     commands:
       - ember dependency-lint
-    failure: ignore
   test:
     image: danlynn/ember-cli:4.8.0
     commands:

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "ember-cli-string-helpers": "^6.1.0",
         "ember-cli-terser": "^4.0.2",
         "ember-composable-helpers": "^5.0.0",
-        "ember-concurrency": "^3.1.1",
+        "ember-concurrency": "^2.3.7",
         "ember-config-helper": "^0.1.3",
         "ember-could-get-used-to-this": "^1.0.1",
         "ember-data": "~4.8.8",
@@ -64,7 +64,7 @@
         "ember-modifier": "^3.2.7",
         "ember-page-title": "^7.0.0",
         "ember-plausible": "^0.2.0",
-        "ember-power-select": "^7.0.0",
+        "ember-power-select": "^6.0.1",
         "ember-promise-helpers": "^2.0.0",
         "ember-qunit": "^6.0.0",
         "ember-resolver": "^10.1.1",
@@ -72,7 +72,7 @@
         "ember-simple-auth": "^4.2.2",
         "ember-source": "~4.8.0",
         "ember-template-lint": "^5.11.2",
-        "ember-truth-helpers": "^4.0.2",
+        "ember-truth-helpers": "^3.1.1",
         "eslint": "^8.49.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-ember": "^11.11.1",
@@ -151,19 +151,6 @@
       },
       "peerDependencies": {
         "ember-source": "^3.28.0 || ^4.0.0"
-      }
-    },
-    "node_modules/@appuniversum/ember-appuniversum/node_modules/tracked-toolbox": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/tracked-toolbox/-/tracked-toolbox-1.3.0.tgz",
-      "integrity": "sha512-KHfYLvNyRr0qQeXQPnmb6Z4JYZ0/47R7LjVwzUrsKc539eQi3Sz2z3mb7FJN9KgaJXVuM3GQ8zcwUFTf0hrOsQ==",
-      "dev": true,
-      "dependencies": {
-        "ember-cache-primitive-polyfill": "^1.0.0",
-        "ember-cli-babel": "^7.26.6"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4499,25 +4486,6 @@
         "node": "10.* || >= 12.*"
       }
     },
-    "node_modules/@lblod/ember-mock-login/node_modules/ember-concurrency": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/ember-concurrency/-/ember-concurrency-2.3.7.tgz",
-      "integrity": "sha512-sz6sTIXN/CuLb5wdpauFa+rWXuvXXSnSHS4kuNzU5GSMDX1pLBWSuovoUk61FUe6CYRqBmT1/UushObwBGickQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.12.13",
-        "@babel/types": "^7.12.13",
-        "@glimmer/tracking": "^1.0.4",
-        "ember-cli-babel": "^7.26.11",
-        "ember-cli-babel-plugin-helpers": "^1.1.1",
-        "ember-cli-htmlbars": "^5.7.1",
-        "ember-compatibility-helpers": "^1.2.0",
-        "ember-destroyable-polyfill": "^2.0.2"
-      },
-      "engines": {
-        "node": "10.* || 12.* || 14.* || >= 16"
-      }
-    },
     "node_modules/@lblod/ember-mock-login/node_modules/fs-tree-diff": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
@@ -4739,381 +4707,6 @@
         "ember-source": "^3.28.0 || ^4.0.0"
       }
     },
-    "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/async-disk-cache": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
-      "integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "heimdalljs": "^0.2.3",
-        "istextorbinary": "^2.5.1",
-        "mkdirp": "^0.5.0",
-        "rimraf": "^3.0.0",
-        "rsvp": "^4.8.5",
-        "username-sync": "^1.0.2"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
-      }
-    },
-    "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/broccoli-persistent-filter": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.3.tgz",
-      "integrity": "sha512-Q+8iezprZzL9voaBsDY3rQVl7c7H5h+bvv8SpzCZXPZgfBFCbx7KFQ2c3rZR6lW5k4Kwoqt7jG+rZMUg67Gwxw==",
-      "dev": true,
-      "dependencies": {
-        "async-disk-cache": "^2.0.0",
-        "async-promise-queue": "^1.0.3",
-        "broccoli-plugin": "^4.0.3",
-        "fs-tree-diff": "^2.0.0",
-        "hash-for-dep": "^1.5.0",
-        "heimdalljs": "^0.2.1",
-        "heimdalljs-logger": "^0.1.7",
-        "promise-map-series": "^0.2.1",
-        "rimraf": "^3.0.0",
-        "symlink-or-copy": "^1.0.1",
-        "sync-disk-cache": "^2.0.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/editions": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
-      "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
-      "dev": true,
-      "dependencies": {
-        "errlop": "^2.0.0",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=0.8"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/editions/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/ember-basic-dropdown": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/ember-basic-dropdown/-/ember-basic-dropdown-6.0.2.tgz",
-      "integrity": "sha512-JgI/cy7eS/Y2WoQl7B2Mko/1aFTAlxr5d+KpQeH7rBKOFml7IQtLvhiDQrpU/FLkrQ9aLNEJtzwtDZV1xQxAKA==",
-      "dev": true,
-      "dependencies": {
-        "@ember/render-modifiers": "^2.0.4",
-        "@embroider/macros": "^1.2.0",
-        "@embroider/util": "^1.2.0",
-        "@glimmer/component": "^1.0.4",
-        "@glimmer/tracking": "^1.0.4",
-        "ember-cli-babel": "^7.26.11",
-        "ember-cli-htmlbars": "^6.0.1",
-        "ember-cli-typescript": "^4.2.1",
-        "ember-element-helper": "^0.6.0",
-        "ember-get-config": "^2.1.1",
-        "ember-maybe-in-element": "^2.0.3",
-        "ember-modifier": "^3.2.7",
-        "ember-style-modifier": "^0.8.0 || ^1.0.0",
-        "ember-truth-helpers": "^2.1.0 || ^3.0.0"
-      },
-      "engines": {
-        "node": "12.* || 14.* || >= 16"
-      }
-    },
-    "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/ember-basic-dropdown/node_modules/ember-cli-typescript": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-4.2.1.tgz",
-      "integrity": "sha512-0iKTZ+/wH6UB/VTWKvGuXlmwiE8HSIGcxHamwNhEC5x1mN3z8RfvsFZdQWYUzIWFN2Tek0gmepGRPTwWdBYl/A==",
-      "dev": true,
-      "dependencies": {
-        "ansi-to-html": "^0.6.15",
-        "broccoli-stew": "^3.0.0",
-        "debug": "^4.0.0",
-        "execa": "^4.0.0",
-        "fs-extra": "^9.0.1",
-        "resolve": "^1.5.0",
-        "rsvp": "^4.8.1",
-        "semver": "^7.3.2",
-        "stagehand": "^1.0.0",
-        "walk-sync": "^2.2.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/ember-concurrency": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/ember-concurrency/-/ember-concurrency-2.3.7.tgz",
-      "integrity": "sha512-sz6sTIXN/CuLb5wdpauFa+rWXuvXXSnSHS4kuNzU5GSMDX1pLBWSuovoUk61FUe6CYRqBmT1/UushObwBGickQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.12.13",
-        "@babel/types": "^7.12.13",
-        "@glimmer/tracking": "^1.0.4",
-        "ember-cli-babel": "^7.26.11",
-        "ember-cli-babel-plugin-helpers": "^1.1.1",
-        "ember-cli-htmlbars": "^5.7.1",
-        "ember-compatibility-helpers": "^1.2.0",
-        "ember-destroyable-polyfill": "^2.0.2"
-      },
-      "engines": {
-        "node": "10.* || 12.* || 14.* || >= 16"
-      }
-    },
-    "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/ember-concurrency/node_modules/ember-cli-htmlbars": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.2.tgz",
-      "integrity": "sha512-Uj6R+3TtBV5RZoJY14oZn/sNPnc+UgmC8nb5rI4P3fR/gYoyTFIZSXiIM7zl++IpMoIrocxOrgt+mhonKphgGg==",
-      "dev": true,
-      "dependencies": {
-        "@ember/edition-utils": "^1.2.0",
-        "babel-plugin-htmlbars-inline-precompile": "^5.0.0",
-        "broccoli-debug": "^0.6.5",
-        "broccoli-persistent-filter": "^3.1.2",
-        "broccoli-plugin": "^4.0.3",
-        "common-tags": "^1.8.0",
-        "ember-cli-babel-plugin-helpers": "^1.1.1",
-        "ember-cli-version-checker": "^5.1.2",
-        "fs-tree-diff": "^2.0.1",
-        "hash-for-dep": "^1.5.1",
-        "heimdalljs-logger": "^0.1.10",
-        "json-stable-stringify": "^1.0.1",
-        "semver": "^7.3.4",
-        "silent-error": "^1.1.1",
-        "strip-bom": "^4.0.0",
-        "walk-sync": "^2.2.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/ember-power-select": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ember-power-select/-/ember-power-select-6.0.1.tgz",
-      "integrity": "sha512-YslsjEUzdHhFfUP7IlklQuKt6rFG/VS38JLCjTYiCcBKrl76pxky/PoGMx3V+Ukh5mI77mGfA7BSKpKv8MAQAw==",
-      "dev": true,
-      "dependencies": {
-        "@embroider/util": "^1.0.0",
-        "@glimmer/component": "^1.1.2",
-        "@glimmer/tracking": "^1.1.2",
-        "ember-assign-helper": "^0.4.0",
-        "ember-basic-dropdown": "^6.0.0",
-        "ember-cli-babel": "^7.26.11",
-        "ember-cli-htmlbars": "^6.1.0",
-        "ember-cli-typescript": "^4.2.0",
-        "ember-concurrency": ">=1.0.0 <3",
-        "ember-concurrency-decorators": "^2.0.0",
-        "ember-text-measurer": "^0.6.0",
-        "ember-truth-helpers": "^3.0.0"
-      },
-      "engines": {
-        "node": "14.* || >= 16"
-      }
-    },
-    "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/ember-power-select/node_modules/ember-cli-typescript": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-4.2.1.tgz",
-      "integrity": "sha512-0iKTZ+/wH6UB/VTWKvGuXlmwiE8HSIGcxHamwNhEC5x1mN3z8RfvsFZdQWYUzIWFN2Tek0gmepGRPTwWdBYl/A==",
-      "dev": true,
-      "dependencies": {
-        "ansi-to-html": "^0.6.15",
-        "broccoli-stew": "^3.0.0",
-        "debug": "^4.0.0",
-        "execa": "^4.0.0",
-        "fs-extra": "^9.0.1",
-        "resolve": "^1.5.0",
-        "rsvp": "^4.8.1",
-        "semver": "^7.3.2",
-        "stagehand": "^1.0.0",
-        "walk-sync": "^2.2.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/ember-style-modifier": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ember-style-modifier/-/ember-style-modifier-1.0.0.tgz",
-      "integrity": "sha512-ANkYpOeI3/tkRxVz750ymb8cQBqfBTKOUOz4RPRsNys8rlaBiaKEa95XLz1JWfCXCzjmqe8i2cIdnAMix+nb3A==",
-      "dev": true,
-      "dependencies": {
-        "ember-cli-babel": "^7.26.11",
-        "ember-modifier": "^3.2.7"
-      },
-      "engines": {
-        "node": "14.* || >= 16"
-      }
-    },
-    "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/ember-truth-helpers": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/ember-truth-helpers/-/ember-truth-helpers-3.1.1.tgz",
-      "integrity": "sha512-FHwJAx77aA5q27EhdaaiBFuy9No+8yaWNT5A7zs0sIFCmf14GbcLn69vJEp6mW7vkITezizGAWhw7gL0Wbk7DA==",
-      "dev": true,
-      "dependencies": {
-        "ember-cli-babel": "^7.22.1"
-      },
-      "engines": {
-        "node": "10.* || >= 12"
-      }
-    },
-    "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/execa": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
-      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "get-stream": "^5.0.0",
-        "human-signals": "^1.1.1",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.0",
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/fs-tree-diff": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
-      "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
-      "dev": true,
-      "dependencies": {
-        "@types/symlink-or-copy": "^1.2.0",
-        "heimdalljs-logger": "^0.1.7",
-        "object-assign": "^4.1.0",
-        "path-posix": "^1.0.0",
-        "symlink-or-copy": "^1.1.8"
-      },
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dev": true,
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/human-signals": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.12.0"
-      }
-    },
-    "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/istextorbinary": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
-      "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
-      "dev": true,
-      "dependencies": {
-        "binaryextensions": "^2.1.2",
-        "editions": "^2.2.0",
-        "textextensions": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/rsvp": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-      "dev": true,
-      "engines": {
-        "node": "6.* || >= 7.*"
-      }
-    },
-    "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/strip-bom": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/walk-sync": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "ensure-posix-path": "^1.1.0",
-        "matcher-collection": "^2.0.0",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
-      }
-    },
     "node_modules/@lblod/ember-rdfa-editor/node_modules/ember-cli-typescript": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz",
@@ -5133,18 +4726,6 @@
       },
       "engines": {
         "node": ">= 12.*"
-      }
-    },
-    "node_modules/@lblod/ember-rdfa-editor/node_modules/ember-truth-helpers": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/ember-truth-helpers/-/ember-truth-helpers-3.1.1.tgz",
-      "integrity": "sha512-FHwJAx77aA5q27EhdaaiBFuy9No+8yaWNT5A7zs0sIFCmf14GbcLn69vJEp6mW7vkITezizGAWhw7gL0Wbk7DA==",
-      "dev": true,
-      "dependencies": {
-        "ember-cli-babel": "^7.22.1"
-      },
-      "engines": {
-        "node": "10.* || >= 12"
       }
     },
     "node_modules/@lblod/ember-rdfa-editor/node_modules/execa": {
@@ -12075,7 +11656,7 @@
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
       "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -13852,35 +13433,34 @@
       }
     },
     "node_modules/ember-basic-dropdown": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/ember-basic-dropdown/-/ember-basic-dropdown-7.1.0.tgz",
-      "integrity": "sha512-ZXFsX81WdF8WXjJb3VQjbZHqql+ozyQxh2YH44FODRd4K6xSLJt5Cvnl1CFcXawF/2+bI4u3b6Z3fIaJnGakGg==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/ember-basic-dropdown/-/ember-basic-dropdown-6.0.2.tgz",
+      "integrity": "sha512-JgI/cy7eS/Y2WoQl7B2Mko/1aFTAlxr5d+KpQeH7rBKOFml7IQtLvhiDQrpU/FLkrQ9aLNEJtzwtDZV1xQxAKA==",
       "dev": true,
       "dependencies": {
-        "@ember/render-modifiers": "^2.0.5",
-        "@embroider/macros": "^1.10.0",
-        "@embroider/util": "^1.10.0",
-        "@glimmer/component": "^1.1.2",
-        "@glimmer/tracking": "^1.1.2",
-        "ember-auto-import": "^2.6.3",
+        "@ember/render-modifiers": "^2.0.4",
+        "@embroider/macros": "^1.2.0",
+        "@embroider/util": "^1.2.0",
+        "@glimmer/component": "^1.0.4",
+        "@glimmer/tracking": "^1.0.4",
         "ember-cli-babel": "^7.26.11",
-        "ember-cli-htmlbars": "^6.2.0",
-        "ember-cli-typescript": "^5.2.1",
-        "ember-element-helper": "^0.6.1",
+        "ember-cli-htmlbars": "^6.0.1",
+        "ember-cli-typescript": "^4.2.1",
+        "ember-element-helper": "^0.6.0",
         "ember-get-config": "^2.1.1",
-        "ember-maybe-in-element": "^2.1.0",
-        "ember-modifier": "^3.2.7 || ^4.0.0",
-        "ember-style-modifier": "^0.8.0 || ^1.0.0 || ^2.0.0 || ^3.0.0",
+        "ember-maybe-in-element": "^2.0.3",
+        "ember-modifier": "^3.2.7",
+        "ember-style-modifier": "^0.8.0 || ^1.0.0",
         "ember-truth-helpers": "^2.1.0 || ^3.0.0"
       },
       "engines": {
-        "node": "16.* || >= 18"
+        "node": "12.* || 14.* || >= 16"
       }
     },
     "node_modules/ember-basic-dropdown/node_modules/ember-cli-typescript": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz",
-      "integrity": "sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-4.2.1.tgz",
+      "integrity": "sha512-0iKTZ+/wH6UB/VTWKvGuXlmwiE8HSIGcxHamwNhEC5x1mN3z8RfvsFZdQWYUzIWFN2Tek0gmepGRPTwWdBYl/A==",
       "dev": true,
       "dependencies": {
         "ansi-to-html": "^0.6.15",
@@ -13895,19 +13475,7 @@
         "walk-sync": "^2.2.0"
       },
       "engines": {
-        "node": ">= 12.*"
-      }
-    },
-    "node_modules/ember-basic-dropdown/node_modules/ember-truth-helpers": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/ember-truth-helpers/-/ember-truth-helpers-3.1.1.tgz",
-      "integrity": "sha512-FHwJAx77aA5q27EhdaaiBFuy9No+8yaWNT5A7zs0sIFCmf14GbcLn69vJEp6mW7vkITezizGAWhw7gL0Wbk7DA==",
-      "dev": true,
-      "dependencies": {
-        "ember-cli-babel": "^7.22.1"
-      },
-      "engines": {
-        "node": "10.* || >= 12"
+        "node": "10.* || >= 12.*"
       }
     },
     "node_modules/ember-basic-dropdown/node_modules/execa": {
@@ -15994,7 +15562,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-6.2.0.tgz",
       "integrity": "sha512-j5EGixjGau23HrqRiW/JjoAovg5UBHfjbyN7wX5ekE90knIEqUUj1z/Mo/cTx/J2VepQ2lE6HdXW9LWQ/WdMtw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@ember/edition-utils": "^1.2.0",
         "babel-plugin-ember-template-compilation": "^2.0.0",
@@ -16019,7 +15587,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
       "integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "debug": "^4.1.1",
         "heimdalljs": "^0.2.3",
@@ -16037,7 +15605,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.3.tgz",
       "integrity": "sha512-Q+8iezprZzL9voaBsDY3rQVl7c7H5h+bvv8SpzCZXPZgfBFCbx7KFQ2c3rZR6lW5k4Kwoqt7jG+rZMUg67Gwxw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "async-disk-cache": "^2.0.0",
         "async-promise-queue": "^1.0.3",
@@ -16059,7 +15627,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
       "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "errlop": "^2.0.0",
         "semver": "^6.3.0"
@@ -16075,7 +15643,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -16084,7 +15652,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
       "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/symlink-or-copy": "^1.2.0",
         "heimdalljs-logger": "^0.1.7",
@@ -16100,7 +15668,7 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
       "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "binaryextensions": "^2.1.2",
         "editions": "^2.2.0",
@@ -16117,7 +15685,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "devOptional": true,
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -16126,7 +15694,7 @@
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -16138,7 +15706,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -16153,7 +15721,7 @@
       "version": "4.8.5",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": "6.* || >= 7.*"
       }
@@ -16162,7 +15730,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
       "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/minimatch": "^3.0.3",
         "ensure-posix-path": "^1.1.0",
@@ -17013,24 +16581,22 @@
       "dev": true
     },
     "node_modules/ember-concurrency": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/ember-concurrency/-/ember-concurrency-3.1.1.tgz",
-      "integrity": "sha512-doXFYYfy1C7jez+jDDlfahTp03QdjXeSY/W3Zbnx/q3UNJ9g10Shf2d7M/HvWo/TC22eU+6dPLIpqd/6q4pR+Q==",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/ember-concurrency/-/ember-concurrency-2.3.7.tgz",
+      "integrity": "sha512-sz6sTIXN/CuLb5wdpauFa+rWXuvXXSnSHS4kuNzU5GSMDX1pLBWSuovoUk61FUe6CYRqBmT1/UushObwBGickQ==",
       "devOptional": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13",
         "@babel/types": "^7.12.13",
-        "@glimmer/tracking": "^1.1.2",
+        "@glimmer/tracking": "^1.0.4",
         "ember-cli-babel": "^7.26.11",
         "ember-cli-babel-plugin-helpers": "^1.1.1",
-        "ember-cli-htmlbars": "^6.2.0",
-        "ember-compatibility-helpers": "^1.2.0"
+        "ember-cli-htmlbars": "^5.7.1",
+        "ember-compatibility-helpers": "^1.2.0",
+        "ember-destroyable-polyfill": "^2.0.2"
       },
       "engines": {
-        "node": "16.* || >= 18"
-      },
-      "peerDependencies": {
-        "ember-source": "^3.28.0 || ^4.0.0 || >=5.0.0"
+        "node": "10.* || 12.* || 14.* || >= 16"
       }
     },
     "node_modules/ember-concurrency-decorators": {
@@ -17388,6 +16954,200 @@
       "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
       "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
       "dev": true,
+      "dependencies": {
+        "@types/minimatch": "^3.0.3",
+        "ensure-posix-path": "^1.1.0",
+        "matcher-collection": "^2.0.0",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": "8.* || >= 10.*"
+      }
+    },
+    "node_modules/ember-concurrency/node_modules/async-disk-cache": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
+      "integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
+      "devOptional": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "heimdalljs": "^0.2.3",
+        "istextorbinary": "^2.5.1",
+        "mkdirp": "^0.5.0",
+        "rimraf": "^3.0.0",
+        "rsvp": "^4.8.5",
+        "username-sync": "^1.0.2"
+      },
+      "engines": {
+        "node": "8.* || >= 10.*"
+      }
+    },
+    "node_modules/ember-concurrency/node_modules/broccoli-persistent-filter": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.3.tgz",
+      "integrity": "sha512-Q+8iezprZzL9voaBsDY3rQVl7c7H5h+bvv8SpzCZXPZgfBFCbx7KFQ2c3rZR6lW5k4Kwoqt7jG+rZMUg67Gwxw==",
+      "devOptional": true,
+      "dependencies": {
+        "async-disk-cache": "^2.0.0",
+        "async-promise-queue": "^1.0.3",
+        "broccoli-plugin": "^4.0.3",
+        "fs-tree-diff": "^2.0.0",
+        "hash-for-dep": "^1.5.0",
+        "heimdalljs": "^0.2.1",
+        "heimdalljs-logger": "^0.1.7",
+        "promise-map-series": "^0.2.1",
+        "rimraf": "^3.0.0",
+        "symlink-or-copy": "^1.0.1",
+        "sync-disk-cache": "^2.0.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/ember-concurrency/node_modules/editions": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
+      "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
+      "devOptional": true,
+      "dependencies": {
+        "errlop": "^2.0.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/ember-concurrency/node_modules/editions/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "devOptional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/ember-concurrency/node_modules/ember-cli-htmlbars": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.2.tgz",
+      "integrity": "sha512-Uj6R+3TtBV5RZoJY14oZn/sNPnc+UgmC8nb5rI4P3fR/gYoyTFIZSXiIM7zl++IpMoIrocxOrgt+mhonKphgGg==",
+      "devOptional": true,
+      "dependencies": {
+        "@ember/edition-utils": "^1.2.0",
+        "babel-plugin-htmlbars-inline-precompile": "^5.0.0",
+        "broccoli-debug": "^0.6.5",
+        "broccoli-persistent-filter": "^3.1.2",
+        "broccoli-plugin": "^4.0.3",
+        "common-tags": "^1.8.0",
+        "ember-cli-babel-plugin-helpers": "^1.1.1",
+        "ember-cli-version-checker": "^5.1.2",
+        "fs-tree-diff": "^2.0.1",
+        "hash-for-dep": "^1.5.1",
+        "heimdalljs-logger": "^0.1.10",
+        "json-stable-stringify": "^1.0.1",
+        "semver": "^7.3.4",
+        "silent-error": "^1.1.1",
+        "strip-bom": "^4.0.0",
+        "walk-sync": "^2.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/ember-concurrency/node_modules/fs-tree-diff": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
+      "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
+      "devOptional": true,
+      "dependencies": {
+        "@types/symlink-or-copy": "^1.2.0",
+        "heimdalljs-logger": "^0.1.7",
+        "object-assign": "^4.1.0",
+        "path-posix": "^1.0.0",
+        "symlink-or-copy": "^1.1.8"
+      },
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/ember-concurrency/node_modules/istextorbinary": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
+      "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
+      "devOptional": true,
+      "dependencies": {
+        "binaryextensions": "^2.1.2",
+        "editions": "^2.2.0",
+        "textextensions": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/ember-concurrency/node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "devOptional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ember-concurrency/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "devOptional": true,
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/ember-concurrency/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "devOptional": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ember-concurrency/node_modules/rsvp": {
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+      "devOptional": true,
+      "engines": {
+        "node": "6.* || >= 7.*"
+      }
+    },
+    "node_modules/ember-concurrency/node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "devOptional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ember-concurrency/node_modules/walk-sync": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
+      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
+      "devOptional": true,
       "dependencies": {
         "@types/minimatch": "^3.0.3",
         "ensure-posix-path": "^1.1.0",
@@ -18376,18 +18136,6 @@
         "node": "8.* || >= 10.*"
       }
     },
-    "node_modules/ember-data-table/node_modules/ember-truth-helpers": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/ember-truth-helpers/-/ember-truth-helpers-3.1.1.tgz",
-      "integrity": "sha512-FHwJAx77aA5q27EhdaaiBFuy9No+8yaWNT5A7zs0sIFCmf14GbcLn69vJEp6mW7vkITezizGAWhw7gL0Wbk7DA==",
-      "dev": true,
-      "dependencies": {
-        "ember-cli-babel": "^7.22.1"
-      },
-      "engines": {
-        "node": "10.* || >= 12"
-      }
-    },
     "node_modules/ember-data-table/node_modules/enhanced-resolve": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
@@ -19005,7 +18753,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/ember-destroyable-polyfill/-/ember-destroyable-polyfill-2.0.3.tgz",
       "integrity": "sha512-TovtNqCumzyAiW0/OisSkkVK93xnVF4NRU6+FN0ubpfwEOpRrmM2RqDwXI6YAChCgSHON1cz0DfQStpA1Gjuuw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "ember-cli-babel": "^7.22.1",
         "ember-cli-version-checker": "^5.1.1",
@@ -21630,96 +21378,32 @@
       }
     },
     "node_modules/ember-power-select": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/ember-power-select/-/ember-power-select-7.0.0.tgz",
-      "integrity": "sha512-FKeeF1PqYw5XfPPGoHP0aPG0X/3W15v9O2nk0z54oVeLIUTn2R3Ry9iSLa0/mAjDi1Cn7Zdnyki4Z1oM2aWOuA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ember-power-select/-/ember-power-select-6.0.1.tgz",
+      "integrity": "sha512-YslsjEUzdHhFfUP7IlklQuKt6rFG/VS38JLCjTYiCcBKrl76pxky/PoGMx3V+Ukh5mI77mGfA7BSKpKv8MAQAw==",
       "dev": true,
       "dependencies": {
         "@embroider/util": "^1.0.0",
         "@glimmer/component": "^1.1.2",
         "@glimmer/tracking": "^1.1.2",
         "ember-assign-helper": "^0.4.0",
-        "ember-basic-dropdown": "^7.0.1",
+        "ember-basic-dropdown": "^6.0.0",
         "ember-cli-babel": "^7.26.11",
         "ember-cli-htmlbars": "^6.1.0",
-        "ember-cli-typescript": "^5.0.0",
-        "ember-concurrency": "^2.0.0",
+        "ember-cli-typescript": "^4.2.0",
+        "ember-concurrency": ">=1.0.0 <3",
+        "ember-concurrency-decorators": "^2.0.0",
         "ember-text-measurer": "^0.6.0",
-        "ember-truth-helpers": "^3.1.0"
+        "ember-truth-helpers": "^3.0.0"
       },
       "engines": {
         "node": "14.* || >= 16"
       }
     },
-    "node_modules/ember-power-select/node_modules/async-disk-cache": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
-      "integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "heimdalljs": "^0.2.3",
-        "istextorbinary": "^2.5.1",
-        "mkdirp": "^0.5.0",
-        "rimraf": "^3.0.0",
-        "rsvp": "^4.8.5",
-        "username-sync": "^1.0.2"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
-      }
-    },
-    "node_modules/ember-power-select/node_modules/broccoli-persistent-filter": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.3.tgz",
-      "integrity": "sha512-Q+8iezprZzL9voaBsDY3rQVl7c7H5h+bvv8SpzCZXPZgfBFCbx7KFQ2c3rZR6lW5k4Kwoqt7jG+rZMUg67Gwxw==",
-      "dev": true,
-      "dependencies": {
-        "async-disk-cache": "^2.0.0",
-        "async-promise-queue": "^1.0.3",
-        "broccoli-plugin": "^4.0.3",
-        "fs-tree-diff": "^2.0.0",
-        "hash-for-dep": "^1.5.0",
-        "heimdalljs": "^0.2.1",
-        "heimdalljs-logger": "^0.1.7",
-        "promise-map-series": "^0.2.1",
-        "rimraf": "^3.0.0",
-        "symlink-or-copy": "^1.0.1",
-        "sync-disk-cache": "^2.0.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-power-select/node_modules/editions": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
-      "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
-      "dev": true,
-      "dependencies": {
-        "errlop": "^2.0.0",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=0.8"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/ember-power-select/node_modules/editions/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/ember-power-select/node_modules/ember-cli-typescript": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz",
-      "integrity": "sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-4.2.1.tgz",
+      "integrity": "sha512-0iKTZ+/wH6UB/VTWKvGuXlmwiE8HSIGcxHamwNhEC5x1mN3z8RfvsFZdQWYUzIWFN2Tek0gmepGRPTwWdBYl/A==",
       "dev": true,
       "dependencies": {
         "ansi-to-html": "^0.6.15",
@@ -21734,65 +21418,7 @@
         "walk-sync": "^2.2.0"
       },
       "engines": {
-        "node": ">= 12.*"
-      }
-    },
-    "node_modules/ember-power-select/node_modules/ember-concurrency": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/ember-concurrency/-/ember-concurrency-2.3.7.tgz",
-      "integrity": "sha512-sz6sTIXN/CuLb5wdpauFa+rWXuvXXSnSHS4kuNzU5GSMDX1pLBWSuovoUk61FUe6CYRqBmT1/UushObwBGickQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.12.13",
-        "@babel/types": "^7.12.13",
-        "@glimmer/tracking": "^1.0.4",
-        "ember-cli-babel": "^7.26.11",
-        "ember-cli-babel-plugin-helpers": "^1.1.1",
-        "ember-cli-htmlbars": "^5.7.1",
-        "ember-compatibility-helpers": "^1.2.0",
-        "ember-destroyable-polyfill": "^2.0.2"
-      },
-      "engines": {
-        "node": "10.* || 12.* || 14.* || >= 16"
-      }
-    },
-    "node_modules/ember-power-select/node_modules/ember-concurrency/node_modules/ember-cli-htmlbars": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.2.tgz",
-      "integrity": "sha512-Uj6R+3TtBV5RZoJY14oZn/sNPnc+UgmC8nb5rI4P3fR/gYoyTFIZSXiIM7zl++IpMoIrocxOrgt+mhonKphgGg==",
-      "dev": true,
-      "dependencies": {
-        "@ember/edition-utils": "^1.2.0",
-        "babel-plugin-htmlbars-inline-precompile": "^5.0.0",
-        "broccoli-debug": "^0.6.5",
-        "broccoli-persistent-filter": "^3.1.2",
-        "broccoli-plugin": "^4.0.3",
-        "common-tags": "^1.8.0",
-        "ember-cli-babel-plugin-helpers": "^1.1.1",
-        "ember-cli-version-checker": "^5.1.2",
-        "fs-tree-diff": "^2.0.1",
-        "hash-for-dep": "^1.5.1",
-        "heimdalljs-logger": "^0.1.10",
-        "json-stable-stringify": "^1.0.1",
-        "semver": "^7.3.4",
-        "silent-error": "^1.1.1",
-        "strip-bom": "^4.0.0",
-        "walk-sync": "^2.2.0"
-      },
-      "engines": {
         "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-power-select/node_modules/ember-truth-helpers": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/ember-truth-helpers/-/ember-truth-helpers-3.1.1.tgz",
-      "integrity": "sha512-FHwJAx77aA5q27EhdaaiBFuy9No+8yaWNT5A7zs0sIFCmf14GbcLn69vJEp6mW7vkITezizGAWhw7gL0Wbk7DA==",
-      "dev": true,
-      "dependencies": {
-        "ember-cli-babel": "^7.22.1"
-      },
-      "engines": {
-        "node": "10.* || >= 12"
       }
     },
     "node_modules/ember-power-select/node_modules/execa": {
@@ -21816,22 +21442,6 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/ember-power-select/node_modules/fs-tree-diff": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
-      "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
-      "dev": true,
-      "dependencies": {
-        "@types/symlink-or-copy": "^1.2.0",
-        "heimdalljs-logger": "^0.1.7",
-        "object-assign": "^4.1.0",
-        "path-posix": "^1.0.0",
-        "symlink-or-copy": "^1.1.8"
-      },
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/ember-power-select/node_modules/get-stream": {
@@ -21858,59 +21468,6 @@
         "node": ">=8.12.0"
       }
     },
-    "node_modules/ember-power-select/node_modules/istextorbinary": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
-      "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
-      "dev": true,
-      "dependencies": {
-        "binaryextensions": "^2.1.2",
-        "editions": "^2.2.0",
-        "textextensions": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/ember-power-select/node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/ember-power-select/node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/ember-power-select/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/ember-power-select/node_modules/rsvp": {
       "version": "4.8.5",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
@@ -21918,15 +21475,6 @@
       "dev": true,
       "engines": {
         "node": "6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-power-select/node_modules/strip-bom": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/ember-power-select/node_modules/walk-sync": {
@@ -22435,20 +21983,16 @@
       }
     },
     "node_modules/ember-style-modifier": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ember-style-modifier/-/ember-style-modifier-3.0.1.tgz",
-      "integrity": "sha512-WHRVIiqY/dpwDtVWlnHW0P4Z+Jha8QEwfaQdIF2ckJL77ZKdjbV2j1XZymS0Nzj61EGx5BM+YEsGL16r3hLv2A==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ember-style-modifier/-/ember-style-modifier-1.0.0.tgz",
+      "integrity": "sha512-ANkYpOeI3/tkRxVz750ymb8cQBqfBTKOUOz4RPRsNys8rlaBiaKEa95XLz1JWfCXCzjmqe8i2cIdnAMix+nb3A==",
       "dev": true,
       "dependencies": {
-        "ember-auto-import": "^2.5.0",
         "ember-cli-babel": "^7.26.11",
-        "ember-modifier": "^3.2.7 || ^4.0.0"
+        "ember-modifier": "^3.2.7"
       },
       "engines": {
-        "node": "14.* || 16.* || >= 18"
-      },
-      "peerDependencies": {
-        "@ember/string": "^3.0.1"
+        "node": "14.* || >= 16"
       }
     },
     "node_modules/ember-template-imports": {
@@ -23217,16 +22761,15 @@
       }
     },
     "node_modules/ember-truth-helpers": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/ember-truth-helpers/-/ember-truth-helpers-4.0.2.tgz",
-      "integrity": "sha512-mTsPwKAVf6D0Mm5leHRPSGl/WkSpKIvgooQKIT9iqQr0FbPHBa10yjYinQ+xR1w4Ea7wDblJ+HtRY426z0koAQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/ember-truth-helpers/-/ember-truth-helpers-3.1.1.tgz",
+      "integrity": "sha512-FHwJAx77aA5q27EhdaaiBFuy9No+8yaWNT5A7zs0sIFCmf14GbcLn69vJEp6mW7vkITezizGAWhw7gL0Wbk7DA==",
       "dev": true,
       "dependencies": {
-        "@embroider/addon-shim": "^1.8.6",
-        "ember-functions-as-helper-polyfill": "^2.1.2"
+        "ember-cli-babel": "^7.22.1"
       },
-      "peerDependencies": {
-        "ember-source": ">=3.28.0"
+      "engines": {
+        "node": "10.* || >= 12"
       }
     },
     "node_modules/ember-unique-id-helper-polyfill": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "ember-cli-string-helpers": "^6.1.0",
     "ember-cli-terser": "^4.0.2",
     "ember-composable-helpers": "^5.0.0",
-    "ember-concurrency": "^3.1.1",
+    "ember-concurrency": "^2.3.7",
     "ember-config-helper": "^0.1.3",
     "ember-could-get-used-to-this": "^1.0.1",
     "ember-data": "~4.8.8",
@@ -79,7 +79,7 @@
     "ember-modifier": "^3.2.7",
     "ember-page-title": "^7.0.0",
     "ember-plausible": "^0.2.0",
-    "ember-power-select": "^7.0.0",
+    "ember-power-select": "^6.0.1",
     "ember-promise-helpers": "^2.0.0",
     "ember-qunit": "^6.0.0",
     "ember-resolver": "^10.1.1",
@@ -87,7 +87,7 @@
     "ember-simple-auth": "^4.2.2",
     "ember-source": "~4.8.0",
     "ember-template-lint": "^5.11.2",
-    "ember-truth-helpers": "^4.0.2",
+    "ember-truth-helpers": "^3.1.1",
     "eslint": "^8.49.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-ember": "^11.11.1",
@@ -107,6 +107,11 @@
     "tracked-built-ins": "^3.1.1",
     "uuid": "^9.0.0",
     "webpack": "^5.88.2"
+  },
+  "overrides": {
+    "@appuniversum/ember-appuniversum": {
+      "tracked-toolbox": "^2.0.0"
+    }
   },
   "engines": {
     "node": "16.* || >= 18"


### PR DESCRIPTION
### Overview

GN-4528: Fix issues reported by `dependency-lint`

* fix issues reported by `dependency-lint`
* require `dependency-lint` CI job to pass

Most of the issues reported were fixed by reducing the major version that was bumped by dependabot. 

The trickiest one was forcing `@appuniversum/ember-appuniversum` to resolve `tracked-toolbox` to `^2.0.0`. Turns out you need to use `overrides` field for `npm` not `resolutions` like `yarn` does 😵‍💫 
Using overrides is the expected approach from appuniversum team - https://github.com/appuniversum/ember-appuniversum/pull/421#issuecomment-1706553230

#### Connected issues and PRs:

https://binnenland.atlassian.net/browse/GN-4528


### Setup

1. Checkout
2. `npm i`
3. `ember dependency-lint`

### How to test/reproduce

`ember dependency-lint` should pass


### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
