### PR TITLE
GN-4607: fix issue with editor of meeting intro/outro not rendering

### DIFF
--- a/.changeset/tricky-countries-bake.md
+++ b/.changeset/tricky-countries-bake.md
@@ -1,0 +1,5 @@
+---
+"frontend-gelinkt-notuleren": patch
+---
+
+Fix import paths of variable-date plugin in `zitting-text-document-container` component

--- a/app/components/zitting-text-document-container.hbs
+++ b/app/components/zitting-text-document-container.hbs
@@ -11,13 +11,13 @@
   @nodeViews={{this.nodeViews}}
 >
   <:sidebarCollapsible>
-    <RdfaDatePlugin::Insert
+    <VariablePlugin::Date::Insert
       @controller={{this.editor}}
       @options={{this.config.date}}
     />
   </:sidebarCollapsible>
   <:sidebar>
-    <RdfaDatePlugin::Card
+    <VariablePlugin::Date::Edit
       @controller={{this.editor}}
       @options={{this.config.date}}
     />

--- a/app/components/zitting-text-document-container.js
+++ b/app/components/zitting-text-document-container.js
@@ -43,7 +43,7 @@ import { inline_rdfa } from '@lblod/ember-rdfa-editor/marks';
 import {
   date,
   dateView,
-} from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/rdfa-date-plugin/nodes/date';
+} from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/variables';
 
 import { service } from '@ember/service';
 import { linkPasteHandler } from '@lblod/ember-rdfa-editor/plugins/link';


### PR DESCRIPTION
### Overview
This PR fixes an issue where the editor instances of an intro/outro of a meeting were not correctly rendered.
Specifically, this PR updates the import paths of the `date-variable` plugin in the `zitting-text-document-container` component.

##### connected issues and PRs:
[GN-4607](https://binnenland.atlassian.net/browse/GN-4607?atlOrigin=eyJpIjoiZDBjNjRlZDFmNDVkNGEzMGI2YmFhMTYxYzVlNzM5YmQiLCJwIjoiaiJ9)


### How to test/reproduce
**Before this fix**
- Start the app
- Open a meeting
- Open the intro/outro of a meeting
- The editor-component is blank and an error shows up

**After this fix**
- Start the app
- Open a meeting
- Open the intro/outro of a meeting
- The editor-component is correctly rendered. It is possible to insert and edit a date.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
