### PR TITLE
Update `@lblod/ember-rdfa-editor` to 6.2.0

### DIFF
--- a/.changeset/strong-rabbits-travel.md
+++ b/.changeset/strong-rabbits-travel.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Update `@lblod/ember-rdfa-editor` to 6.2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@lblod/ember-acmidm-login": "^2.0.0-beta.1",
         "@lblod/ember-environment-banner": "^0.2.0",
         "@lblod/ember-mock-login": "0.7.0",
-        "@lblod/ember-rdfa-editor": "^6.1.0",
+        "@lblod/ember-rdfa-editor": "^6.2.0",
         "@lblod/ember-rdfa-editor-lblod-plugins": "^13.0.0",
         "@release-it-plugins/lerna-changelog": "^6.0.0",
         "broccoli-asset-rev": "^3.0.0",
@@ -4589,9 +4589,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-6.1.0.tgz",
-      "integrity": "sha512-82d9yG71T598Mw9Oxm7UNmx4wM8RVLd6m7Qujtd3K3ic2/feceDOFydqOE2h6pzhdFUIY8ro78wXZCQ18+BQhA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-6.2.0.tgz",
+      "integrity": "sha512-8+qWZnpqKsIPd6D7R5uTKqT7pgCNoEGrAqyXv19YSWbIwfoJ6xf8LWW/+Ulvf2k5TfaeFYMWGSnO9Q4IQI6QNw==",
       "dev": true,
       "dependencies": {
         "@codemirror/lang-html": "^6.1.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@lblod/ember-acmidm-login": "^2.0.0-beta.1",
     "@lblod/ember-environment-banner": "^0.2.0",
     "@lblod/ember-mock-login": "0.7.0",
-    "@lblod/ember-rdfa-editor": "^6.1.0",
+    "@lblod/ember-rdfa-editor": "^6.2.0",
     "@lblod/ember-rdfa-editor-lblod-plugins": "^13.0.0",
     "@release-it-plugins/lerna-changelog": "^6.0.0",
     "broccoli-asset-rev": "^3.0.0",


### PR DESCRIPTION
### Overview
Updates the `@lblod/ember-rdfa-editor` package to 6.2.0 which includes embedded-editor fixes and a `say-content` sass-mixin.