### PR TITLE
Update editor packages

### DIFF
--- a/.changeset/dirty-goats-boil.md
+++ b/.changeset/dirty-goats-boil.md
@@ -1,0 +1,5 @@
+---
+"frontend-gelinkt-notuleren": patch
+---
+
+Update `@appuniversum/ember-appuniversum` to 2.15.0

--- a/.changeset/friendly-flies-arrive.md
+++ b/.changeset/friendly-flies-arrive.md
@@ -1,0 +1,5 @@
+---
+"frontend-gelinkt-notuleren": patch
+---
+
+Update `@lblod/ember-rdfa-editor` to 9.0.0

--- a/.changeset/funny-chicken-arrive.md
+++ b/.changeset/funny-chicken-arrive.md
@@ -1,0 +1,5 @@
+---
+"frontend-gelinkt-notuleren": patch
+---
+
+Update `ember-intl` to 6.1.0

--- a/.changeset/rich-mangos-bow.md
+++ b/.changeset/rich-mangos-bow.md
@@ -1,0 +1,5 @@
+---
+"frontend-gelinkt-notuleren": patch
+---
+
+Update `@lblod/ember-rdfa-editor-lblod-plugins` to 16.0.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "tracked-toolbox": "^2.0.0"
       },
       "devDependencies": {
-        "@appuniversum/ember-appuniversum": "^2.12.0",
+        "@appuniversum/ember-appuniversum": "~2.15.0",
         "@babel/eslint-parser": "^7.22.9",
         "@babel/plugin-proposal-decorators": "^7.22.5",
         "@changesets/changelog-github": "^0.4.8",
@@ -28,8 +28,8 @@
         "@lblod/ember-acmidm-login": "^2.0.0-beta.1",
         "@lblod/ember-environment-banner": "^0.2.0",
         "@lblod/ember-mock-login": "0.7.0",
-        "@lblod/ember-rdfa-editor": "^8.2.0",
-        "@lblod/ember-rdfa-editor-lblod-plugins": "^15.2.2",
+        "@lblod/ember-rdfa-editor": "^9.0.0",
+        "@lblod/ember-rdfa-editor-lblod-plugins": "^16.0.0",
         "@release-it-plugins/lerna-changelog": "^6.0.0",
         "broccoli-asset-rev": "^3.0.0",
         "broccoli-plugin": "^4.0.7",
@@ -61,7 +61,7 @@
         "ember-drag-drop": "^0.9.0-beta.0",
         "ember-feature-flags": "^6.0.0",
         "ember-fetch": "^8.1.2",
-        "ember-intl": "^5.7.2",
+        "ember-intl": "^6.1.0",
         "ember-load-initializers": "^2.1.2",
         "ember-modifier": "^3.2.7",
         "ember-page-title": "^8.0.0",
@@ -120,20 +120,21 @@
       }
     },
     "node_modules/@appuniversum/ember-appuniversum": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@appuniversum/ember-appuniversum/-/ember-appuniversum-2.12.0.tgz",
