### PR TITLE
Also save title when saving document + fix save pill and don't allow empty titles

### DIFF
--- a/.changeset/wet-forks-smell.md
+++ b/.changeset/wet-forks-smell.md
@@ -1,0 +1,8 @@
+---
+'frontend-gelinkt-notuleren': minor
+---
+
+- automatically save the document title if clicking outside of the title input box
+- Do not allow empty document titles
+- saving a document will also save its title
+- the "saved" pill will only show up if something is actually saved

--- a/app/components/editor-document-title.hbs
+++ b/app/components/editor-document-title.hbs
@@ -4,7 +4,7 @@
   </h1>
 {{else}}
   {{#if this.active}}
-    <form {{on 'submit' this.submit}} {{on "focusout" this.cancel}}>
+    <form {{on 'submit' this.submit}} {{on "focusout" this.submit}}>
       <div class="au-c-app-chrome__title-group {{if this.error "au-c-input--error"}}">
         {{#let (unique-id) as |id|}}
           <AuLabel for={{id}} class="au-u-hidden-visually">

--- a/app/components/editor-document-title.hbs
+++ b/app/components/editor-document-title.hbs
@@ -5,18 +5,19 @@
 {{else}}
   {{#if this.active}}
     <form {{on 'submit' this.submit}} {{on "focusout" this.submit}}>
-      <div class="au-c-app-chrome__title-group {{if this.error "au-c-input--error"}}">
+      <div class="au-c-app-chrome__title-group">
         {{#let (unique-id) as |id|}}
-          <AuLabel for={{id}} class="au-u-hidden-visually">
+<AuLabel for={{id}} class="au-u-hidden-visually">
             {{t "editor-document-title-agendapoint-title"}}
           </AuLabel>
             <input
-              class="au-c-app-chrome__title-input {{if this.error "au-c-input--error"}}"
+              class="au-c-app-chrome__title-input {{if this.isInvalidTitle "au-c-input--error"}}"
               placeholder={{t "editor-document-title.placeholder"}}
               id={{id}}
               type="text"
               value={{this.title}}
               {{on "input" this.setTitle}}
+              {{on "keydown" this.cancelOnEscape}}
               {{did-insert this.focus}}
             />
         {{/let}}
@@ -26,7 +27,7 @@
           @skin="secondary"
           @icon="check"
           @hideText={{true}}
-          @disabled={{not this.titleModified}}
+          @disabled={{this.isInvalidTitle}}
         >{{t "editor-document-title.change-title"}}</AuButton>
       </div>
     </form>
@@ -35,7 +36,7 @@
       {{limit-content this.title 70}} 
       <AuButton {{on "click" this.enableEdit}} @icon="pencil" @skin="tertiary" @hideText={{true}} >{{t "editor-document-title.change-title"}}</AuButton>
     </h1>
-    {{#if this.showSaved}}
+    {{#if this.showIsSavedTask.isRunning}}
       <AuPill
         @skin="success"
         @icon="check"

--- a/app/components/editor-document-title.js
+++ b/app/components/editor-document-title.js
@@ -1,12 +1,14 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import { isBlank } from '../utils/strings';
+import { restartableTask, timeout } from 'ember-concurrency';
 
 export default class EditorDocumentTitleComponent extends Component {
   @tracked active = false;
   @tracked error = false;
   @tracked _title;
-  @tracked showSaved = false;
+
   constructor() {
     super(...arguments);
     this.active = this.args.editActive;
@@ -20,11 +22,16 @@ export default class EditorDocumentTitleComponent extends Component {
     }
   }
 
-  get titleModified() {
+  get isTitleModified() {
     if (!this._title) {
       return false;
     }
     return this.args.title !== this._title;
+  }
+
+  get isInvalidTitle() {
+    // do not allow empty titles
+    return isBlank(this.title);
   }
 
   @action
@@ -40,18 +47,30 @@ export default class EditorDocumentTitleComponent extends Component {
   @action
   submit(event) {
     event.preventDefault();
+    if (this.isInvalidTitle || !this.isTitleModified) {
+      this.cancel();
+      return;
+    }
     this.args.onSubmit?.(this.title);
-    this.disabledEdit();
-    this.showSaved = true;
-    setTimeout(() => (this.showSaved = false), 30000);
+    this.disableEdit();
+    this.showIsSavedTask.perform();
     return false;
   }
 
+  showIsSavedTask = restartableTask(async () => {
+    await timeout(3000);
+  });
+
   @action
-  cancel(event) {
-    if (!event.currentTarget.contains(event.relatedTarget)) {
-      this._title = undefined;
-      this.disabledEdit();
+  cancel() {
+    this._title = undefined;
+    this.disableEdit();
+  }
+
+  @action
+  cancelOnEscape(keyEvent) {
+    if (keyEvent.key === 'Escape') {
+      this.cancel();
     }
   }
 
@@ -59,6 +78,7 @@ export default class EditorDocumentTitleComponent extends Component {
   // the cancel event + submit which cause a bug in prod environments.
   @action
   enableEdit() {
+    this.showIsSavedTask.cancelAll();
     if (this.active) {
       return;
     }
@@ -66,15 +86,11 @@ export default class EditorDocumentTitleComponent extends Component {
   }
 
   @action
-  disabledEdit() {
+  disableEdit() {
     if (!this.active) {
       return;
     }
-    if (!this.title) {
-      this.error = true;
-    } else {
-      this.active = false;
-    }
+    this.active = false;
   }
 
   @action

--- a/app/utils/strings.js
+++ b/app/utils/strings.js
@@ -1,0 +1,3 @@
+export function isBlank(str) {
+  return !str || /^\s*$/.test(str);
+}


### PR DESCRIPTION
### Overview
See mostly https://github.com/lblod/frontend-reglementaire-bijlage/pull/191 (copied from there)

- Empty titles are not permitted
- If title is empty, an error shows up
- save pill is only shown if something is actually saved
- save pill logic is a lot simpler and more logical, using the state of ember-concurrency, instead of keeping the exact same state ourselves.
- title is automatically save if focus is lost. => **ticket fix**: this fixes the original ticket issue. When pressing save-document button, the title input box will lose focus, making it automatically save together with saving the document.


##### connected issues and PRs:
[binnenland.atlassian.net/browse/GN-4473](https://binnenland.atlassian.net/browse/GN-4473)

similar changes in https://github.com/lblod/frontend-reglementaire-bijlage/pull/191


### How to test/reproduce
- try to save the title of any document (e.g. a regulatory statement). See if it works as expected and save-pill does not show up if nothing was saved.
- It should never be possible to save an empty title.
- Pressing save for the document should also save the title.
- Press escape and see your title not being changed.
