### PR TITLE
GN-4772: Fix supported language detection

### DIFF
--- a/.changeset/calm-llamas-protect.md
+++ b/.changeset/calm-llamas-protect.md
@@ -1,0 +1,5 @@
+---
+"frontend-gelinkt-notuleren": patch
+---
+
+GN-4772: Fix supported language detection

--- a/tests/unit/utils/intl-test.js
+++ b/tests/unit/utils/intl-test.js
@@ -1,0 +1,35 @@
+import { module, test } from 'qunit';
+
+import { decentLocaleMatch } from 'frontend-gelinkt-notuleren/utils/intl';
+
+const supportedLocales = ['en-us', 'nl-BE'];
+const defaultLocale = 'nl-BE';
+
+module('Unit | Utils | intl', function () {
+  test.each(
+    'decentLocaleMatch',
+    [
+      {
+        userLocales: ['nl-NL', 'nl', 'en-US', 'en'],
+        expectedResult: ['nl-be', 'en-us'],
+      },
+      {
+        userLocales: ['nl-NL', 'nl'],
+        expectedResult: ['nl-be'],
+      },
+      {
+        userLocales: ['en-US', 'en', 'nl-NL', 'nl'],
+        expectedResult: ['en-us', 'nl-be'],
+      },
+    ],
+    (assert, { userLocales, expectedResult }) => {
+      const result = decentLocaleMatch(
+        userLocales,
+        supportedLocales,
+        defaultLocale,
+      );
+
+      assert.deepEqual(result, expectedResult);
+    },
+  );
+});


### PR DESCRIPTION
### Overview

User preferred order of languages (e.g. from `navigator.languages`) was not taken into regard if _more_ preferred language did not match supported language code exactly, but there is an exactly matching less preferred language.

E.g.  user `navigator.languages` returns `['nl-NL', 'en-US']` but supported languages are `['nl-BE', 'en-US']`, then `decentLocaleMatch` function would return `['en-us', 'nl-be']`, as `en-US` was matched and added to the matched languages first because of how the code was structured.

##### connected issues and PRs:

* https://binnenland.atlassian.net/browse/GN-4772
Closes #642 


### Setup

1. Checkout
2. `ember s --proxy https://dev.gelinkt-notuleren.lblod.info` 

### How to test/reproduce

You will need a Local Switcher extension installed. Set it up like so

![CleanShot 2024-04-12 at 14 23 26@2x](https://github.com/lblod/frontend-gelinkt-notuleren/assets/769698/a0438c37-f70c-4a6a-afdb-b2a2e7ceeaae)

Navigate to the application, it should be in Dutch. If you test without this PR then it will be in English. I've also added unit test to make sure this won't get broken again (hopefully).

### Checks PR readiness
- [X] UI: works on smaller screen sizes
- [X] UI: feedback for any loading/error states
- [X] Check cancel/go-back flows
- [X] Check database state correct when deleting/updating (especially regarding relationships)
- [X] changelog
- [X] npm lint
- [X] no new deprecations