-      "integrity": "sha512-b0VBhXbuNZ4DEYtctiSGdEto4tHoOso+Z2pheQeZDgKehufXwKEyZRRNwt3Ju24W3BDF0huhHLYLvKpdwtnYaw==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/@appuniversum/ember-appuniversum/-/ember-appuniversum-2.15.0.tgz",
+      "integrity": "sha512-Z77MTwJM7gWVt4rj6pckADETE+UxMtQD0vWSf+1aEedWqnDMWp853APlhJYz1VPq8xtfJL9g809XFQUmyHUN6A==",
       "dev": true,
       "dependencies": {
+        "@babel/core": "^7.22.10",
         "@duetds/date-picker": "^1.4.0",
         "@embroider/macros": "^1.9.0",
         "@floating-ui/dom": "^1.1.0",
         "@glimmer/component": "^1.1.2",
         "@glimmer/tracking": "^1.1.2",
         "@zestia/ember-auto-focus": "^4.2.0",
-        "ember-auto-import": "^2.5.0",
+        "ember-auto-import": "^2.6.3",
         "ember-cli-babel": "^7.26.11",
-        "ember-cli-htmlbars": "^6.2.0",
+        "ember-cli-htmlbars": "^6.3.0",
         "ember-concurrency": "2.x || ^3.1.0",
         "ember-data-table": "^2.1.0",
         "ember-file-upload": "^7.0.3",
@@ -151,15 +152,31 @@
         "ember-power-select": "2.x || 3.x || 4.x || 5.x || 6.x || 7.x"
       },
       "peerDependencies": {
-        "ember-source": "^3.28.0 || ^4.0.0"
+        "ember-source": "^3.28.0 || ^4.0.0 || ^5.0.0"
+      }
+    },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/ember-focus-trap": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ember-focus-trap/-/ember-focus-trap-1.1.0.tgz",
+      "integrity": "sha512-KxbCKpAJaBVZm+bW4tHPoBJAZThmxa6pI+WQusL+bj0RtAnGUNkWsVy6UBMZ5QqTQzf4EvGHkCVACVp5lbAWMQ==",
+      "dev": true,
+      "dependencies": {
+        "@embroider/addon-shim": "^1.0.0",
+        "focus-trap": "^6.7.1"
+      },
+      "engines": {
+        "node": "12.* || >= 14"
+      },
+      "peerDependencies": {
+        "ember-source": "^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.22.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
-      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
+      "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
       "dependencies": {
-        "@babel/highlight": "^7.22.13",
+        "@babel/highlight": "^7.23.4",
         "chalk": "^2.4.2"
       },
       "engines": {
@@ -231,33 +248,33 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.22.3",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.3.tgz",
-      "integrity": "sha512-aNtko9OPOwVESUFp3MZfD8Uzxl7JzSeJpd7npIoxCasU37PFbAQRpKglkaKwlHOyeJdrREpo8TW8ldrkYWwvIQ==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.5.tgz",
+      "integrity": "sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.22.1",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.1.tgz",
-      "integrity": "sha512-Hkqu7J4ynysSXxmAahpN1jjRwVJ+NdpraFLIWflgjpVob3KNyK3/tIUc7Q7szed8WMp0JNa7Qtd1E9Oo22F9gA==",
+      "version": "7.23.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.7.tgz",
+      "integrity": "sha512-+UpDgowcmqe36d4NwqvKsyPMlOLNGMsfMmQ5WGCu+siCe3t3dfe9njrzGfdN4qq+bcNUt0+Vw6haRxBOycs4dw==",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.21.4",
-        "@babel/generator": "^7.22.0",
-        "@babel/helper-compilation-targets": "^7.22.1",
-        "@babel/helper-module-transforms": "^7.22.1",
-        "@babel/helpers": "^7.22.0",
-        "@babel/parser": "^7.22.0",
-        "@babel/template": "^7.21.9",
-        "@babel/traverse": "^7.22.1",
-        "@babel/types": "^7.22.0",
-        "convert-source-map": "^1.7.0",
+        "@babel/code-frame": "^7.23.5",
+        "@babel/generator": "^7.23.6",
+        "@babel/helper-compilation-targets": "^7.23.6",
+        "@babel/helper-module-transforms": "^7.23.3",
+        "@babel/helpers": "^7.23.7",
+        "@babel/parser": "^7.23.6",
+        "@babel/template": "^7.22.15",
+        "@babel/traverse": "^7.23.7",
+        "@babel/types": "^7.23.6",
+        "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.2",
-        "semver": "^6.3.0"
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -266,6 +283,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/babel"
       }
+    },
+    "node_modules/@babel/core/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
     },
     "node_modules/@babel/core/node_modules/semver": {
       "version": "6.3.1",
@@ -312,11 +334,11 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
-      "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
+      "integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
       "dependencies": {
-        "@babel/types": "^7.23.0",
+        "@babel/types": "^7.23.6",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -348,21 +370,18 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.22.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.1.tgz",
-      "integrity": "sha512-Rqx13UM3yVB5q0D/KwQ8+SPfX/+Rnsy1Lw1k/UwOC4KC6qrzIQoY3lYnBu5EHKBlEHHcj0M0W8ltPSkD8rqfsQ==",
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
+      "integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
       "dependencies": {
-        "@babel/compat-data": "^7.22.0",
-        "@babel/helper-validator-option": "^7.21.0",
-        "browserslist": "^4.21.3",
+        "@babel/compat-data": "^7.23.5",
+        "@babel/helper-validator-option": "^7.23.5",
+        "browserslist": "^4.22.2",
         "lru-cache": "^5.1.1",
-        "semver": "^6.3.0"
+        "semver": "^6.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
@@ -374,19 +393,19 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.22.5.tgz",
-      "integrity": "sha512-xkb58MyOYIslxu3gKmVXmjTtUPvBU4odYzbiIQbWwLKIHCsx6UGZGX6F1IznMFVnDdirseUZopzN+ZRt8Xb33Q==",
+      "version": "7.23.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.23.7.tgz",
+      "integrity": "sha512-xCoqR/8+BoNnXOY7RVSgv6X+o7pmT5q1d+gGcRlXYkI+9B31glE4jeejhKVpA04O1AtzOt7OSQ6VYKP5FcRl9g==",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
-        "@babel/helper-environment-visitor": "^7.22.5",
-        "@babel/helper-function-name": "^7.22.5",
-        "@babel/helper-member-expression-to-functions": "^7.22.5",
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-function-name": "^7.23.0",
+        "@babel/helper-member-expression-to-functions": "^7.23.0",
         "@babel/helper-optimise-call-expression": "^7.22.5",
-        "@babel/helper-replace-supers": "^7.22.5",
+        "@babel/helper-replace-supers": "^7.22.20",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.5",
-        "semver": "^6.3.0"
+        "@babel/helper-split-export-declaration": "^7.22.6",
+        "semver": "^6.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -483,43 +502,43 @@
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.22.5.tgz",
-      "integrity": "sha512-aBiH1NKMG0H2cGZqspNvsaBe6wNGjbJjuLy29aU+eDZjSbbN53BaxlpB02xm9v34pLTZ1nIQPFYn2qMZoa5BQQ==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.23.0.tgz",
+      "integrity": "sha512-6gfrPwh7OuT6gZyJZvd6WbTfrqAo7vm4xCzAXOusKqq/vWdKXphTpj5klHKNmRUU6/QRGlBsyU9mAIPaWHlqJA==",
       "dependencies": {
-        "@babel/types": "^7.22.5"
+        "@babel/types": "^7.23.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.21.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.21.4.tgz",
-      "integrity": "sha512-orajc5T2PsRYUN3ZryCEFeMDYwyw09c/pZeaQEZPH0MpKzSvn3e0uXsDBu3k03VI+9DBiRo+l22BfKTpKwa/Wg==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
+      "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
       "dependencies": {
-        "@babel/types": "^7.21.4"
+        "@babel/types": "^7.22.15"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.22.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.1.tgz",
-      "integrity": "sha512-dxAe9E7ySDGbQdCVOY/4+UcD8M9ZFqZcZhSPsPacvCG4M+9lwtDDQfI2EoaSvmf7W/8yCBkGU0m7Pvt1ru3UZw==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
+      "integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
       "dependencies": {
-        "@babel/helper-environment-visitor": "^7.22.1",
-        "@babel/helper-module-imports": "^7.21.4",
-        "@babel/helper-simple-access": "^7.21.5",
-        "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/helper-validator-identifier": "^7.19.1",
-        "@babel/template": "^7.21.9",
-        "@babel/traverse": "^7.22.1",
-        "@babel/types": "^7.22.0"
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-module-imports": "^7.22.15",
+        "@babel/helper-simple-access": "^7.22.5",
+        "@babel/helper-split-export-declaration": "^7.22.6",
+        "@babel/helper-validator-identifier": "^7.22.20"
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/@babel/helper-optimise-call-expression": {
@@ -559,27 +578,27 @@
       }
     },
     "node_modules/@babel/helper-replace-supers": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.22.5.tgz",
-      "integrity": "sha512-aLdNM5I3kdI/V9xGNyKSF3X/gTyMUBohTZ+/3QdQKAA9vxIiy12E+8E2HoOP1/DjeqU+g6as35QHJNMDDYpuCg==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.22.20.tgz",
+      "integrity": "sha512-qsW0In3dbwQUbK8kejJ4R7IHVGwHJlV6lpG6UA7a9hSa2YEiAib+N1T2kr6PEeUT+Fl7najmSOS6SmAwCHK6Tw==",
       "dependencies": {
-        "@babel/helper-environment-visitor": "^7.22.5",
-        "@babel/helper-member-expression-to-functions": "^7.22.5",
-        "@babel/helper-optimise-call-expression": "^7.22.5",
-        "@babel/template": "^7.22.5",
-        "@babel/traverse": "^7.22.5",
-        "@babel/types": "^7.22.5"
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-member-expression-to-functions": "^7.22.15",
+        "@babel/helper-optimise-call-expression": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/@babel/helper-simple-access": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.21.5.tgz",
-      "integrity": "sha512-ENPDAMC1wAjR0uaCUwliBdiSl1KBJAVnMTzXqi64c2MG8MPR6ii4qf7bSXDqSFbr4W6W028/rf5ivoHop5/mkg==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
+      "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
       "dependencies": {
-        "@babel/types": "^7.21.5"
+        "@babel/types": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -608,9 +627,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
+      "integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -624,9 +643,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.21.0.tgz",
-      "integrity": "sha512-rmL/B8/f0mKS2baE9ZpyTcTavvEuWhTTW8amjzXNvYG4AwBsqTLikfXsEofsJEfKHf+HQVQbFOHy6o+4cnC/fQ==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
+      "integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -646,22 +665,22 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.22.3",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.3.tgz",
-      "integrity": "sha512-jBJ7jWblbgr7r6wYZHMdIqKc73ycaTcCaWRq4/2LpuPHcx7xMlZvpGQkOYc9HeSjn6rcx15CPlgVcBtZ4WZJ2w==",
+      "version": "7.23.8",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.8.tgz",
+      "integrity": "sha512-KDqYz4PiOWvDFrdHLPhKtCThtIcKVy6avWD2oG4GEvyQ+XDZwHD4YQd+H2vNMnq2rkdxsDkU82T+Vk8U/WXHRQ==",
       "dependencies": {
-        "@babel/template": "^7.21.9",
-        "@babel/traverse": "^7.22.1",
-        "@babel/types": "^7.22.3"
+        "@babel/template": "^7.22.15",
+        "@babel/traverse": "^7.23.7",
+        "@babel/types": "^7.23.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
-      "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
+      "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.22.20",
         "chalk": "^2.4.2",
@@ -736,9 +755,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
-      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz",
+      "integrity": "sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -1225,12 +1244,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-class-static-block": {
-      "version": "7.22.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.22.3.tgz",
-      "integrity": "sha512-5BirgNWNOx7cwbTJCOmKFJ1pZjwk5MUfMIwiBBvsirCJMZeQgs5pk6i1OlkVg+1Vef5LfBahFOrdCnAWvkVKMw==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.23.4.tgz",
+      "integrity": "sha512-nsWu/1M+ggti1SOALj3hfx5FXzAY06fwPJsUZD4/A5e1bWi46VUIWtD+kOX6/IdhXGsXBWllLFDSnqSCdUNydQ==",
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.22.1",
-        "@babel/helper-plugin-utils": "^7.21.5",
+        "@babel/helper-create-class-features-plugin": "^7.22.15",
+        "@babel/helper-plugin-utils": "^7.22.5",
         "@babel/plugin-syntax-class-static-block": "^7.14.5"
       },
       "engines": {
@@ -2058,19 +2077,19 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
-      "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
+      "version": "7.23.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.7.tgz",
+      "integrity": "sha512-tY3mM8rH9jM0YHFGyfC0/xf+SB5eKUu7HPj7/k3fpi9dAlsMc5YbQvDi0Sh2QTPXqMhyaAtzAr807TIyfQrmyg==",
       "dependencies": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.23.0",
+        "@babel/code-frame": "^7.23.5",
+        "@babel/generator": "^7.23.6",
         "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-function-name": "^7.23.0",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.23.0",
-        "@babel/types": "^7.23.0",
-        "debug": "^4.1.0",
+        "@babel/parser": "^7.23.6",
+        "@babel/types": "^7.23.6",
+        "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
       "engines": {
@@ -2078,11 +2097,11 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
-      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
+      "integrity": "sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.22.5",
+        "@babel/helper-string-parser": "^7.23.4",
         "@babel/helper-validator-identifier": "^7.22.20",
         "to-fast-properties": "^2.0.0"
       },
@@ -3874,52 +3893,97 @@
       }
     },
     "node_modules/@formatjs/ecma402-abstract": {
-      "version": "1.11.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.4.tgz",
-      "integrity": "sha512-EBikYFp2JCdIfGEb5G9dyCkTGDmC57KSHhRQOC3aYxoPWVZvfWCDjZwkGYHN7Lis/fmuWl906bnNTJifDQ3sXw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.18.0.tgz",
+      "integrity": "sha512-PEVLoa3zBevWSCZzPIM/lvPCi8P5l4G+NXQMc/CjEiaCWgyHieUoo0nM7Bs0n/NbuQ6JpXEolivQ9pKSBHaDlA==",
       "dev": true,
       "dependencies": {
-        "@formatjs/intl-localematcher": "0.2.25",
-        "tslib": "^2.1.0"
+        "@formatjs/intl-localematcher": "0.5.2",
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@formatjs/fast-memoize": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-1.2.1.tgz",
-      "integrity": "sha512-Rg0e76nomkz3vF9IPlKeV+Qynok0r7YZjL6syLz4/urSg0IbjPZCB/iYUMNsYA643gh4mgrX3T7KEIFIxJBQeg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.0.tgz",
+      "integrity": "sha512-hnk/nY8FyrL5YxwP9e4r9dqeM6cAbo8PeU9UjyXojZMNvVad2Z06FAVHyR3Ecw6fza+0GH7vdJgiKIVXTMbSBA==",
       "dev": true,
       "dependencies": {
-        "tslib": "^2.1.0"
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.1.0.tgz",
-      "integrity": "sha512-Qxv/lmCN6hKpBSss2uQ8IROVnta2r9jd3ymUEIjm2UyIkUCHVcbUVRGL/KS/wv7876edvsPe+hjHVJ4z8YuVaw==",
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.7.3.tgz",
+      "integrity": "sha512-X/jy10V9S/vW+qlplqhMUxR8wErQ0mmIYSq4mrjpjDl9mbuGcCILcI1SUYkL5nlM4PJqpc0KOS0bFkkJNPxYRw==",
       "dev": true,
       "dependencies": {
-        "@formatjs/ecma402-abstract": "1.11.4",
-        "@formatjs/icu-skeleton-parser": "1.3.6",
-        "tslib": "^2.1.0"
+        "@formatjs/ecma402-abstract": "1.18.0",
+        "@formatjs/icu-skeleton-parser": "1.7.0",
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.3.6.tgz",
-      "integrity": "sha512-I96mOxvml/YLrwU2Txnd4klA7V8fRhb6JG/4hm3VMNmeJo1F03IpV2L3wWt7EweqNLES59SZ4d6hVOPCSf80Bg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.7.0.tgz",
+      "integrity": "sha512-Cfdo/fgbZzpN/jlN/ptQVe0lRHora+8ezrEeg2RfrNjyp+YStwBy7cqDY8k5/z2LzXg6O0AdzAV91XS0zIWv+A==",
       "dev": true,
       "dependencies": {
-        "@formatjs/ecma402-abstract": "1.11.4",
-        "tslib": "^2.1.0"
+        "@formatjs/ecma402-abstract": "1.18.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@formatjs/intl": {
+      "version": "2.9.9",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-2.9.9.tgz",
+      "integrity": "sha512-JI3CNgL2Zdg5lv9ncT2sYKqbAj2RGrCbdzaCckIxMPxn4QuHuOVvYUGmBAXVusBmfG/0sxLmMrnwnBioz+QKdA==",
+      "dev": true,
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.18.0",
+        "@formatjs/fast-memoize": "2.2.0",
+        "@formatjs/icu-messageformat-parser": "2.7.3",
+        "@formatjs/intl-displaynames": "6.6.4",
+        "@formatjs/intl-listformat": "7.5.3",
+        "intl-messageformat": "10.5.8",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "typescript": "5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@formatjs/intl-displaynames": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-6.6.4.tgz",
+      "integrity": "sha512-ET8KQ+L9Q0K8x1SnJQa4DNssUcbATlMopWqYvGGR8yAvw5qwAQc1fv+DshCoZNIE9pbcue0IGC4kWNAkWqlFag==",
+      "dev": true,
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.18.0",
+        "@formatjs/intl-localematcher": "0.5.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@formatjs/intl-listformat": {
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-listformat/-/intl-listformat-7.5.3.tgz",
+      "integrity": "sha512-l7EOr0Yh1m8KagytukB90yw81uyzrM7amKFrgxXqphz4KeSIL0KPa68lPsdtZ+JmQB73GaDQRwLOwUKFZ1VZPQ==",
+      "dev": true,
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.18.0",
+        "@formatjs/intl-localematcher": "0.5.2",
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@formatjs/intl-localematcher": {
-      "version": "0.2.25",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.25.tgz",
-      "integrity": "sha512-YmLcX70BxoSopLFdLr1Ds99NdlTI2oWoLbaUW2M406lxOIPzE1KQhRz2fPUkq34xVZQaihCoU29h0KK7An3bhA==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.2.tgz",
+      "integrity": "sha512-txaaE2fiBMagLrR4jYhxzFO6wEdEG4TPMqrzBAcbr4HFUYzH/YC+lg6OIzKCHm8WgDdyQevxbAAV1OgcXctuGw==",
       "dev": true,
       "dependencies": {
-        "tslib": "^2.1.0"
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@gar/promisify": {
@@ -4725,9 +4789,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-8.2.0.tgz",
-      "integrity": "sha512-Fss216FPCF1J49hlvDUXhKCKT+v1xOKaGsmzbrdl8C4zeIdZi6v+irwQmTFKuTkbT4wfEeNmnybL5fDJ+yNMJg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-9.0.0.tgz",
+      "integrity": "sha512-xV1nsmnHKOVTYoi/9m7RvnXM45m72FtXI72ekxksc0KzseoVibGyTDhXlZZyYuhvOnjugFTxl+KAd7+wQ16oWw==",
       "dev": true,
       "dependencies": {
         "@codemirror/lang-html": "^6.1.1",
@@ -4752,9 +4816,7 @@
         "ember-cli-htmlbars": "^6.2.0",
         "ember-cli-typescript": "^5.1.0",
         "ember-focus-trap": "~1.0.1",
-        "ember-functions-as-helper-polyfill": "^2.1.2",
         "ember-truth-helpers": "^3.0.0",
-        "ember-unique-id-helper-polyfill": "^1.2.2",
         "ember-velcro": "^2.1.0",
         "handlebars": "^4.7.7",
         "handlebars-loader": "^1.7.2",
@@ -4770,7 +4832,7 @@
         "prosemirror-schema-basic": "^1.2.1",
         "prosemirror-schema-list": "^1.2.2",
         "prosemirror-state": "^1.4.2",
-        "prosemirror-tables": "^1.3.2",
+        "prosemirror-tables": "git://github.com/lblod/prosemirror-tables.git",
         "prosemirror-transform": "^1.8.0",
         "prosemirror-view": "^1.32.4",
         "rdf-data-factory": "^1.1.0",
@@ -4781,21 +4843,21 @@
         "xml-formatter": "^3.2.1"
       },
       "engines": {
-        "node": "16.* || >= 18"
+        "node": "16.* || 18.* || >= 20"
       },
       "peerDependencies": {
-        "@appuniversum/ember-appuniversum": "^2.4.2",
+        "@appuniversum/ember-appuniversum": "^2.15.0",
         "@glint/template": "^1.1.0",
         "ember-cli-sass": "^11.0.1",
-        "ember-intl": "^5.7.2 || ^6.1.0",
+        "ember-intl": "^6.1.0",
         "ember-modifier": "^3.2.7",
-        "ember-source": "^3.28.0 || ^4.0.0"
+        "ember-source": "^4.12.0"
       }
     },
     "node_modules/@lblod/ember-rdfa-editor-lblod-plugins": {
-      "version": "15.2.2",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-15.2.2.tgz",
-      "integrity": "sha512-PfVHhthHeLgU2rOJzDyEK66mXeA9680eZ6IRAd+LbU40iJvlizStluIcdRT4jObzQJj1aTSh9wChYrww0gnr+Q==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-16.0.0.tgz",
+      "integrity": "sha512-jgpTGVqfZfxxTQaKGquEmDUSQU5pi4BlhpMPbILPz3Xh9lclijSfF4QP5BXsP+imG1RCbbyOHytqpO4YTqsfKw==",
       "dev": true,
       "dependencies": {
         "@codemirror/lang-html": "^6.4.3",
@@ -4815,7 +4877,7 @@
         "ember-auto-import": "~2.6.3",
         "ember-cli-babel": "^7.26.11",
         "ember-cli-htmlbars": "^6.1.1",
-        "ember-concurrency": "^2.x || ^3.1.0",
+        "ember-concurrency": "2.3.7",
         "ember-mu-transform-helpers": "^2.0.0",
         "ember-resources": "^6.1.1",
         "ember-velcro": "^2.1.0",
@@ -4833,14 +4895,15 @@
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@appuniversum/ember-appuniversum": "^2.4.2",
+        "@appuniversum/ember-appuniversum": "^2.15.0",
         "@ember/string": "3.x",
         "@glint/template": "^1.1.0",
-        "@lblod/ember-rdfa-editor": "^6.0.0 || ^7.0.1 || ^8.0.1",
-        "ember-concurrency": "2.x || ^3.1.0",
+        "@lblod/ember-rdfa-editor": "^9.0.0",
+        "ember-concurrency": "^2.3.7 || ^3.1.0",
+        "ember-intl": "^6.1.0",
         "ember-modifier": "^3.2.7",
         "ember-power-select": "6.x || 7.x",
-        "ember-source": "^4.8.0"
+        "ember-source": "^4.12.0"
       }
     },
     "node_modules/@lblod/ember-rdfa-editor/node_modules/ember-cli-typescript": {
@@ -10599,9 +10662,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.7",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.7.tgz",
-      "integrity": "sha512-BauCXrQ7I2ftSqd2mvKHGo85XR0u7Ru3C/Hxsy/0TkfCtjrmAbPdzLGasmoiBxplpDXlPvdjX9u7srIMfgasNA==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.2.tgz",
+      "integrity": "sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==",
       "funding": [
         {
           "type": "opencollective",
@@ -10617,10 +10680,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001489",
-        "electron-to-chromium": "^1.4.411",
-        "node-releases": "^2.0.12",
-        "update-browserslist-db": "^1.0.11"
+        "caniuse-lite": "^1.0.30001565",
+        "electron-to-chromium": "^1.4.601",
+        "node-releases": "^2.0.14",
+        "update-browserslist-db": "^1.0.13"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -10857,12 +10920,13 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
+      "integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.1",
+        "set-function-length": "^1.1.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -10965,9 +11029,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001492",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001492.tgz",
-      "integrity": "sha512-2efF8SAZwgAX1FJr87KWhvuJxnGJKOnctQa8xLOskAXNXq8oiuqgl6u1kk3fFpsp3GgvzlRjiK1sl63hNtFADw==",
+      "version": "1.0.30001576",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001576.tgz",
+      "integrity": "sha512-ff5BdakGe2P3SQsMsiqmt1Lc8221NR1VzHj5jXN5vBny9A6fpze94HiVV/n7XRosOlsShJcvMv5mdnpjOGCEgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -11396,9 +11460,9 @@
       }
     },
     "node_modules/cldr-core": {
-      "version": "36.0.0",
-      "resolved": "https://registry.npmjs.org/cldr-core/-/cldr-core-36.0.0.tgz",
-      "integrity": "sha512-QLnAjt20rZe38c8h8OJ9jPND+O4o5O8Nw0TK/P3KpNn1cmOhMu0rk6Kc3ap96c5OStQ9gAngs9+Be2sum26NOw==",
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/cldr-core/-/cldr-core-44.1.0.tgz",
+      "integrity": "sha512-ssbJaXu3pCkc4YqNC6xHhgleZG7YqnOFZ9laMlJfHOfnspoA9waI4AH54gKB3Fe/+wI4i3cVxKFdCTVGTRw+UA==",
       "dev": true
     },
     "node_modules/clean-base-url": {
@@ -12327,7 +12391,8 @@
     "node_modules/convert-source-map": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "dev": true
     },
     "node_modules/cookie": {
       "version": "0.5.0",
@@ -13117,6 +13182,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
+      "integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
+      "dependencies": {
+        "get-intrinsic": "^1.2.1",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/define-lazy-prop": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
@@ -13460,9 +13538,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.416",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.416.tgz",
-      "integrity": "sha512-AUYh0XDTb2vrj0rj82jb3P9hHSyzQNdTPYWZIhPdCOui7/vpme7+HTE07BE5jwuqg/34TZ8ktlRz6GImJ4IXjA=="
+      "version": "1.4.630",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.630.tgz",
+      "integrity": "sha512-osHqhtjojpCsACVnuD11xO5g9xaCyw7Qqn/C2KParkMv42i8jrJJgx3g7mkHfpxwhy9MnOJr8+pKOdZ7qzgizg=="
     },
     "node_modules/elliptic": {
       "version": "6.5.4",
@@ -20083,41 +20161,37 @@
       }
     },
     "node_modules/ember-intl": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/ember-intl/-/ember-intl-5.7.2.tgz",
-      "integrity": "sha512-gs17uY1ywzMaUpx1gxfBkFQYRTWTSa/zbkL13MVtffG9aBLP+998MibytZOUxIipMtLCm4sr/g6/1aaKRr9/+g==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/ember-intl/-/ember-intl-6.4.0.tgz",
+      "integrity": "sha512-BXxscjgoqzXQ6tUSV8aJsQcUAIcfqLJnNjegarFWdBBHLEOffQ8xARhvQC0hW40zGi/RHFEyTTx7vbiCPGtP1A==",
       "dev": true,
       "dependencies": {
+        "@formatjs/icu-messageformat-parser": "^2.7.3",
+        "@formatjs/intl": "^2.9.9",
         "broccoli-caching-writer": "^3.0.3",
-        "broccoli-funnel": "^3.0.3",
+        "broccoli-funnel": "^3.0.8",
         "broccoli-merge-files": "^0.8.0",
         "broccoli-merge-trees": "^4.2.0",
-        "broccoli-source": "^3.0.0",
+        "broccoli-source": "^3.0.1",
         "broccoli-stew": "^3.0.0",
         "calculate-cache-key-for-tree": "^2.0.0",
-        "cldr-core": "^36.0.0",
-        "ember-auto-import": "^1.5.3",
-        "ember-cli-babel": "^7.23.0",
-        "ember-cli-typescript": "^4.0.0",
+        "cldr-core": "^44.0.1",
+        "ember-auto-import": "^2.7.0",
+        "ember-cli-babel": "^8.2.0",
+        "ember-cli-typescript": "^5.2.1",
+        "eventemitter3": "^5.0.1",
         "extend": "^3.0.2",
         "fast-memoize": "^2.5.2",
-        "has-unicode": "^2.0.1",
-        "intl-messageformat": "^9.3.6",
-        "intl-messageformat-parser": "^6.0.5",
-        "js-yaml": "^3.13.1",
-        "json-stable-stringify": "^1.0.1",
-        "locale-emoji": "^0.3.0",
-        "lodash.castarray": "^4.4.0",
-        "lodash.last": "^3.0.0",
-        "lodash.omit": "^4.5.0",
-        "mkdirp": "^1.0.4",
+        "intl-messageformat": "^10.5.8",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify": "^1.1.0",
         "silent-error": "^1.1.1"
       },
       "engines": {
-        "node": ">= 10.*"
+        "node": "16.* || >= 18"
       },
       "peerDependencies": {
-        "typescript": "^4.0.0"
+        "typescript": "^4.8.0 || ^5.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -20125,208 +20199,78 @@
         }
       }
     },
-    "node_modules/ember-intl/node_modules/@embroider/shared-internals": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-1.8.3.tgz",
-      "integrity": "sha512-N5Gho6Qk8z5u+mxLCcMYAoQMbN4MmH+z2jXwQHVs859bxuZTxwF6kKtsybDAASCtd2YGxEmzcc1Ja/wM28824w==",
+    "node_modules/ember-intl/node_modules/@babel/runtime": {
+      "version": "7.12.18",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.18.tgz",
+      "integrity": "sha512-BogPQ7ciE6SYAUPtlm9tWbgI9+2AgqSam6QivMgXgAT+fKbgppaj4ZX15MHeLC1PVF5sNk70huBu20XxWOs8Cg==",
       "dev": true,
       "dependencies": {
-        "babel-import-util": "^1.1.0",
-        "ember-rfc176-data": "^0.3.17",
-        "fs-extra": "^9.1.0",
-        "js-string-escape": "^1.0.1",
-        "lodash": "^4.17.21",
-        "resolve-package-path": "^4.0.1",
-        "semver": "^7.3.5",
-        "typescript-memoize": "^1.0.1"
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "node_modules/ember-intl/node_modules/async-disk-cache": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
+      "integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "heimdalljs": "^0.2.3",
+        "istextorbinary": "^2.5.1",
+        "mkdirp": "^0.5.0",
+        "rimraf": "^3.0.0",
+        "rsvp": "^4.8.5",
+        "username-sync": "^1.0.2"
       },
       "engines": {
-        "node": "12.* || 14.* || >= 16"
+        "node": "8.* || >= 10.*"
       }
     },
-    "node_modules/ember-intl/node_modules/@webassemblyjs/ast": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
-      "integrity": "sha512-C6wW5L+b7ogSDVqymbkkvuW9kruN//YisMED04xzeBBqjHa2FYnmvOlS6Xj68xWQRgWvI9cIglsjFowH/RJyEA==",
+    "node_modules/ember-intl/node_modules/babel-plugin-module-resolver": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-5.0.0.tgz",
+      "integrity": "sha512-g0u+/ChLSJ5+PzYwLwP8Rp8Rcfowz58TJNCe+L/ui4rpzE/mg//JVX0EWBUYoxaextqnwuGHzfGp2hh0PPV25Q==",
       "dev": true,
       "dependencies": {
-        "@webassemblyjs/helper-module-context": "1.9.0",
-        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
-        "@webassemblyjs/wast-parser": "1.9.0"
-      }
-    },
-    "node_modules/ember-intl/node_modules/@webassemblyjs/helper-api-error": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.9.0.tgz",
-      "integrity": "sha512-NcMLjoFMXpsASZFxJ5h2HZRcEhDkvnNFOAKneP5RbKRzaWJN36NC4jqQHKwStIhGXu5mUWlUUk7ygdtrO8lbmw==",
-      "dev": true
-    },
-    "node_modules/ember-intl/node_modules/@webassemblyjs/helper-buffer": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.9.0.tgz",
-      "integrity": "sha512-qZol43oqhq6yBPx7YM3m9Bv7WMV9Eevj6kMi6InKOuZxhw+q9hOkvq5e/PpKSiLfyetpaBnogSbNCfBwyB00CA==",
-      "dev": true
-    },
-    "node_modules/ember-intl/node_modules/@webassemblyjs/helper-wasm-bytecode": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.9.0.tgz",
-      "integrity": "sha512-R7FStIzyNcd7xKxCZH5lE0Bqy+hGTwS3LJjuv1ZVxd9O7eHCedSdrId/hMOd20I+v8wDXEn+bjfKDLzTepoaUw==",
-      "dev": true
-    },
-    "node_modules/ember-intl/node_modules/@webassemblyjs/helper-wasm-section": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.9.0.tgz",
-      "integrity": "sha512-XnMB8l3ek4tvrKUUku+IVaXNHz2YsJyOOmz+MMkZvh8h1uSJpSen6vYnw3IoQ7WwEuAhL8Efjms1ZWjqh2agvw==",
-      "dev": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/helper-buffer": "1.9.0",
-        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
-        "@webassemblyjs/wasm-gen": "1.9.0"
-      }
-    },
-    "node_modules/ember-intl/node_modules/@webassemblyjs/ieee754": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.9.0.tgz",
-      "integrity": "sha512-dcX8JuYU/gvymzIHc9DgxTzUUTLexWwt8uCTWP3otys596io0L5aW02Gb1RjYpx2+0Jus1h4ZFqjla7umFniTg==",
-      "dev": true,
-      "dependencies": {
-        "@xtuc/ieee754": "^1.2.0"
-      }
-    },
-    "node_modules/ember-intl/node_modules/@webassemblyjs/leb128": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.9.0.tgz",
-      "integrity": "sha512-ENVzM5VwV1ojs9jam6vPys97B/S65YQtv/aanqnU7D8aSoHFX8GyhGg0CMfyKNIHBuAVjy3tlzd5QMMINa7wpw==",
-      "dev": true,
-      "dependencies": {
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "node_modules/ember-intl/node_modules/@webassemblyjs/utf8": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.9.0.tgz",
-      "integrity": "sha512-GZbQlWtopBTP0u7cHrEx+73yZKrQoBMpwkGEIqlacljhXCkVM1kMQge/Mf+csMJAjEdSwhOyLAS0AoR3AG5P8w==",
-      "dev": true
-    },
-    "node_modules/ember-intl/node_modules/@webassemblyjs/wasm-edit": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.9.0.tgz",
-      "integrity": "sha512-FgHzBm80uwz5M8WKnMTn6j/sVbqilPdQXTWraSjBwFXSYGirpkSWE2R9Qvz9tNiTKQvoKILpCuTjBKzOIm0nxw==",
-      "dev": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/helper-buffer": "1.9.0",
-        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
-        "@webassemblyjs/helper-wasm-section": "1.9.0",
-        "@webassemblyjs/wasm-gen": "1.9.0",
-        "@webassemblyjs/wasm-opt": "1.9.0",
-        "@webassemblyjs/wasm-parser": "1.9.0",
-        "@webassemblyjs/wast-printer": "1.9.0"
-      }
-    },
-    "node_modules/ember-intl/node_modules/@webassemblyjs/wasm-gen": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.9.0.tgz",
-      "integrity": "sha512-cPE3o44YzOOHvlsb4+E9qSqjc9Qf9Na1OO/BHFy4OI91XDE14MjFN4lTMezzaIWdPqHnsTodGGNP+iRSYfGkjA==",
-      "dev": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
-        "@webassemblyjs/ieee754": "1.9.0",
-        "@webassemblyjs/leb128": "1.9.0",
-        "@webassemblyjs/utf8": "1.9.0"
-      }
-    },
-    "node_modules/ember-intl/node_modules/@webassemblyjs/wasm-opt": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.9.0.tgz",
-      "integrity": "sha512-Qkjgm6Anhm+OMbIL0iokO7meajkzQD71ioelnfPEj6r4eOFuqm4YC3VBPqXjFyyNwowzbMD+hizmprP/Fwkl2A==",
-      "dev": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/helper-buffer": "1.9.0",
-        "@webassemblyjs/wasm-gen": "1.9.0",
-        "@webassemblyjs/wasm-parser": "1.9.0"
-      }
-    },
-    "node_modules/ember-intl/node_modules/@webassemblyjs/wasm-parser": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.9.0.tgz",
-      "integrity": "sha512-9+wkMowR2AmdSWQzsPEjFU7njh8HTO5MqO8vjwEHuM+AMHioNqSBONRdr0NQQ3dVQrzp0s8lTcYqzUdb7YgELA==",
-      "dev": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/helper-api-error": "1.9.0",
-        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
-        "@webassemblyjs/ieee754": "1.9.0",
-        "@webassemblyjs/leb128": "1.9.0",
-        "@webassemblyjs/utf8": "1.9.0"
-      }
-    },
-    "node_modules/ember-intl/node_modules/@webassemblyjs/wast-printer": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.9.0.tgz",
-      "integrity": "sha512-2J0nE95rHXHyQ24cWjMKJ1tqB/ds8z/cyeOZxJhcb+rW+SQASVjuznUSmdz5GpVJTzU8JkhYut0D3siFDD6wsA==",
-      "dev": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/wast-parser": "1.9.0",
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "node_modules/ember-intl/node_modules/acorn": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
-      "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
-      "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
+        "find-babel-config": "^2.0.0",
+        "glob": "^8.0.3",
+        "pkg-up": "^3.1.0",
+        "reselect": "^4.1.7",
+        "resolve": "^1.22.1"
       },
       "engines": {
-        "node": ">=0.4.0"
+        "node": ">= 16"
       }
     },
