### PR TITLE
Enable rdfa mode for rbs and some tweaks

### DIFF
--- a/app/controllers/regulatory-statements/edit.js
+++ b/app/controllers/regulatory-statements/edit.js
@@ -58,6 +58,7 @@ import {
   templateComment,
   templateCommentView,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/template-comments-plugin';
+import { getActiveEditableNode } from '@lblod/ember-rdfa-editor/plugins/_private/editable-node';
 import {
   STRUCTURE_NODES,
   STRUCTURE_SPECS,
@@ -90,6 +91,7 @@ import {
   OCMW,
 } from '../../utils/bestuurseenheid-classificatie-codes';
 
+import SnippetInsertRdfaComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/snippet-plugin/snippet-insert-rdfa';
 export default class RegulatoryStatementsRoute extends Controller {
   @service documentService;
   @service store;
@@ -100,6 +102,7 @@ export default class RegulatoryStatementsRoute extends Controller {
   @service intl;
   editor;
   @tracked citationPlugin = citationPlugin(this.config.citation);
+  SnippetInsert = SnippetInsertRdfaComponent;
 
   schema = new Schema({
     nodes: {
@@ -183,6 +186,12 @@ export default class RegulatoryStatementsRoute extends Controller {
     ];
   }
 
+  get activeNode() {
+    if (this.controller) {
+      return getActiveEditableNode(this.controller.activeEditorState);
+    }
+    return null;
+  }
   get config() {
     return {
       tableOfContents: [
@@ -225,6 +234,9 @@ export default class RegulatoryStatementsRoute extends Controller {
         interactive: true,
       },
       structures: STRUCTURE_SPECS,
+      snippet: {
+        endpoint: ENV.regulatoryStatementEndpoint,
+      },
     };
   }
 

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -38,6 +38,7 @@
 @import "variable-plugin";
 @import "besluit-plugin";
 @import "template-comments-plugin";
+@import "article-structure-plugin";
 @import "project/p-annotations"; // @TODO: refactor in ember-rdfa-editor
 
 // give treatment (behandeling) content the same style as other say-documents

--- a/app/templates/regulatory-statements/edit.hbs
+++ b/app/templates/regulatory-statements/edit.hbs
@@ -57,60 +57,60 @@
               locale=this.intl.primaryLocale
             }}
             {{#if revision.status.label}}
-              <AuPill @skin='success'>{{revision.status.label}}</AuPill>
+              <AuPill @skin="success">{{revision.status.label}}</AuPill>
             {{/if}}
           </AuLink>
         {{/each}}
         <AuLink
-          @route='regulatory-statements.edit.history'
+          @route="regulatory-statements.edit.history"
           @model={{this.documentContainer.id}}
-          @skin='link'
-          @icon='clock'
-          class='au-u-padding-tiny au-u-padding-left-small'
-          role='menuitem'
+          @skin="link"
+          @icon="clock"
+          class="au-u-padding-tiny au-u-padding-left-small"
+          role="menuitem"
         >
-          {{t 'utils.full-history'}}
+          {{t "utils.full-history"}}
         </AuLink>
       </div>
     </AuDropdown>
   </:actionsAfterTitle>
   <:actions>
     <AuDropdown
-      @title={{t 'utils.file-options'}}
-      @buttonLabel={{t 'utils.file-options'}}
-      @alignment='right'
+      @title={{t "utils.file-options"}}
+      @buttonLabel={{t "utils.file-options"}}
+      @alignment="right"
     >
       {{! template-lint-disable require-context-role }}
-      <AuButton {{on 'click' this.download}} @skin='link' role='menuitem'>
-        <AuIcon @icon='export' @alignment='left' />
-        {{t 'utils.html-export'}}
+      <AuButton {{on "click" this.download}} @skin="link" role="menuitem">
+        <AuIcon @icon="export" @alignment="left" />
+        {{t "utils.html-export"}}
       </AuButton>
     </AuDropdown>
     <AuButton
-      {{on 'click' (perform this.saveTask)}}
+      {{on "click" (perform this.saveTask)}}
       @disabled={{this.save.isRunning}}
     >
-      {{t 'utils.save'}}
+      {{t "utils.save"}}
     </AuButton>
   </:actions>
 </AppChrome>
 
 <AuBodyContainer
-  vocab='http://data.vlaanderen.be/ns/besluit#'
-  prefix='eli: http://data.europa.eu/eli/ontology# prov: http://www.w3.org/ns/prov# mandaat: http://data.vlaanderen.be/ns/mandaat# besluit: http://data.vlaanderen.be/ns/besluit# say:https://say.data.gift/ns/ dct: http://purl.org/dc/terms/ ext:http://mu.semte.ch/vocabularies/ext/'
+  vocab="http://data.vlaanderen.be/ns/besluit#"
+  prefix="eli: http://data.europa.eu/eli/ontology# prov: http://www.w3.org/ns/prov# mandaat: http://data.vlaanderen.be/ns/mandaat# besluit: http://data.vlaanderen.be/ns/besluit# say:https://say.data.gift/ns/ dct: http://purl.org/dc/terms/ ext:http://mu.semte.ch/vocabularies/ext/"
 >
   <RdfaEditorContainer
     @rdfaEditorInit={{this.handleRdfaEditorInit}}
-    @typeOfWrappingDiv='lblodgn:ReglementaireBijlage'
+    @typeOfWrappingDiv="lblodgn:ReglementaireBijlage"
     @showToggleRdfaAnnotations={{true}}
     @editorDocument={{this.editorDocument}}
     @busy={{or this.saveTask.isRunning}}
-    @busyText={{t 'rdfa-editor-container.saving'}}
+    @busyText={{t "rdfa-editor-container.saving"}}
     @schema={{this.schema}}
     @widgets={{this.widgets}}
     @nodeViews={{this.nodeViews}}
     @plugins={{this.plugins}}
-    @shouldEditRdfa={{false}}
+    @shouldEditRdfa={{true}}
   >
     <:toolbar>
       <Plugins::Formatting::FormattingToggle @controller={{this.controller}} />

--- a/app/templates/regulatory-statements/edit.hbs
+++ b/app/templates/regulatory-statements/edit.hbs
@@ -126,11 +126,13 @@
         @plugin={{this.citationPlugin}}
         @config={{this.config.citation}}
       />
-      <this.SnippetInsert
-        @controller={{this.controller}}
-        @config={{this.config.snippet}}
-        @node={{this.activeNode}}
-      />
+      {{#if this.activeNode}}
+        <this.SnippetInsert
+          @controller={{this.controller}}
+          @config={{this.config.snippet}}
+          @node={{this.activeNode}}
+        />
+      {{/if}}
       <VariablePlugin::Date::Insert
         @controller={{this.controller}}
         @options={{this.config.date}}

--- a/app/templates/regulatory-statements/edit.hbs
+++ b/app/templates/regulatory-statements/edit.hbs
@@ -1,4 +1,4 @@
-{{page-title (t 'regulatory-statement.page-title')}}
+{{page-title (t "regulatory-statement.page-title")}}
 <AppChrome
   @editorDocument={{this.editorDocument}}
   @documentContainer={{this.documentContainer}}
@@ -9,47 +9,47 @@
 >
   <:returnLink>
     <AuLink
-      @route='inbox.regulatory-statements'
+      @route="inbox.regulatory-statements"
       @model={{@meetingId}}
-      @icon='arrow-left'
+      @icon="arrow-left"
     >
-      {{t 'inbox.regulatory-statements.return'}}
+      {{t "inbox.regulatory-statements.return"}}
     </AuLink>
   </:returnLink>
   <:actionsAfterTitle>
     <AuDropdown
-      @title={{t 'utils.current-version'}}
-      @buttonLabel={{t 'utils.current-version'}}
-      @alignment='left'
+      @title={{t "utils.current-version"}}
+      @buttonLabel={{t "utils.current-version"}}
+      @alignment="left"
     >
       <p
-        class='au-u-padding-small regulatory-statement-current-version-container-active'
+        class="au-u-padding-small regulatory-statement-current-version-container-active"
       >
-        <span class='au-u-medium au-u-margin-right-large'>{{t
-            'utils.current-version'
+        <span class="au-u-medium au-u-margin-right-large">{{t
+            "utils.current-version"
           }}:
         </span>
-        <span class='au-u-light'>{{human-friendly-date
+        <span class="au-u-light">{{human-friendly-date
             this.editorDocument.updatedOn
             locale=this.intl.primaryLocale
           }}</span>
       </p>
       <AuHr />
       <div
-        class='au-u-flex--column au-u-flex'
+        class="au-u-flex--column au-u-flex"
         {{did-update (perform this.fetchRevisions)}}
         {{did-insert (perform this.fetchRevisions)}}
       >
         <p
-          class='au-u-muted au-u-medium au-u-padding-tiny au-u-padding-left-small'
-        >{{t 'utils.history'}}</p>
+          class="au-u-muted au-u-medium au-u-padding-tiny au-u-padding-left-small"
+        >{{t "utils.history"}}</p>
         {{#each this.revisions as |revision|}}
           {{! template-lint-disable require-context-role }}
           <AuLink
-            @route='regulatory-statements.revisions'
-            @skin='secondary'
-            class='au-u-padding-tiny au-u-padding-left-small'
-            role='menuitem'
+            @route="regulatory-statements.revisions"
+            @skin="secondary"
+            class="au-u-padding-tiny au-u-padding-left-small"
+            role="menuitem"
             @models={{array this.documentContainer.id revision.id}}
           >
             {{human-friendly-date
@@ -126,6 +126,11 @@
         @plugin={{this.citationPlugin}}
         @config={{this.config.citation}}
       />
+      <this.SnippetInsert
+        @controller={{this.controller}}
+        @config={{this.config.snippet}}
+        @node={{this.activeNode}}
+      />
       <VariablePlugin::Date::Insert
         @controller={{this.controller}}
         @options={{this.config.date}}
@@ -169,6 +174,6 @@
 </AuBodyContainer>
 <ConfirmRouteLeave
   @enabled={{this.dirty}}
-  @message={{t 'behandeling-van-agendapunten.confirm-leave-without-saving'}}
+  @message={{t "behandeling-van-agendapunten.confirm-leave-without-saving"}}
 />
 {{outlet}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@lblod/ember-environment-banner": "^0.2.0",
         "@lblod/ember-mock-login": "0.7.0",
         "@lblod/ember-rdfa-editor": "10.0.0-next.1",
-        "@lblod/ember-rdfa-editor-lblod-plugins": "git://git@github.com:lblod/ember-rdfa-editor-lblod-plugins.git#7c6aafc051c30096d23fa388212e4732605b91a6",
+        "@lblod/ember-rdfa-editor-lblod-plugins": "git://git@github.com:lblod/ember-rdfa-editor-lblod-plugins.git#38d2078e60422e378ffb08c360129caed2f82cdc",
         "@release-it-plugins/lerna-changelog": "^6.0.0",
         "broccoli-asset-rev": "^3.0.0",
         "broccoli-plugin": "^4.0.7",
@@ -4801,8 +4801,8 @@
     },
     "node_modules/@lblod/ember-rdfa-editor-lblod-plugins": {
       "version": "16.0.1",
-      "resolved": "git+https://git@github.com/lblod/ember-rdfa-editor-lblod-plugins.git#7c6aafc051c30096d23fa388212e4732605b91a6",
-      "integrity": "sha512-lWrVSHfwSqKFUUo/ExjXMx9KGXJSLk5Vy3qHR7WHoRH15rCIb0QsOga8xJwHDbu52j7StG4tXzZrHkThBIJ26g==",
+      "resolved": "git+https://git@github.com/lblod/ember-rdfa-editor-lblod-plugins.git#38d2078e60422e378ffb08c360129caed2f82cdc",
+      "integrity": "sha512-DkHwSqJAYR4D4JqnWRREknOvHVoq+01oQmzexPo08G01L/D+Nqd4aAVC9KeQFxq3wt7G6G9SGt4oFrJOpy75+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@lblod/ember-environment-banner": "^0.2.0",
         "@lblod/ember-mock-login": "0.7.0",
         "@lblod/ember-rdfa-editor": "10.0.0-next.1",
-        "@lblod/ember-rdfa-editor-lblod-plugins": "git://git@github.com:lblod/ember-rdfa-editor-lblod-plugins.git#78c9dcac693cd392d137aaab2d5ea5c6dd5f7567",
+        "@lblod/ember-rdfa-editor-lblod-plugins": "git://git@github.com:lblod/ember-rdfa-editor-lblod-plugins.git#7c6aafc051c30096d23fa388212e4732605b91a6",
         "@release-it-plugins/lerna-changelog": "^6.0.0",
         "broccoli-asset-rev": "^3.0.0",
         "broccoli-plugin": "^4.0.7",
@@ -4801,8 +4801,8 @@
     },
     "node_modules/@lblod/ember-rdfa-editor-lblod-plugins": {
       "version": "16.0.1",
-      "resolved": "git+https://git@github.com/lblod/ember-rdfa-editor-lblod-plugins.git#78c9dcac693cd392d137aaab2d5ea5c6dd5f7567",
-      "integrity": "sha512-qEtpcXNvzNEFkn6VxCZZtB9f8FqxSOtn35DfRqm8fe1nvF3x91fo0KtL83YyjKdxHe9G2/tOO03DlYfaqj2Rkw==",
+      "resolved": "git+https://git@github.com/lblod/ember-rdfa-editor-lblod-plugins.git#7c6aafc051c30096d23fa388212e4732605b91a6",
+      "integrity": "sha512-lWrVSHfwSqKFUUo/ExjXMx9KGXJSLk5Vy3qHR7WHoRH15rCIb0QsOga8xJwHDbu52j7StG4tXzZrHkThBIJ26g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@lblod/ember-environment-banner": "^0.2.0",
     "@lblod/ember-mock-login": "0.7.0",
     "@lblod/ember-rdfa-editor": "10.0.0-next.1",
-    "@lblod/ember-rdfa-editor-lblod-plugins": "git://git@github.com:lblod/ember-rdfa-editor-lblod-plugins.git#78c9dcac693cd392d137aaab2d5ea5c6dd5f7567",
+    "@lblod/ember-rdfa-editor-lblod-plugins": "git://git@github.com:lblod/ember-rdfa-editor-lblod-plugins.git#7c6aafc051c30096d23fa388212e4732605b91a6",
     "@release-it-plugins/lerna-changelog": "^6.0.0",
     "broccoli-asset-rev": "^3.0.0",
     "broccoli-plugin": "^4.0.7",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@lblod/ember-environment-banner": "^0.2.0",
     "@lblod/ember-mock-login": "0.7.0",
     "@lblod/ember-rdfa-editor": "10.0.0-next.1",
-    "@lblod/ember-rdfa-editor-lblod-plugins": "git://git@github.com:lblod/ember-rdfa-editor-lblod-plugins.git#38d2078e60422e378ffb08c360129caed2f82cdc",
+    "@lblod/ember-rdfa-editor-lblod-plugins": "git://git@github.com:lblod/ember-rdfa-editor-lblod-plugins.git#73a7b99b25ff78e740640c5775886a4bfa237a3f",
     "@release-it-plugins/lerna-changelog": "^6.0.0",
     "broccoli-asset-rev": "^3.0.0",
     "broccoli-plugin": "^4.0.7",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@lblod/ember-environment-banner": "^0.2.0",
     "@lblod/ember-mock-login": "0.7.0",
     "@lblod/ember-rdfa-editor": "10.0.0-next.1",
-    "@lblod/ember-rdfa-editor-lblod-plugins": "git://git@github.com:lblod/ember-rdfa-editor-lblod-plugins.git#7c6aafc051c30096d23fa388212e4732605b91a6",
+    "@lblod/ember-rdfa-editor-lblod-plugins": "git://git@github.com:lblod/ember-rdfa-editor-lblod-plugins.git#38d2078e60422e378ffb08c360129caed2f82cdc",
     "@release-it-plugins/lerna-changelog": "^6.0.0",
     "broccoli-asset-rev": "^3.0.0",
     "broccoli-plugin": "^4.0.7",


### PR DESCRIPTION
Mainly adding the snippet insert feature and the css import

### Overview
<!-- high level overview of changes (not just "implement ticket") + *why* + design document, special notes like ticket partially implemented etc. -->

##### connected issues and PRs:
<!-- links to connected jira tickets -->
<!-- Link to PRs that are related (and in what way) -->


### Setup
<!-- PR dependencies -->
<!-- override snippets -->
just npm i and run, the plugins are connected with github link

Note: to connect to the futurenow RB backend when running locally, you'll need to change the endpoints in config/environment.js
I debated adding that here but I wanna avoid frantic debugging due to forgetting this was changed.

### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->



### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations