### PR TITLE
GN-4525 Changes to support removal of ember-data from plugins

### DIFF
--- a/.changeset/two-pants-thank.md
+++ b/.changeset/two-pants-thank.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Pass standard templates into standard template plugin instead of it loading them itself

--- a/app/components/document-creator.js
+++ b/app/components/document-creator.js
@@ -15,7 +15,6 @@ export default class DocumentCreatorComponent extends Component {
   @tracked errorSaving;
 
   @service store;
-  @service standardTemplatePlugin;
   @service currentSession;
   @service documentService;
 

--- a/app/controllers/agendapoints/edit.js
+++ b/app/controllers/agendapoints/edit.js
@@ -159,6 +159,7 @@ export default class AgendapointsEditController extends Controller {
   });
 
   get config() {
+    const classificatie = this.currentSession.classificatie;
     return {
       date: {
         formats: [
@@ -195,6 +196,7 @@ export default class AgendapointsEditController extends Controller {
       },
       besluitType: {
         endpoint: 'https://centrale-vindplaats.lblod.info/sparql',
+        classificatieUri: classificatie.uri,
       },
       structures: structureSpecs,
     };

--- a/app/controllers/agendapoints/edit.js
+++ b/app/controllers/agendapoints/edit.js
@@ -101,6 +101,7 @@ export default class AgendapointsEditController extends Controller {
   @service router;
   @service documentService;
   @service currentSession;
+
   @tracked hasDocumentValidationErrors = false;
   @tracked displayDeleteModal = false;
   @tracked _editorDocument;

--- a/app/controllers/agendapoints/edit.js
+++ b/app/controllers/agendapoints/edit.js
@@ -196,7 +196,7 @@ export default class AgendapointsEditController extends Controller {
       },
       besluitType: {
         endpoint: 'https://centrale-vindplaats.lblod.info/sparql',
-        classificatieUri: classificatie.uri,
+        classificatieUri: classificatie?.uri,
       },
       structures: structureSpecs,
     };
@@ -204,7 +204,7 @@ export default class AgendapointsEditController extends Controller {
 
   get defaultMunicipality() {
     const classificatie = this.currentSession.classificatie;
-    if (classificatie.uri === GEMEENTE || classificatie.uri === OCMW) {
+    if (classificatie?.uri === GEMEENTE || classificatie?.uri === OCMW) {
       return this.currentSession.group.naam;
     } else {
       return null;

--- a/app/controllers/regulatory-statements/edit.js
+++ b/app/controllers/regulatory-statements/edit.js
@@ -268,7 +268,7 @@ export default class RegulatoryStatementsRoute extends Controller {
   get defaultMunicipality() {
     const classificatie = this.currentSession.classificatie;
 
-    if (classificatie.uri === GEMEENTE || classificatie.uri === OCMW) {
+    if (classificatie?.uri === GEMEENTE || classificatie?.uri === OCMW) {
       return this.currentSession.group.naam;
     } else {
       return null;

--- a/app/models/template.js
+++ b/app/models/template.js
@@ -1,1 +1,8 @@
-export { default } from '@lblod/ember-rdfa-editor-lblod-plugins/models/template';
+import Model, { attr } from '@ember-data/model';
+export default class TemplateModel extends Model {
+  @attr title;
+  @attr('string-set', { defaultValue: () => [] }) matches;
+  @attr body;
+  @attr('string-set', { defaultValue: () => [] }) contexts;
+  @attr('string-set', { defaultValue: () => [] }) disabledInContexts;
+}

--- a/app/routes/agendapoints/edit.js
+++ b/app/routes/agendapoints/edit.js
@@ -4,6 +4,7 @@ import { service } from '@ember/service';
 export default class AgendapointsEditRoute extends Route {
   @service currentSession;
   @service router;
+  @service standardTemplate;
 
   beforeModel(transition) {
     if (!this.currentSession.canWrite) {
@@ -16,10 +17,13 @@ export default class AgendapointsEditRoute extends Route {
   async model() {
     const { documentContainer, returnToMeeting } =
       this.modelFor('agendapoints');
+    const standardTemplates =
+      await this.standardTemplate.fetchTemplates.perform();
     return {
       documentContainer,
       editorDocument: await documentContainer.get('currentVersion'),
       returnToMeeting,
+      standardTemplates,
     };
   }
 

--- a/app/routes/inbox/agendapoints/new.js
+++ b/app/routes/inbox/agendapoints/new.js
@@ -4,7 +4,7 @@ import { service } from '@ember/service';
 export default class InboxAgendapointsNewRoute extends Route {
   @service currentSession;
   @service router;
-  @service standardTemplatePlugin;
+  @service standardTemplate;
 
   beforeModel() {
     if (!this.currentSession.canWrite) {
@@ -13,9 +13,8 @@ export default class InboxAgendapointsNewRoute extends Route {
   }
 
   async model() {
-    const templates =
-      await this.standardTemplatePlugin.fetchTemplates.perform();
-    return this.standardTemplatePlugin.templatesForContext(templates, [
+    const templates = await this.standardTemplate.fetchTemplates.perform();
+    return this.standardTemplate.templatesForContext(templates, [
       'http://data.vlaanderen.be/ns/besluit#BehandelingVanAgendapunt',
     ]);
   }

--- a/app/routes/regulatory-statements/edit.js
+++ b/app/routes/regulatory-statements/edit.js
@@ -6,6 +6,7 @@ export default class RegulatoryStatementsEditRoute extends Route {
   @service currentSession;
   @service store;
   @service router;
+  @service standardTemplate;
 
   beforeModel(transition) {
     if (!this.currentSession.canWrite) {
@@ -21,10 +22,13 @@ export default class RegulatoryStatementsEditRoute extends Route {
       params.id,
       { include: 'status' },
     );
+    const standardTemplates =
+      await this.standardTemplate.fetchTemplates.perform();
     const currentVersion = await container.get('currentVersion');
     return RSVP.hash({
       documentContainer: container,
       editorDocument: currentVersion,
+      standardTemplates,
     });
   }
   setupController(controller, model) {

--- a/app/services/standard-template.js
+++ b/app/services/standard-template.js
@@ -1,0 +1,51 @@
+import Service, { inject as service } from '@ember/service';
+import { task, waitForProperty } from 'ember-concurrency';
+import { tracked } from '@glimmer/tracking';
+
+const BLACKLISTED_TEMPLATES = new Set(['Citeeropschrift']);
+
+export default class StandardTemplateService extends Service {
+  @service store;
+  @tracked templates;
+
+  constructor(...args) {
+    super(...args);
+    this.loadTemplates().catch((err) =>
+      console.error('Error loading standard templates', err),
+    );
+  }
+
+  fetchTemplates = task(async () => {
+    await waitForProperty(this, 'templates');
+    return this.templates;
+  });
+
+  async loadTemplates() {
+    const templates = await this.store.query('template', {
+      fields: { templates: 'title,contexts,matches,disabled-in-contexts' },
+    });
+    this.templates = templates.filter(
+      (template) => !BLACKLISTED_TEMPLATES.has(template.title),
+    );
+  }
+
+  /**
+   Filter the valid templates for a context.
+   @method templatesForContext
+   @param {Array} Array of templates
+   @param {Array} The path of rdfaContext objects from the root till the current context
+   @return {Array} Array of templates (filtered)
+   @private
+   */
+  templatesForContext(templates, rdfaTypes) {
+    const isMatchingForContext = (template) => {
+      return (
+        rdfaTypes.filter((e) => template.get('contexts').includes(e)).length >
+          0 &&
+        rdfaTypes.filter((e) => template.get('disabledInContexts').includes(e))
+          .length === 0
+      );
+    };
+    return templates.filter(isMatchingForContext);
+  }
+}

--- a/app/services/standard-template.js
+++ b/app/services/standard-template.js
@@ -21,9 +21,7 @@ export default class StandardTemplateService extends Service {
   });
 
   async loadTemplates() {
-    const templates = await this.store.query('template', {
-      fields: { templates: 'title,contexts,matches,disabled-in-contexts' },
-    });
+    const templates = await this.store.findAll('template');
     this.templates = templates.filter(
       (template) => !BLACKLISTED_TEMPLATES.has(template.title),
     );

--- a/app/templates/agendapoints/edit.hbs
+++ b/app/templates/agendapoints/edit.hbs
@@ -115,6 +115,7 @@
     <:toolbar>
       <BesluitTypePlugin::ToolbarDropdown
         @controller={{this.controller}}
+        @classificatieUri={{this.config.classificatieUri}}
         @options={{this.config.besluitType}}
       />
       <Plugins::Formatting::FormattingToggle @controller={{this.controller}} />

--- a/app/templates/agendapoints/edit.hbs
+++ b/app/templates/agendapoints/edit.hbs
@@ -137,7 +137,10 @@
         @controller={{this.controller}}
         @options={{this.config.roadsignRegulation}}
       />
-      <StandardTemplatePlugin::Card @controller={{this.controller}} />
+      <StandardTemplatePlugin::Card
+        @controller={{this.controller}}
+        @templates={{this.model.standardTemplates}}
+      />
       {{#if (feature-flag 'regulatoryStatements')}}
         <EditorPlugins::RegulatoryStatements::SidebarInsert
           @controller={{this.controller}}

--- a/app/templates/regulatory-statements/edit.hbs
+++ b/app/templates/regulatory-statements/edit.hbs
@@ -129,7 +129,10 @@
         @controller={{this.controller}}
         @options={{this.config.date}}
       />
-      <StandardTemplatePlugin::Card @controller={{this.controller}} />
+      <StandardTemplatePlugin::Card
+        @controller={{this.controller}}
+        @templates={{this.model.standardTemplates}}
+      />
       <TemplateCommentsPlugin::Insert @controller={{this.controller}} />
       <VariablePlugin::Address::Insert @controller={{this.controller}} />
     </:sidebarCollapsible>

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@lblod/ember-environment-banner": "^0.2.0",
         "@lblod/ember-mock-login": "0.7.0",
         "@lblod/ember-rdfa-editor": "^6.1.0",
-        "@lblod/ember-rdfa-editor-lblod-plugins": "^13.0.0",
+        "@lblod/ember-rdfa-editor-lblod-plugins": "^14.0.0",
         "@release-it-plugins/lerna-changelog": "^6.0.0",
         "broccoli-asset-rev": "^3.0.0",
         "broccoli-plugin": "^4.0.7",
@@ -4658,9 +4658,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor-lblod-plugins": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-13.0.0.tgz",
-      "integrity": "sha512-9hWR4Cchf+7rdv7WFxKX7wJLPgdwx72L/q0VzqB95Jfvbhx7JlrD9x2aIlvsLZ071YUCxSU5yok5djJe84ZMsA==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-14.0.0.tgz",
+      "integrity": "sha512-GwGEVqXhfq70PC9gNkvSH2HNHI77MuP5YEGiun5wLoz2wEgdSPB5D68Neb1Wywcd8WFyGF7EjtP2figAdg93qw==",
       "dev": true,
       "dependencies": {
         "@codemirror/lang-html": "^6.4.3",
@@ -4702,7 +4702,6 @@
         "@glint/template": "^1.1.0",
         "@lblod/ember-rdfa-editor": "^6.0.0",
         "ember-concurrency": "^2.3.7",
-        "ember-data": "^3.28.0 || ^4.0.0",
         "ember-modifier": "^3.2.7",
         "ember-source": "^3.28.0 || ^4.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@lblod/ember-environment-banner": "^0.2.0",
     "@lblod/ember-mock-login": "0.7.0",
     "@lblod/ember-rdfa-editor": "^6.1.0",
-    "@lblod/ember-rdfa-editor-lblod-plugins": "^13.0.0",
+    "@lblod/ember-rdfa-editor-lblod-plugins": "^14.0.0",
     "@release-it-plugins/lerna-changelog": "^6.0.0",
     "broccoli-asset-rev": "^3.0.0",
     "broccoli-plugin": "^4.0.7",


### PR DESCRIPTION
### Overview
Pull standard-template-service from plugins and pass templates in to the standard template plugin.
Edit: modified to also pass in classificatieUri to besluit-type-plugin as needed by [plugins](https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/314)

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-4525
https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/313
https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/314

### Setup
Needs the latest plugins as that uses the passed in templates correctly. This shouldn't break with older versions of the plugins though as it's simply passing in an arg that isn't used.

### How to test/reproduce
Test that editing agenda points and inserting templates works as expected.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
