### PR TITLE
Bump `ember-rdfa-editor-lblod-plugins` to `17.1.0`

### DIFF
--- a/.changeset/gentle-colts-try.md
+++ b/.changeset/gentle-colts-try.md
@@ -1,0 +1,14 @@
+---
+"frontend-gelinkt-notuleren": minor
+---
+
+Bump `ember-rdfa-editor-lblod-plugins` to `17.1.0` to get snippet changes:
+
+##### GN-4811: Only show the titles of the snippets
+
+In the snippet insert modal: only show the titles of the snippets
+
+#### GN-4816: Add sorting for snippet lists
+
+* Use AuDataTable
+* Add sorting for snippet lists

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@lblod/ember-environment-banner": "^0.5.0",
         "@lblod/ember-mock-login": "0.7.0",
         "@lblod/ember-rdfa-editor": "9.6.1",
-        "@lblod/ember-rdfa-editor-lblod-plugins": "^17.0.0",
+        "@lblod/ember-rdfa-editor-lblod-plugins": "^17.1.0",
         "@release-it-plugins/lerna-changelog": "^6.0.0",
         "broccoli-asset-rev": "^3.0.0",
         "broccoli-plugin": "^4.0.7",
@@ -5014,9 +5014,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor-lblod-plugins": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-17.0.0.tgz",
-      "integrity": "sha512-ZU+VmRR1i75KGClWqZWlTffkf3FcquwqBWjxxE86Kvfprp+pZcpQR4FaL54OR0Gb/A2+gzB69zv1HszWDQhJzw==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-17.1.0.tgz",
+      "integrity": "sha512-qCkGCZ+MdN779dAEOZkzziZP+npfuwXW8B8JRwW/3eW/X36MF+0/ocON00hzs2cAHUeeq1R9pUC2eHfdZXTIGA==",
       "dev": true,
       "dependencies": {
         "@codemirror/lang-html": "^6.4.3",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@lblod/ember-environment-banner": "^0.5.0",
     "@lblod/ember-mock-login": "0.7.0",
     "@lblod/ember-rdfa-editor": "9.6.1",
-    "@lblod/ember-rdfa-editor-lblod-plugins": "^17.0.0",
+    "@lblod/ember-rdfa-editor-lblod-plugins": "^17.1.0",
     "@release-it-plugins/lerna-changelog": "^6.0.0",
     "broccoli-asset-rev": "^3.0.0",
     "broccoli-plugin": "^4.0.7",


### PR DESCRIPTION
Bump `ember-rdfa-editor-lblod-plugins` to `17.1.0` to get snippet changes:

##### GN-4811: Only show the titles of the snippets

In the snippet insert modal: only show the titles of the snippets

#### GN-4816: Add sorting for snippet lists

* Use AuDataTable
* Add sorting for snippet lists