-    "node_modules/ember-intl/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/ember-intl/node_modules/braces": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-      "dev": true,
-      "dependencies": {
-        "arr-flatten": "^1.1.0",
-        "array-unique": "^0.3.2",
-        "extend-shallow": "^2.0.1",
-        "fill-range": "^4.0.0",
-        "isobject": "^3.0.1",
-        "repeat-element": "^1.1.2",
-        "snapdragon": "^0.8.1",
-        "snapdragon-node": "^2.0.1",
-        "split-string": "^3.0.2",
-        "to-regex": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ember-intl/node_modules/braces/node_modules/extend-shallow": {
+    "node_modules/ember-intl/node_modules/brace-expansion": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
       "dependencies": {
-        "is-extendable": "^0.1.0"
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/ember-intl/node_modules/broccoli-babel-transpiler": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-8.0.0.tgz",
+      "integrity": "sha512-3HEp3flvasUKJGWERcrPgM1SWvHJ0O/fmbEtY9L4kDyMSnqjY6hTYvNvgWCIgbwXAYAUlZP0vjAQsmyLNGLwFw==",
+      "dev": true,
+      "dependencies": {
+        "broccoli-persistent-filter": "^3.0.0",
+        "clone": "^2.1.2",
+        "hash-for-dep": "^1.4.7",
+        "heimdalljs": "^0.2.1",
+        "heimdalljs-logger": "^0.1.9",
+        "json-stable-stringify": "^1.0.1",
+        "rsvp": "^4.8.4",
+        "workerpool": "^6.0.2"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": "16.* || >= 18"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.17.9"
       }
     },
     "node_modules/ember-intl/node_modules/broccoli-merge-trees": {
@@ -20342,142 +20286,157 @@
         "node": "10.* || >= 12.*"
       }
     },
