### PR TITLE
Add translation for 'insert' in the sidebar

### DIFF
--- a/.changeset/weak-pumpkins-remain.md
+++ b/.changeset/weak-pumpkins-remain.md
@@ -1,0 +1,5 @@
+---
+"frontend-gelinkt-notuleren": patch
+---
+
+Correctly translate 'insert' in the sidebar

--- a/app/components/rdfa-editor-container.hbs
+++ b/app/components/rdfa-editor-container.hbs
@@ -96,7 +96,7 @@
             {{#if this.controller}}
               <Sidebar as |Sidebar|>
                 {{#if (has-block 'sidebarCollapsible')}}
-                  <Sidebar.Collapsible @title='Insert'>
+                  <Sidebar.Collapsible @title={{t "utils.insert"}}>
                     {{yield to='sidebarCollapsible'}}
                   </Sidebar.Collapsible>
                 {{/if}}

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -651,6 +651,7 @@ uittreksel-error:
 
 utils:
   save: Save
+  insert: Insert
   file-options: File options
   html-export: Export as HTML
   delete: Delete

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -649,6 +649,7 @@ uittreksel-error:
 
 utils:
   save: Bewaar
+  insert: Invoegen
   file-options: Bestand acties
   html-export: Exporteer als HTML
   delete: Naar prullenmand


### PR DESCRIPTION
### Overview
In the sidebar, this used to say 'Insert':
![image](https://github.com/lblod/frontend-gelinkt-notuleren/assets/1323250/ecdc73e9-c4fb-47e4-a975-55072f274ec0)

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-4665

### Setup
Recommended, some way to change locales easily, e.g. [this extension](https://addons.mozilla.org/en-US/firefox/addon/locale-switcher/)

### How to test/reproduce
Open any agendapoint or regulatory statement and confirm that the word 'insert' is in the correct language (NL for anything but locale of en-US).

### Challenges/uncertainties
I don't know the correct dutch and there seems to be difference with the `insert-label` translation.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
