### PR TITLE
Add say-content styling to all treatment content (Fixes sub/superscript)

### DIFF
--- a/.changeset/pink-readers-destroy.md
+++ b/.changeset/pink-readers-destroy.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Use the say-content style for any treatment content, like rendering sub/superscripts correctly

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -40,6 +40,10 @@
 @import "template-comments-plugin";
 @import "project/p-annotations"; // @TODO: refactor in ember-rdfa-editor
 
+// give treatment (behandeling) content the same style as other say-documents
+.c-template-content--treatment {
+   @include say-content();
+}
 
 // PROJECT UTILITIES
 @import 'project/u-print'; // @TODO: refactor in ember-appuniversum where possible


### PR DESCRIPTION
### Overview
Some preview content in GN did not show the same as content on other places. The problem comes from a missing class `say-content`.
This adds the same styling of `say-content` to `c-template-content--treatment`, which contains this content where the styling was missing.

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-4210
https://github.com/lblod/ember-rdfa-editor/pull/989

### Setup
npm link the editor
`npm link @lblod/ember-rdfa-editor` in this repo

### How to test/reproduce
See ticket for a specific example. The easiest is to add some superscript/subscript to an agenda item and see that this is rendered correctly on any place an agenda item is rendered.

### Challenges/uncertainties
I wanted to avoid this solution as it is a bit hacky (and needs an editor change)
However:
- changing the preview means changing the notulen-prepublish-service template, which is something we don't want to touch. It might also mean that this extra class would be added to a published document. In principle `c-template-content--treatment` is enough as a class to identify the treatment part in the template. No need to add another class.
- could also add the class `say-content` in the frontend somehow. 
  - add `say-content` via queries in components, but there are many components showing this preview.
  - add `say-content` class via queries in a special getter for treatment (e.g. `previewContent`). But this means parsing the html before it is rendered. This might be better, but for big documents this could take some time and the css fix is quite easy to understand.