-    "node_modules/ember-intl/node_modules/cacache": {
-      "version": "12.0.4",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.4.tgz",
-      "integrity": "sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==",
+    "node_modules/ember-intl/node_modules/broccoli-persistent-filter": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.3.tgz",
+      "integrity": "sha512-Q+8iezprZzL9voaBsDY3rQVl7c7H5h+bvv8SpzCZXPZgfBFCbx7KFQ2c3rZR6lW5k4Kwoqt7jG+rZMUg67Gwxw==",
       "dev": true,
       "dependencies": {
-        "bluebird": "^3.5.5",
-        "chownr": "^1.1.1",
-        "figgy-pudding": "^3.5.1",
-        "glob": "^7.1.4",
-        "graceful-fs": "^4.1.15",
-        "infer-owner": "^1.0.3",
-        "lru-cache": "^5.1.1",
-        "mississippi": "^3.0.0",
-        "mkdirp": "^0.5.1",
-        "move-concurrently": "^1.0.1",
-        "promise-inflight": "^1.0.1",
-        "rimraf": "^2.6.3",
-        "ssri": "^6.0.1",
-        "unique-filename": "^1.1.1",
-        "y18n": "^4.0.0"
-      }
-    },
-    "node_modules/ember-intl/node_modules/cacache/node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.6"
+        "async-disk-cache": "^2.0.0",
+        "async-promise-queue": "^1.0.3",
+        "broccoli-plugin": "^4.0.3",
+        "fs-tree-diff": "^2.0.0",
+        "hash-for-dep": "^1.5.0",
+        "heimdalljs": "^0.2.1",
+        "heimdalljs-logger": "^0.1.7",
+        "promise-map-series": "^0.2.1",
+        "rimraf": "^3.0.0",
+        "symlink-or-copy": "^1.0.1",
+        "sync-disk-cache": "^2.0.0"
       },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
