### PR TITLE
GN-4529: ensure editor is only initialized after prefix attribute of wrapping div has been set

### DIFF
--- a/.changeset/famous-balloons-smell.md
+++ b/.changeset/famous-balloons-smell.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Ensure editor is only initalized after correct prefix attribute has been set

--- a/app/components/rdfa-editor-container.hbs
+++ b/app/components/rdfa-editor-container.hbs
@@ -24,7 +24,7 @@
     </div>
   </AuBodyContainer>
 {{else}}
-  <AuBodyContainer vocab="{{this.vocab}}" {{did-insert this.setPrefix}}
+  <AuBodyContainer vocab="{{this.vocab}}" {{this.setUpPrefixAttr}}
        typeof="{{@typeOfWrappingDiv}}" property="{{@property}}" resource="#">
       {{#if this.ready}}
         <EditorContainer

--- a/app/components/rdfa-editor-container.js
+++ b/app/components/rdfa-editor-container.js
@@ -6,11 +6,30 @@ import applyDevTools from 'prosemirror-dev-tools';
 import { firefoxCursorFix } from '@lblod/ember-rdfa-editor/plugins/firefox-cursor-fix';
 import { lastKeyPressedPlugin } from '@lblod/ember-rdfa-editor/plugins/last-key-pressed';
 import { chromeHacksPlugin } from '@lblod/ember-rdfa-editor/plugins/chrome-hacks-plugin';
+import { modifier } from 'ember-modifier';
 
 export default class RdfaEditorContainerComponent extends Component {
   @service features;
   @tracked controller;
   @tracked ready = false;
+
+  /**
+   * this is a workaround because emberjs does not allow us to assign the prefix attribute in the template
+   * see https://github.com/emberjs/ember.js/issues/19369
+   */
+  setUpPrefixAttr = modifier(
+    (element) => {
+      element.setAttribute(
+        'prefix',
+        this.prefixToAttrString(this.documentContext.prefix),
+      );
+      this.ready = true;
+      return () => {
+        this.ready = false;
+      };
+    },
+    { eager: false },
+  );
 
   get plugins() {
     const plugins = this.args.plugins || [];
@@ -78,19 +97,6 @@ export default class RdfaEditorContainerComponent extends Component {
 
   get vocab() {
     return this.documentContext['vocab'];
-  }
-
-  /**
-   * this is a workaround because emberjs does not allow us to assign the prefix attribute in the template
-   * see https://github.com/emberjs/ember.js/issues/19369
-   */
-  @action
-  setPrefix(element) {
-    element.setAttribute(
-      'prefix',
-      this.prefixToAttrString(this.documentContext.prefix),
-    );
-    this.ready = true;
   }
 
   @action


### PR DESCRIPTION
### Overview
This PR ensures that the editor component is only initialized after the prefix attribute of it's wrapping container has been set.

This PR:
- introduces a `setUpPrefixAttr` modifier on the wrapping container which sets the prefix attribute. It also controls the `ready` property which indicates when the editor may be initialized.
 * After the `prefix` attribute has been set, the `ready` property is set to `true`
 * When the element linked to the `setUpPrefixAttr` modifier is destroyed, the `ready` property is set to `false` (as the prefix attribute no longer exists)
=> this also means that the `setUpPrefixAttr` modifier is not generic and is only meant to be used in combination with the wrapping container.

This PR should solve the issue with the datastore calculation after having saved a document. (When the datastore is calculated, the `prefix` attribute should be set)

##### connected issues and PRs:
Should solve [GN-4529](https://binnenland.atlassian.net/browse/GN-4529)

### How to test/reproduce
- Create an empty agendapoint
- Notice that you have the option to insert a template
- Save the document
- The options to insert templates should still be there.

### Challenges/uncertainties
- The modifier to set the prefix attribute is necessary as ember does not allow to set the `prefix` attribute directly in a template (see https://github.com/emberjs/ember.js/issues/19369)
- The new `setUpPrefixAttr` is not generic and should only be used once (as it controls the component property `ready`). I could not find a better way to solve this.



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
