### PR TITLE
 GN-XXX: Fix agendapoint/regulatory attachment template "reload"

### DIFF
--- a/.changeset/wild-melons-dress.md
+++ b/.changeset/wild-melons-dress.md
@@ -1,0 +1,5 @@
+---
+"frontend-gelinkt-notuleren": patch
+---
+
+GN-XXX: Fix agendapoint/regulatory attachment template "reload"

--- a/app/components/document-creator.js
+++ b/app/components/document-creator.js
@@ -79,9 +79,24 @@ export default class DocumentCreatorComponent extends Component {
 
   async buildTemplate() {
     if (this.template) {
-      if (this.template.reload) {
-        // regular templates from templatesForContext do not return body of template
-        await this.template.reload(this.template);
+      /**
+       * Document Creator component is used by two different screens:
+       *   - Create agenda point flow
+       *   - Create regulatory statements flow
+       *
+       * `templates` coming from regulatory statements flow are _NOT_ `TemplateModel` instances,
+       * they are just plain objects with a `title` and a `loadTemplateBody` property. So we
+       * have to use `loadTemplateBody` to load the template body if we need to build the template
+       * when creating a regulatory statement.
+       *
+       * This was previously checking and calling `this.template.reload`, but that was causing
+       * `reload` to mutate from function to a "boolean" when `TemplateModel` of `ember-data` is used,
+       * causing errors when calling `reload` on the template again, as it became a boolean.
+       *
+       * The fix was to change `reload` to `loadTemplateBody` in `RegulatoryAttachmentsFetcher`
+       */
+      if (this.template.loadTemplateBody) {
+        await this.template.loadTemplateBody(this.template);
       }
       const trimmedHtml = this.template.body.replace(/>\s+</g, '><');
       return instantiateUuids(trimmedHtml);

--- a/app/services/regulatory-attachments-fetcher.js
+++ b/app/services/regulatory-attachments-fetcher.js
@@ -27,7 +27,7 @@ export default class RegulatoryAttachmentsFetcher extends Service {
           pav:hasCurrentVersion ?container.
         ?container dct:title ?title;
           mu:uuid ?fileId.
-        OPTIONAL { 
+        OPTIONAL {
           ?container schema:validThrough ?validThrough.
         }
         FILTER( ! BOUND(?validThrough) || ?validThrough > NOW())
@@ -56,7 +56,7 @@ export default class RegulatoryAttachmentsFetcher extends Service {
       const bindings = json.results.bindings;
       const templates = bindings.map((binding) => ({
         title: binding.title.value,
-        reload: async (template) => {
+        loadTemplateBody: async (template) => {
           const response = await fetch(
             `${config.regulatoryStatementFileEndpoint}/${binding.fileId.value}/download`,
           );


### PR DESCRIPTION
### Overview

```ts
 /**
       * Document Creator component is used by two different screens:
       *   - Create agenda point flow
       *   - Create regulatory statements flow
       *
       * `templates` coming from regulatory statements flow are _NOT_ `TemplateModel` instances,
       * they are just plain objects with a `title` and a `loadTemplateBody` property. So we
       * have to use `loadTemplateBody` to load the template body if we need to build the template
       * when creating a regulatory statement.
       *
       * This was previously checking and calling `this.template.reload`, but that was causing
       * `reload` to mutate from function to a "boolean" when `TemplateModel` of `ember-data` is used,
       * causing errors when calling `reload` on the template again, as it became a boolean.
       *
       * The fix was to change `reload` to `loadTemplateBody` in `RegulatoryAttachmentsFetcher`
       */
```


##### connected issues and PRs:
<!-- links to connected jira tickets -->
<!-- Link to PRs that are related (and in what way) -->


### Setup
<!-- PR dependencies -->
<!-- override snippets -->

### How to test/reproduce

Below bug should not occur again

* Create Agenda Point - workds fine
* Go back to list
* Create another: "error: template.reload is not a function"
* Refresh
* Create Agenda Point - works again


### Checks PR readiness
- [X] UI: works on smaller screen sizes
- [X] UI: feedback for any loading/error states
- [X] Check cancel/go-back flows
- [X] Check database state correct when deleting/updating (especially regarding relationships)
- [X] changelog
- [X] npm lint
- [X] no new deprecations
