### PR TITLE
Use undo history to track 'isDirty' instead of comparing html strings

### DIFF
--- a/.changeset/smooth-maps-type.md
+++ b/.changeset/smooth-maps-type.md
@@ -1,0 +1,5 @@
+---
+"frontend-gelinkt-notuleren": patch
+---
+
+Correctly track the saved state so we only ask to save changes when changes have been made

--- a/app/controllers/agendapoints/edit.js
+++ b/app/controllers/agendapoints/edit.js
@@ -94,6 +94,7 @@ import {
   GEMEENTE,
   OCMW,
 } from '../../utils/bestuurseenheid-classificatie-codes';
+import { undo } from '@lblod/ember-rdfa-editor/plugins/history';
 
 export default class AgendapointsEditController extends Controller {
   @service store;
@@ -258,7 +259,11 @@ export default class AgendapointsEditController extends Controller {
   }
 
   get dirty() {
-    return this.editorDocument.content !== this.controller?.htmlContent;
+    // Since we clear the undo history when saving, this works. If we want to maintain undo history
+    // on save, we would need to add functionality to the editor to track what is the 'saved' state
+    return this.controller?.checkCommand(undo, {
+      view: this.controller?.mainEditorView,
+    });
   }
 
   get editorDocument() {

--- a/app/controllers/meetings/edit/intro.js
+++ b/app/controllers/meetings/edit/intro.js
@@ -3,6 +3,7 @@ import { task } from 'ember-concurrency';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
+import { undo } from '@lblod/ember-rdfa-editor/plugins/history';
 
 export default class MeetingsEditIntroController extends Controller {
   @service router;
@@ -10,7 +11,11 @@ export default class MeetingsEditIntroController extends Controller {
   @service intl;
 
   get dirty() {
-    return this.model.intro !== this.editor.htmlContent;
+    // Since we clear the undo history when saving, this works. If we want to maintain undo history
+    // on save, we would need to add functionality to the editor to track what is the 'saved' state
+    return this.editor?.checkCommand(undo, {
+      view: this.editor?.mainEditorView,
+    });
   }
 
   @action

--- a/app/controllers/meetings/edit/outro.js
+++ b/app/controllers/meetings/edit/outro.js
@@ -3,13 +3,18 @@ import { task } from 'ember-concurrency';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
+import { undo } from '@lblod/ember-rdfa-editor/plugins/history';
 
 export default class MeetingsEditOutroController extends Controller {
   @service router;
   @tracked editor;
 
   get dirty() {
-    return this.model.outro !== this.editor.htmlContent;
+    // Since we clear the undo history when saving, this works. If we want to maintain undo history
+    // on save, we would need to add functionality to the editor to track what is the 'saved' state
+    return this.editor?.checkCommand(undo, {
+      view: this.editor?.mainEditorView,
+    });
   }
 
   @action

--- a/app/controllers/regulatory-statements/edit.js
+++ b/app/controllers/regulatory-statements/edit.js
@@ -90,6 +90,7 @@ import {
   GEMEENTE,
   OCMW,
 } from '../../utils/bestuurseenheid-classificatie-codes';
+import { undo } from '@lblod/ember-rdfa-editor/plugins/history';
 
 export default class RegulatoryStatementsRoute extends Controller {
   @service documentService;
@@ -239,7 +240,11 @@ export default class RegulatoryStatementsRoute extends Controller {
   });
 
   get dirty() {
-    return this.editorDocument.content !== this.controller?.htmlContent;
+    // Since we clear the undo history when saving, this works. If we want to maintain undo history
+    // on save, we would need to add functionality to the editor to track what is the 'saved' state
+    return this.controller?.checkCommand(undo, {
+      view: this.controller?.mainEditorView,
+    });
   }
 
   get editorDocument() {


### PR DESCRIPTION
### Overview
Since we often add extra attributes to the html loaded into the editor, comparing the html input and that in the editor always fails, so we think the document has been modified. Since we clear the undo state on save, we can instead use this to determine whether all changes have been saved. This misses changes that have been manually undone, such as adding, then deleting the same text but this feels like an acceptable trade for the simplicity of this solution.

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-4016

### Setup
N/A

### How to test/reproduce
Open any agenda point or regulatory statement, optionally make some changes and undo them, then go back, you are no longer asked whether you want to leave with unsaved changes. If you have unsaved changes, it will ask to confirm.

### Challenges/uncertainties
As noted in the code, if we were to maintain the undo history, we would need to modify this functionality. Ideally this case would be supported directly by the editor.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