+      "engines": {
+        "node": "10.* || >= 12.*"
       }
     },
-    "node_modules/ember-intl/node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "dev": true
+    "node_modules/ember-intl/node_modules/editions": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
+      "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
+      "dev": true,
+      "dependencies": {
+        "errlop": "^2.0.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
     },
-    "node_modules/ember-intl/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
+    "node_modules/ember-intl/node_modules/editions/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
     },
     "node_modules/ember-intl/node_modules/ember-auto-import": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/ember-auto-import/-/ember-auto-import-1.12.2.tgz",
-      "integrity": "sha512-gLqML2k77AuUiXxWNon1FSzuG1DV7PEPpCLCU5aJvf6fdL6rmFfElsZRh+8ELEB/qP9dT+LHjNEunVzd2dYc8A==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/ember-auto-import/-/ember-auto-import-2.7.2.tgz",
+      "integrity": "sha512-pkWIljmJClYL17YBk8FjO7NrZPQoY9v0b+FooJvaHf/xlDQIBYVP7OaDHbNuNbpj7+wAwSDAnnwxjCoLsmm4cw==",
       "dev": true,
       "dependencies": {
-        "@babel/core": "^7.1.6",
-        "@babel/preset-env": "^7.10.2",
-        "@babel/traverse": "^7.1.6",
-        "@babel/types": "^7.1.6",
-        "@embroider/shared-internals": "^1.0.0",
-        "babel-core": "^6.26.3",
+        "@babel/core": "^7.16.7",
+        "@babel/plugin-proposal-class-properties": "^7.16.7",
+        "@babel/plugin-proposal-decorators": "^7.16.7",
+        "@babel/plugin-proposal-private-methods": "^7.16.7",
+        "@babel/plugin-transform-class-static-block": "^7.16.7",
+        "@babel/preset-env": "^7.16.7",
+        "@embroider/macros": "^1.0.0",
+        "@embroider/shared-internals": "^2.0.0",
         "babel-loader": "^8.0.6",
+        "babel-plugin-ember-modules-api-polyfill": "^3.5.0",
+        "babel-plugin-ember-template-compilation": "^2.0.1",
+        "babel-plugin-htmlbars-inline-precompile": "^5.2.1",
         "babel-plugin-syntax-dynamic-import": "^6.18.0",
-        "babylon": "^6.18.0",
         "broccoli-debug": "^0.6.4",
-        "broccoli-node-api": "^1.7.0",
+        "broccoli-funnel": "^3.0.8",
+        "broccoli-merge-trees": "^4.2.0",
         "broccoli-plugin": "^4.0.0",
         "broccoli-source": "^3.0.0",
-        "debug": "^3.1.0",
-        "ember-cli-babel": "^7.0.0",
-        "enhanced-resolve": "^4.0.0",
-        "fs-extra": "^6.0.1",
+        "css-loader": "^5.2.0",
+        "debug": "^4.3.1",
+        "fs-extra": "^10.0.0",
         "fs-tree-diff": "^2.0.0",
         "handlebars": "^4.3.1",
         "js-string-escape": "^1.0.1",
         "lodash": "^4.17.19",
-        "mkdirp": "^0.5.1",
-        "resolve-package-path": "^3.1.0",
-        "rimraf": "^2.6.2",
+        "mini-css-extract-plugin": "^2.5.2",
+        "minimatch": "^3.0.0",
+        "parse5": "^6.0.1",
+        "resolve": "^1.20.0",
+        "resolve-package-path": "^4.0.3",
         "semver": "^7.3.4",
-        "symlink-or-copy": "^1.2.0",
+        "style-loader": "^2.0.0",
         "typescript-memoize": "^1.0.0-alpha.3",
-        "walk-sync": "^0.3.3",
-        "webpack": "^4.43.0"
+        "walk-sync": "^3.0.0"
       },
       "engines": {
-        "node": ">= 10.*"
-      }
-    },
-    "node_modules/ember-intl/node_modules/ember-auto-import/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "^2.1.1"
+        "node": "12.* || 14.* || >= 16"
       }
     },
     "node_modules/ember-intl/node_modules/ember-auto-import/node_modules/fs-extra": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
