### PR TITLE
Add support for signed/published-resource contents in files

### DIFF
--- a/.changeset/fresh-queens-protect.md
+++ b/.changeset/fresh-queens-protect.md
@@ -1,0 +1,5 @@
+---
+"frontend-gelinkt-notuleren": patch
+---
+
+Add support for signed-resources and published-resources which have their content in files instead of directly as text

--- a/app/controllers/meetings/publish/notulen.js
+++ b/app/controllers/meetings/publish/notulen.js
@@ -151,9 +151,12 @@ export default class MeetingsPublishNotulenController extends Controller {
       this.publicBehandelingUris = publicNotulen.publicBehandelingen || [];
       if (isEmpty(publicNotulen.content)) {
         const fileMeta = await publicNotulen.file;
-        publicNotulen.content = await (
-          await fetch(fileMeta.downloadLink)
-        ).text();
+        const fileReq = await fetch(fileMeta.downloadLink);
+        if (fileReq.ok) {
+          publicNotulen.content = await fileReq.text();
+        } else {
+          this.errors = [`Error fetching file contents: ${fileReq.statusText}`];
+        }
       }
       this.notulen = publicNotulen;
     } else {

--- a/app/controllers/meetings/publish/uittreksels/show.js
+++ b/app/controllers/meetings/publish/uittreksels/show.js
@@ -143,6 +143,7 @@ export default class MeetingsPublishUittrekselsShowController extends Controller
   @action
   async refreshRoute() {
     await this.router.refresh();
+    this.error = undefined;
   }
 
   signDocumentTask = task(async () => {

--- a/app/models/published-resource.js
+++ b/app/models/published-resource.js
@@ -1,18 +1,27 @@
 import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class PublishedResourceModel extends Model {
+  /** Optional, content might be in .file instead **/
   @attr content;
   @attr hashValue;
   @attr('datetime') createdOn;
   @attr submissionStatus;
 
-  @belongsTo('blockchain-status', { inverse: null }) status;
-  @belongsTo('gebruiker', { inverse: null }) gebruiker;
-  @belongsTo('agenda', { inverse: 'publishedResource' }) agenda;
-  @belongsTo('versioned-besluiten-lijst', { inverse: 'publishedResource' })
+  @belongsTo('blockchain-status', { async: true, inverse: null }) status;
+  @belongsTo('gebruiker', { async: true, inverse: null }) gebruiker;
+  @belongsTo('agenda', { async: true, inverse: 'publishedResource' }) agenda;
+  @belongsTo('versioned-besluiten-lijst', {
+    async: true,
+    inverse: 'publishedResource',
+  })
   versionedBesluitenLijst;
-  @belongsTo('versioned-behandeling', { inverse: 'publishedResource' })
+  @belongsTo('versioned-behandeling', {
+    async: true,
+    inverse: 'publishedResource',
+  })
   versionedBehandeling;
-  @belongsTo('versioned-notulen', { inverse: 'publishedResource' })
+  @belongsTo('versioned-notulen', { async: true, inverse: 'publishedResource' })
   versionedNotulen;
+  /** Optional, content might be in .content instead **/
+  @belongsTo('file', { async: true, inverse: null }) file;
 }

--- a/app/models/signed-resource.js
+++ b/app/models/signed-resource.js
@@ -1,18 +1,27 @@
 import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class SignedResourceModel extends Model {
+  /** Optional, content might be in .file instead **/
   @attr content;
   @attr hashValue;
   @attr('boolean', { defaultValue: false }) deleted;
   @attr('datetime') createdOn;
 
-  @belongsTo('blockchain-status', { inverse: null }) status;
-  @belongsTo('gebruiker', { inverse: null }) gebruiker;
-  @belongsTo('agenda', { inverse: 'signedResources' }) agenda;
-  @belongsTo('versioned-besluiten-lijst', { inverse: 'signedResources' })
+  @belongsTo('blockchain-status', { async: true, inverse: null }) status;
+  @belongsTo('gebruiker', { async: true, inverse: null }) gebruiker;
+  @belongsTo('agenda', { async: true, inverse: 'signedResources' }) agenda;
+  @belongsTo('versioned-besluiten-lijst', {
+    async: true,
+    inverse: 'signedResources',
+  })
   versionedBesluitenLijst;
-  @belongsTo('versioned-behandeling', { inverse: 'signedResources' })
+  @belongsTo('versioned-behandeling', {
+    async: true,
+    inverse: 'signedResources',
+  })
   versionedBehandeling;
-  @belongsTo('versioned-notulen', { inverse: 'signedResources' })
+  @belongsTo('versioned-notulen', { async: true, inverse: 'signedResources' })
   versionedNotulen;
+  /** Optional, content might be in .content instead **/
+  @belongsTo('file', { async: true, inverse: null }) file;
 }

--- a/app/routes/meetings/publish/publication-actions/detail.js
+++ b/app/routes/meetings/publish/publication-actions/detail.js
@@ -12,8 +12,13 @@ export default class MeetingsPublishPublicationActionsDetailRoute extends Route 
       },
     );
     const signedResource = await log.signedResource;
-    if (signedResource) {
+    if (signedResource?.content) {
       return signedResource.content;
+    } else if (signedResource?.file) {
+      const fileMeta = await signedResource.file;
+      const fileContent =
+        fileMeta && (await (await fetch(fileMeta.downloadLink)).text());
+      return fileContent;
     } else {
       const publishedResource = await log.publishedResource;
       return publishedResource.content;

--- a/app/routes/meetings/publish/publication-actions/detail.js
+++ b/app/routes/meetings/publish/publication-actions/detail.js
@@ -16,9 +16,12 @@ export default class MeetingsPublishPublicationActionsDetailRoute extends Route 
       return signedResource.content;
     } else if (signedResource?.file) {
       const fileMeta = await signedResource.file;
-      const fileContent =
-        fileMeta && (await (await fetch(fileMeta.downloadLink)).text());
-      return fileContent;
+      const fileReq = await fetch(fileMeta.downloadLink);
+      if (fileReq.ok) {
+        return fileReq.text();
+      } else {
+        return `<div class="au-c-alert au-c-alert--warning"><p>Error fetching file contents: ${fileReq.statusText}</p></div>`;
+      }
     } else {
       const publishedResource = await log.publishedResource;
       return publishedResource.content;

--- a/app/routes/meetings/publish/uittreksels/index.js
+++ b/app/routes/meetings/publish/uittreksels/index.js
@@ -36,7 +36,7 @@ export default class MeetingsPublishUittrekselsRoute extends Route {
       query['filter[titel]'] = params.title;
     }
     const result = await this.store.query('agendapunt', query);
-    const agendapoints = result.toArray();
+    const agendapoints = result.slice();
     const agendapointsToDisplay = [];
     agendapointsToDisplay.meta = result.meta;
 
@@ -48,7 +48,7 @@ export default class MeetingsPublishUittrekselsRoute extends Route {
           'filter[:or:][deleted]': false,
           'filter[:or:][:has-no:deleted]': 'yes',
         })
-      ).toArray()[0];
+      )[0];
       agendapointsToDisplay.push({
         titel: agendapoint.titel,
         behandeling: agendapoint.behandeling,

--- a/app/routes/meetings/publish/uittreksels/show.js
+++ b/app/routes/meetings/publish/uittreksels/show.js
@@ -76,7 +76,7 @@ export default class MeetingsPublishUittrekselsShowRoute extends Route {
         versionedTreatment,
         meeting,
         signedResources: signedResources.toArray(),
-        publishedResource: publishedResource.firstObject,
+        publishedResource: publishedResource[0],
         // if a versionedTreatment exists, that means some signature or publication
         // has happened, which means that there are no errors, so we can safely do this
         validationErrors: [],

--- a/app/templates/meetings/publish/uittreksels/show.hbs
+++ b/app/templates/meetings/publish/uittreksels/show.hbs
@@ -4,7 +4,7 @@
     <AuAlert @icon="cross" @sitle={{t "publish.excerpt-error-message"}} @skin="error" @size="small">
       <code>{{this.error}}</code>
     </AuAlert>
-    <AuButton {{on "click" (perform this.loadExtract)}}>{{t "publish.retry"}}</AuButton>
+    <AuButton {{on "click" this.refreshRoute}}>{{t "publish.retry"}}</AuButton>
   {{else}}
     <div class="au-u-margin-bottom-small au-u-hide-on-print">
       <AuLink @route="meetings.publish.uittreksels" @skin="secondary" @icon="arrow-left" @iconAlignment="left">{{t


### PR DESCRIPTION
### Overview
Handle the possibility that published or signed resources have content in a file instead of directly in the resource as a string. Also added some very basic error handling for file lookups instead of just returning blank data.

##### connected issues and PRs:
Part of #639 
Needed for https://github.com/lblod/app-gelinkt-notuleren/pull/181

### Setup
Needs to be tested with the app-gn from the PR.

### How to test/reproduce
See [the app-gn PR](https://github.com/lblod/app-gelinkt-notuleren/pull/181) on how to test/reproduce.

### Challenges/uncertainties
The sheer number of deprecations makes it hard to see messages...

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
