### PR TITLE
GN-4808: Fix language detection for first time users

### DIFF
--- a/.changeset/tiny-worms-fix.md
+++ b/.changeset/tiny-worms-fix.md
@@ -1,0 +1,5 @@
+---
+"frontend-gelinkt-notuleren": patch
+---
+
+GN-4808: Fix language detection for users that are coming to GN for the first time

--- a/app/utils/intl.js
+++ b/app/utils/intl.js
@@ -35,9 +35,21 @@ export function decentLocaleMatch(
   );
 
   const deduplicatedSupportedLocales = new Set([
-    ...supportedLocalesThatUserPrefers.map((locale) => locale.toLowerCase()),
+    ...supportedLocalesThatUserPrefers.map(
+      (locale) => locale && locale.toLowerCase(),
+    ),
     defaultLocale.toLowerCase(),
   ]);
 
-  return [...deduplicatedSupportedLocales];
+  const definedSupportedLocales = [...deduplicatedSupportedLocales].filter(
+    (locale) => typeof locale === 'string',
+  );
+
+  const lowerCaseDefaultLocale = defaultLocale.toLowerCase();
+
+  if (definedSupportedLocales.length < 1) {
+    return [lowerCaseDefaultLocale];
+  }
+
+  return [...definedSupportedLocales, lowerCaseDefaultLocale];
 }


### PR DESCRIPTION
GN-4808: Fix language detection for users that are coming to GN for the first time

### Overview

There's a chance that `matchUserLocaleToSupportedLocale` will return undefined value, calling `toLowerCase` will then throw an error, this might happen when application is loading for the first time for the user, and there's nothing yet stored in the browser for the user.

##### connected issues and PRs:

* Caused by https://binnenland.atlassian.net/browse/GN-4772
* Ticket - https://binnenland.atlassian.net/browse/GN-4808


### Setup

1. Checkout
2. `ember s --proxy https://reglementairebijlagen.lblod.info` 

### How to test/reproduce

1. Try to open in incognito tab

### Challenges/uncertainties

There's no TS in this project, without it's help I've missed this possibility.



### Checks PR readiness
- [X] UI: works on smaller screen sizes
- [X] UI: feedback for any loading/error states
- [X] Check cancel/go-back flows
- [X] Check database state correct when deleting/updating (especially regarding relationships)
- [X] changelog
- [X] npm lint
- [X] no new deprecations