-      "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "dev": true,
       "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      }
-    },
-    "node_modules/ember-intl/node_modules/ember-auto-import/node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/ember-intl/node_modules/ember-auto-import/node_modules/resolve-package-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-3.1.0.tgz",
-      "integrity": "sha512-2oC2EjWbMJwvSN6Z7DbDfJMnD8MYEouaLn5eIX0j8XwPsYCVIyY9bbnX88YHVkbr8XHqvZrYbxaLPibfTYKZMA==",
-      "dev": true,
-      "dependencies": {
-        "path-root": "^0.1.1",
-        "resolve": "^1.17.0"
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
       },
       "engines": {
-        "node": "10.* || >= 12"
+        "node": ">=12"
+      }
+    },
+    "node_modules/ember-intl/node_modules/ember-cli-babel": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-8.2.0.tgz",
+      "integrity": "sha512-8H4+jQElCDo6tA7CamksE66NqBXWs7VNpS3a738L9pZCjg2kXIX4zoyHzkORUqCtr0Au7YsCnrlAMi1v2ALo7A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-compilation-targets": "^7.20.7",
+        "@babel/plugin-proposal-class-properties": "^7.16.5",
+        "@babel/plugin-proposal-decorators": "^7.20.13",
+        "@babel/plugin-proposal-private-methods": "^7.16.5",
+        "@babel/plugin-proposal-private-property-in-object": "^7.20.5",
+        "@babel/plugin-transform-class-static-block": "^7.22.11",
+        "@babel/plugin-transform-modules-amd": "^7.20.11",
+        "@babel/plugin-transform-runtime": "^7.13.9",
+        "@babel/plugin-transform-typescript": "^7.20.13",
+        "@babel/preset-env": "^7.20.2",
+        "@babel/runtime": "7.12.18",
+        "amd-name-resolver": "^1.3.1",
+        "babel-plugin-debug-macros": "^0.3.4",
+        "babel-plugin-ember-data-packages-polyfill": "^0.1.2",
+        "babel-plugin-ember-modules-api-polyfill": "^3.5.0",
+        "babel-plugin-module-resolver": "^5.0.0",
+        "broccoli-babel-transpiler": "^8.0.0",
+        "broccoli-debug": "^0.6.4",
+        "broccoli-funnel": "^3.0.8",
+        "broccoli-source": "^3.0.1",
+        "calculate-cache-key-for-tree": "^2.0.0",
+        "clone": "^2.1.2",
+        "ember-cli-babel-plugin-helpers": "^1.1.1",
+        "ember-cli-version-checker": "^5.1.2",
+        "ensure-posix-path": "^1.0.2",
+        "resolve-package-path": "^4.0.3",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": "16.* || 18.* || >= 20"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.12.0"
       }
     },
     "node_modules/ember-intl/node_modules/ember-cli-typescript": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-4.2.1.tgz",
-      "integrity": "sha512-0iKTZ+/wH6UB/VTWKvGuXlmwiE8HSIGcxHamwNhEC5x1mN3z8RfvsFZdQWYUzIWFN2Tek0gmepGRPTwWdBYl/A==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz",
+      "integrity": "sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==",
       "dev": true,
       "dependencies": {
         "ansi-to-html": "^0.6.15",
@@ -20492,7 +20451,7 @@
         "walk-sync": "^2.2.0"
       },
       "engines": {
-        "node": "10.* || >= 12.*"
+        "node": ">= 12.*"
       }
     },
     "node_modules/ember-intl/node_modules/ember-cli-typescript/node_modules/walk-sync": {
@@ -20510,41 +20469,11 @@
         "node": "8.* || >= 10.*"
       }
     },
