### PR TITLE
GN-4529 Fix bug when saving a blank agenda point required reload to insert

### DIFF
--- a/.changeset/early-eagles-exercise.md
+++ b/.changeset/early-eagles-exercise.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Fix bug in creating agenda points, where after saving a blank document, a reload was needed to insert decision templates

--- a/app/templates/agendapoints/edit.hbs
+++ b/app/templates/agendapoints/edit.hbs
@@ -98,7 +98,7 @@
 >
   <RdfaEditorContainer
     @rdfaEditorInit={{this.handleRdfaEditorInit}}
-    @typeOfWrappingDiv='besluit:BehandelingVanAgendapunt'
+    @typeOfWrappingDiv='http://data.vlaanderen.be/ns/besluit#BehandelingVanAgendapunt'
     @showToggleRdfaAnnotations={{true}}
     @editorDocument={{this.editorDocument}}
     @busy={{or this.saveTask.isRunning this.copyAgendapunt.isRunning}}


### PR DESCRIPTION
### Overview
After saving the RDFA parser lacks prefix information that it has on first load (see [related](https://binnenland.atlassian.net/browse/GN-3728). This was resulting in the standard template plugin being unable to match any templates as relevant as it didn't know how to interpret the `besluit` prefix. This is a workaround to use an un-prefixed version to wrap the RdfaEditorContainer.

##### connected issues and PRs:
Issue: https://binnenland.atlassian.net/browse/GN-4529
Ticket for wider issue: https://binnenland.atlassian.net/browse/GN-3728

### Setup
N/A

### How to test/reproduce
See [ticket](https://binnenland.atlassian.net/browse/GN-4529) for screens.
Open a new 'vrije text' agenda point
Confirm (without using them) that there are decision template options in the insert sidebar
Click save
Confirm that they are still there (bug is that they were missing).

### Challenges/uncertainties
I didn't look for other prefixed uris that might cause issues. The use of a prefixed version of this exact uri in `app/controllers/meetings/publish/notulen.js#L332` was confirmed to work only with the existing prefixed version, so was left as-is.

### Checks PR readiness
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
