### PR TITLE
Add null-checks to behandeling-van-agendapunt component

### DIFF
--- a/.changeset/gold-mirrors-bake.md
+++ b/.changeset/gold-mirrors-bake.md
@@ -1,0 +1,5 @@
+---
+"frontend-gelinkt-notuleren": patch
+---
+
+Add null/undefined checks to `behandeling-van-agendapunt` component to prevent errors


### PR DESCRIPTION
### Overview
This PR adds several null/undefined checks to the `behandeling-van-agendapunt` component in order to prevent `undefined` errors.

##### connected issues and PRs:
None

### How to test/reproduce
- Start the application
- Open up a meeting with agendapoints
- Remove an agendapoint
- The `container is undefined` error should no longer show up

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