-    "node_modules/ember-intl/node_modules/enhanced-resolve": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
-      "integrity": "sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "memory-fs": "^0.5.0",
-        "tapable": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/ember-intl/node_modules/eslint-scope": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
-      "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
-      "dev": true,
-      "dependencies": {
-        "esrecurse": "^4.1.0",
-        "estraverse": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/ember-intl/node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0"
-      }
+    "node_modules/ember-intl/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "dev": true
     },
     "node_modules/ember-intl/node_modules/execa": {
       "version": "4.1.0",
@@ -20569,57 +20498,17 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
-    "node_modules/ember-intl/node_modules/fill-range": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-      "integrity": "sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==",
+    "node_modules/ember-intl/node_modules/find-babel-config": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-2.0.0.tgz",
+      "integrity": "sha512-dOKT7jvF3hGzlW60Gc3ONox/0rRZ/tz7WCil0bqA1In/3I8f1BctpXahRnEKDySZqci7u+dqq93sZST9fOJpFw==",
       "dev": true,
       "dependencies": {
-        "extend-shallow": "^2.0.1",
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1",
-        "to-regex-range": "^2.1.0"
+        "json5": "^2.1.1",
+        "path-exists": "^4.0.0"
       },
       "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ember-intl/node_modules/fill-range/node_modules/extend-shallow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
-      "dev": true,
-      "dependencies": {
-        "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ember-intl/node_modules/find-cache-dir": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
-      "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
-      "dev": true,
-      "dependencies": {
-        "commondir": "^1.0.1",
-        "make-dir": "^2.0.0",
-        "pkg-dir": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/ember-intl/node_modules/find-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-      "dev": true,
-      "dependencies": {
-        "locate-path": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/ember-intl/node_modules/fs-tree-diff": {
@@ -20653,6 +20542,37 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/ember-intl/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ember-intl/node_modules/glob/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ember-intl/node_modules/human-signals": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
@@ -20662,177 +20582,21 @@
         "node": ">=8.12.0"
       }
     },
-    "node_modules/ember-intl/node_modules/is-extendable": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ember-intl/node_modules/is-number": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-      "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
+    "node_modules/ember-intl/node_modules/istextorbinary": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
+      "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
       "dev": true,
       "dependencies": {
-        "kind-of": "^3.0.2"
+        "binaryextensions": "^2.1.2",
+        "editions": "^2.2.0",
+        "textextensions": "^2.5.0"
       },
       "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ember-intl/node_modules/is-number/node_modules/kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-      "dev": true,
-      "dependencies": {
-        "is-buffer": "^1.1.5"
+        "node": ">=0.12"
       },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ember-intl/node_modules/is-wsl": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-      "integrity": "sha512-gfygJYZ2gLTDlmbWMI0CE2MwnFzSN/2SZfkMlItC4K/JBlsWVDB0bO6XhqcY13YXE7iMcAJnzTCJjPiTeJJ0Mw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ember-intl/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true
-    },
-    "node_modules/ember-intl/node_modules/isobject": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ember-intl/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/ember-intl/node_modules/json5": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
-    "node_modules/ember-intl/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "dev": true,
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/ember-intl/node_modules/loader-runner": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
-      "integrity": "sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.3.0 <5.0.0 || >=5.10"
-      }
-    },
-    "node_modules/ember-intl/node_modules/loader-utils": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
-      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
-      "dev": true,
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/ember-intl/node_modules/locate-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-      "dev": true,
-      "dependencies": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/ember-intl/node_modules/make-dir": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-      "dev": true,
-      "dependencies": {
-        "pify": "^4.0.1",
-        "semver": "^5.6.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/ember-intl/node_modules/make-dir/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/ember-intl/node_modules/micromatch": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-      "dev": true,
-      "dependencies": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "braces": "^2.3.1",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "extglob": "^2.0.4",
-        "fragment-cache": "^0.2.1",
-        "kind-of": "^6.0.2",
-        "nanomatch": "^1.2.9",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
+      "funding": {
+        "url": "https://bevry.me/fund"
       }
     },
     "node_modules/ember-intl/node_modules/minimist": {
@@ -20844,295 +20608,7 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/ember-intl/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ember-intl/node_modules/p-locate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-      "dev": true,
-      "dependencies": {
-        "p-limit": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/ember-intl/node_modules/pify": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/ember-intl/node_modules/pkg-dir": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-      "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
-      "dev": true,
-      "dependencies": {
-        "find-up": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/ember-intl/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dev": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/ember-intl/node_modules/rsvp": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-      "dev": true,
-      "engines": {
-        "node": "6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-intl/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
-    },
-    "node_modules/ember-intl/node_modules/schema-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-      "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
-      "dev": true,
-      "dependencies": {
-        "ajv": "^6.1.0",
-        "ajv-errors": "^1.0.0",
-        "ajv-keywords": "^3.1.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/ember-intl/node_modules/serialize-javascript": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
-      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
-      "dev": true,
-      "dependencies": {
-        "randombytes": "^2.1.0"
-      }
-    },
-    "node_modules/ember-intl/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ember-intl/node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true
-    },
-    "node_modules/ember-intl/node_modules/ssri": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
-      "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
-      "dev": true,
-      "dependencies": {
-        "figgy-pudding": "^3.5.1"
-      }
-    },
-    "node_modules/ember-intl/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/ember-intl/node_modules/tapable": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
-      "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/ember-intl/node_modules/terser": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.1.tgz",
-      "integrity": "sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==",
-      "dev": true,
-      "dependencies": {
-        "commander": "^2.20.0",
-        "source-map": "~0.6.1",
-        "source-map-support": "~0.5.12"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/ember-intl/node_modules/terser-webpack-plugin": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz",
-      "integrity": "sha512-04Rfe496lN8EYruwi6oPQkG0vo8C+HT49X687FZnpPF0qMAIHONI6HEXYPKDOE8e5HjXTyKfqRd/agHtH0kOtw==",
-      "dev": true,
-      "dependencies": {
-        "cacache": "^12.0.2",
-        "find-cache-dir": "^2.1.0",
-        "is-wsl": "^1.1.0",
-        "schema-utils": "^1.0.0",
-        "serialize-javascript": "^4.0.0",
-        "source-map": "^0.6.1",
-        "terser": "^4.1.2",
-        "webpack-sources": "^1.4.0",
-        "worker-farm": "^1.7.0"
-      },
-      "engines": {
-        "node": ">= 6.9.0"
-      },
-      "peerDependencies": {
-        "webpack": "^4.0.0"
-      }
-    },
-    "node_modules/ember-intl/node_modules/to-regex-range": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-      "integrity": "sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==",
-      "dev": true,
-      "dependencies": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ember-intl/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/ember-intl/node_modules/watchpack": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.5.tgz",
-      "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0"
-      },
-      "optionalDependencies": {
-        "chokidar": "^3.4.1",
-        "watchpack-chokidar2": "^2.0.1"
-      }
-    },
-    "node_modules/ember-intl/node_modules/webpack": {
-      "version": "4.46.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.46.0.tgz",
-      "integrity": "sha512-6jJuJjg8znb/xRItk7bkT0+Q7AHCYjjFnvKIWQPkNIOyRqoCGvkOs0ipeQzrqz4l5FtN5ZI/ukEHroeX/o1/5Q==",
-      "dev": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/helper-module-context": "1.9.0",
-        "@webassemblyjs/wasm-edit": "1.9.0",
-        "@webassemblyjs/wasm-parser": "1.9.0",
-        "acorn": "^6.4.1",
-        "ajv": "^6.10.2",
-        "ajv-keywords": "^3.4.1",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^4.5.0",
-        "eslint-scope": "^4.0.3",
-        "json-parse-better-errors": "^1.0.2",
-        "loader-runner": "^2.4.0",
-        "loader-utils": "^1.2.3",
-        "memory-fs": "^0.4.1",
-        "micromatch": "^3.1.10",
-        "mkdirp": "^0.5.3",
-        "neo-async": "^2.6.1",
-        "node-libs-browser": "^2.2.1",
-        "schema-utils": "^1.0.0",
-        "tapable": "^1.1.3",
-        "terser-webpack-plugin": "^1.4.3",
-        "watchpack": "^1.7.4",
-        "webpack-sources": "^1.4.1"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
-      },
-      "engines": {
-        "node": ">=6.11.5"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        },
-        "webpack-command": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ember-intl/node_modules/webpack-sources": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
-      "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
-      "dev": true,
-      "dependencies": {
-        "source-list-map": "^2.0.0",
-        "source-map": "~0.6.1"
-      }
-    },
-    "node_modules/ember-intl/node_modules/webpack/node_modules/memory-fs": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
-      "integrity": "sha512-cda4JKCxReDXFXRqOHPQscuIYg1PvxbE2S2GP45rnwfEK+vZaXC8C1OFvdHIbgw0DLzowXGVoxLaAmlgRy14GQ==",
-      "dev": true,
-      "dependencies": {
-        "errno": "^0.1.3",
-        "readable-stream": "^2.0.1"
-      }
-    },
-    "node_modules/ember-intl/node_modules/webpack/node_modules/mkdirp": {
+    "node_modules/ember-intl/node_modules/mkdirp": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
@@ -21144,11 +20620,73 @@
         "mkdirp": "bin/cmd.js"
       }
     },
-    "node_modules/ember-intl/node_modules/y18n": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-      "dev": true
+    "node_modules/ember-intl/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ember-intl/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ember-intl/node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ember-intl/node_modules/rsvp": {
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || >= 7.*"
+      }
+    },
+    "node_modules/ember-intl/node_modules/walk-sync": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-3.0.0.tgz",
+      "integrity": "sha512-41TvKmDGVpm2iuH7o+DAOt06yyu/cSHpX3uzAwetzASvlNtVddgIjXIb2DfB/Wa20B1Jo86+1Dv1CraSU7hWdw==",
+      "dev": true,
+      "dependencies": {
+        "@types/minimatch": "^3.0.4",
+        "ensure-posix-path": "^1.1.0",
+        "matcher-collection": "^2.0.1",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
     },
     "node_modules/ember-load-initializers": {
       "version": "2.1.2",
@@ -23381,20 +22919,6 @@
       },
       "engines": {
         "node": "10.* || >= 12"
-      }
-    },
-    "node_modules/ember-unique-id-helper-polyfill": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/ember-unique-id-helper-polyfill/-/ember-unique-id-helper-polyfill-1.2.2.tgz",
-      "integrity": "sha512-gjcwTBkCDUA0iYFS7aArfJub+eos/itxEsC399JUbdKNIBJLesB/1OHnmxLLwExZHp7gyHuiDFOPcknafhFm3g==",
-      "dev": true,
-      "dependencies": {
-        "broccoli-funnel": "^3.0.8",
-        "ember-cli-babel": "^7.26.10",
-        "ember-cli-version-checker": "^5.1.2"
-      },
-      "engines": {
-        "node": "12.* || 14.* || >= 16"
       }
     },
     "node_modules/ember-velcro": {
@@ -25822,9 +25346,12 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/function.prototype.name": {
       "version": "1.1.5",
@@ -25897,14 +25424,14 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
-      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
+      "integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
+        "function-bind": "^1.1.2",
         "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3"
+        "has-symbols": "^1.0.3",
+        "hasown": "^2.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -26458,11 +25985,11 @@
       }
     },
     "node_modules/has-property-descriptors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
-      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
+      "integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
       "dependencies": {
-        "get-intrinsic": "^1.1.1"
+        "get-intrinsic": "^1.2.2"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -26638,6 +26165,17 @@
       "dependencies": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+      "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/heimdalljs": {
@@ -27212,35 +26750,15 @@
       }
     },
     "node_modules/intl-messageformat": {
-      "version": "9.13.0",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-9.13.0.tgz",
-      "integrity": "sha512-7sGC7QnSQGa5LZP7bXLDhVDtQOeKGeBFGHF2Y8LVBwYZoQZCgWeKoPGTa5GMG8g/TzDgeXuYJQis7Ggiw2xTOw==",
+      "version": "10.5.8",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.5.8.tgz",
+      "integrity": "sha512-NRf0jpBWV0vd671G5b06wNofAN8tp7WWDogMZyaU8GUAsmbouyvgwmFJI7zLjfAMpm3zK+vSwRP3jzaoIcMbaA==",
       "dev": true,
       "dependencies": {
-        "@formatjs/ecma402-abstract": "1.11.4",
-        "@formatjs/fast-memoize": "1.2.1",
-        "@formatjs/icu-messageformat-parser": "2.1.0",
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/intl-messageformat-parser": {
-      "version": "6.4.4",
-      "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-6.4.4.tgz",
-      "integrity": "sha512-7AaFKNZEfzLQR6+jivOuz9e7yA8ka5KrmLebgY4QHTRLf8r64dp3LjnW98LkBWjdk8GK0sawD2dHDqW++A/pXA==",
-      "deprecated": "We've written a new parser that's 6x faster and is backwards compatible. Please use @formatjs/icu-messageformat-parser",
-      "dev": true,
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "1.6.4",
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/intl-messageformat-parser/node_modules/@formatjs/ecma402-abstract": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.6.4.tgz",
-      "integrity": "sha512-ukFjGD9dLsxcD9D5AEshJqQElPQeUAlTALT/lzIV6OcYojyuU81gw/uXDUOrs6XW79jtOJwQDkLqHbCJBJMOTw==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.1.0"
+        "@formatjs/ecma402-abstract": "1.18.0",
+        "@formatjs/fast-memoize": "2.2.0",
+        "@formatjs/icu-messageformat-parser": "2.7.3",
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/invariant": {
@@ -28157,11 +27675,17 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "node_modules/json-stable-stringify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.2.tgz",
-      "integrity": "sha512-eunSSaEnxV12z+Z73y/j5N37/In40GK4GmsSy+tEHJMxknvqnA7/djeYtAgW0GsWHUfg+847WJjKaEylk2y09g==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.1.0.tgz",
+      "integrity": "sha512-zfA+5SuwYN2VWqN1/5HZaDzQKLJHaBVMZIIM+wuYjdptkaQsqzDdqjqf+lZZJUuJq1aanHiY8LhH8LmH+qBYJA==",
       "dependencies": {
-        "jsonify": "^0.0.1"
+        "call-bind": "^1.0.5",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -28540,12 +28064,6 @@
       "integrity": "sha512-9M2KvGT6duzGMgkOcTkWb+PR/Q2Oe54df/tLgHGVmFpAmtqJ553xJh6N63iFYI2yjo2PeJXbS5skHi/QpJq4vA==",
       "dev": true
     },
-    "node_modules/locale-emoji": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/locale-emoji/-/locale-emoji-0.3.0.tgz",
-      "integrity": "sha512-JGm8+naU49CBDnH1jksS3LecPdfWQLxFgkLN6ZhYONKa850pJ0Xt8DPGJnYK0ZuJI8jTuiDDPCDtSL3nyacXwg==",
-      "dev": true
-    },
     "node_modules/locate-character": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-2.0.5.tgz",
@@ -28762,12 +28280,6 @@
         "lodash.isarguments": "^3.0.0",
         "lodash.isarray": "^3.0.0"
       }
-    },
-    "node_modules/lodash.last": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.last/-/lodash.last-3.0.0.tgz",
-      "integrity": "sha512-14mq7rSkCxG4XMy9lF2FbIOqqgF0aH0NfPuQ3LPR3vIh0kHnUvIYP70dqa1Hf47zyXfQ8FzAg0MYOQeSuE1R7A==",
-      "dev": true
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -30818,9 +30330,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.12.tgz",
-      "integrity": "sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ=="
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
     },
     "node_modules/node-watch": {
       "version": "0.7.3",
@@ -32753,10 +32265,10 @@
       }
     },
     "node_modules/prosemirror-tables": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.3.2.tgz",
-      "integrity": "sha512-/9JTeN6s58Zq66HXaxP6uf8PAmc7XXKZFPlOGVtLvxEd6xBP6WtzaJB9wBjiGUzwbdhdMEy7V62yuHqk/3VrnQ==",
+      "version": "1.3.5",
+      "resolved": "git+ssh://git@github.com/lblod/prosemirror-tables.git#91e0d357d5ac20fc0974907044cc8dd4a85e8014",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "prosemirror-keymap": "^1.1.2",
         "prosemirror-model": "^1.8.1",
@@ -35436,6 +34948,21 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.0.tgz",
+      "integrity": "sha512-4DBHDoyHlM1IRPGYcoxexgh67y4ueR53FKV1yyxwFMY7aCqcN/38M1+SwZ/qJQ8iLv7+ck385ot4CcisOAPT9w==",
+      "dependencies": {
+        "define-data-property": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.2",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/set-value": {
       "version": "2.0.1",
@@ -38524,9 +38051,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
-      "integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
       "funding": [
         {
           "type": "opencollective",

--- a/package-lock.json
+++ b/package-lock.json
@@ -155,22 +155,6 @@
         "ember-source": "^3.28.0 || ^4.0.0 || ^5.0.0"
       }
     },
-    "node_modules/@appuniversum/ember-appuniversum/node_modules/ember-focus-trap": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ember-focus-trap/-/ember-focus-trap-1.1.0.tgz",
-      "integrity": "sha512-KxbCKpAJaBVZm+bW4tHPoBJAZThmxa6pI+WQusL+bj0RtAnGUNkWsVy6UBMZ5QqTQzf4EvGHkCVACVp5lbAWMQ==",
-      "dev": true,
-      "dependencies": {
-        "@embroider/addon-shim": "^1.0.0",
-        "focus-trap": "^6.7.1"
-      },
-      "engines": {
-        "node": "12.* || >= 14"
-      },
-      "peerDependencies": {
-        "ember-source": "^4.0.0 || ^5.0.0"
-      }
-    },
     "node_modules/@babel/code-frame": {
       "version": "7.23.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
@@ -19979,9 +19963,9 @@
       }
     },
     "node_modules/ember-focus-trap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ember-focus-trap/-/ember-focus-trap-1.0.2.tgz",
-      "integrity": "sha512-/8Cx9KI7uqoMaNN4Iyxc24P2JIvAcCL3cI1tYdZRHTwTd1sG6esEZWOnpxZOSE7m4xHww8HVUSiXzgyqD8YIhA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ember-focus-trap/-/ember-focus-trap-1.1.0.tgz",
+      "integrity": "sha512-KxbCKpAJaBVZm+bW4tHPoBJAZThmxa6pI+WQusL+bj0RtAnGUNkWsVy6UBMZ5QqTQzf4EvGHkCVACVp5lbAWMQ==",
       "dev": true,
       "dependencies": {
         "@embroider/addon-shim": "^1.0.0",
@@ -19989,6 +19973,9 @@
       },
       "engines": {
         "node": "12.* || >= 14"
+      },
+      "peerDependencies": {
+        "ember-source": "^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/ember-functions-as-helper-polyfill": {

--- a/package.json
+++ b/package.json
@@ -112,6 +112,9 @@
   "overrides": {
     "@appuniversum/ember-appuniversum": {
       "tracked-toolbox": "^2.0.0"
+    },
+    "@lblod/ember-rdfa-editor": {
+      "ember-focus-trap": "^1.1.0"
     }
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "release": "release-it"
   },
   "devDependencies": {
-    "@appuniversum/ember-appuniversum": "^2.12.0",
+    "@appuniversum/ember-appuniversum": "~2.15.0",
     "@babel/eslint-parser": "^7.22.9",
     "@babel/plugin-proposal-decorators": "^7.22.5",
     "@changesets/changelog-github": "^0.4.8",
@@ -43,8 +43,8 @@
     "@lblod/ember-acmidm-login": "^2.0.0-beta.1",
     "@lblod/ember-environment-banner": "^0.2.0",
     "@lblod/ember-mock-login": "0.7.0",
-    "@lblod/ember-rdfa-editor": "^8.2.0",
-    "@lblod/ember-rdfa-editor-lblod-plugins": "^15.2.2",
+    "@lblod/ember-rdfa-editor": "^9.0.0",
+    "@lblod/ember-rdfa-editor-lblod-plugins": "^16.0.0",
     "@release-it-plugins/lerna-changelog": "^6.0.0",
     "broccoli-asset-rev": "^3.0.0",
     "broccoli-plugin": "^4.0.7",
@@ -76,7 +76,7 @@
     "ember-drag-drop": "^0.9.0-beta.0",
     "ember-feature-flags": "^6.0.0",
     "ember-fetch": "^8.1.2",
-    "ember-intl": "^5.7.2",
+    "ember-intl": "^6.1.0",
     "ember-load-initializers": "^2.1.2",
     "ember-modifier": "^3.2.7",
     "ember-page-title": "^8.0.0",


### PR DESCRIPTION
### Overview
This PR includes updates to the following packages:
- `@lblod/ember-rdfa-editor` to 9.0.0
- `@lblod/ember-rdfa-editor-lblod-plugins` to 16.0.0
- `@appuniversum/ember-appuniversum` to 2.15.0
- `ember-intl` to 6.1.0

### Checks PR readiness
- [x] changelog
- [x] npm lint
- [x] no new deprecations
