### PR TITLE
Update `@lblod/ember-rdfa-editor` to 9.7.0 and enable support for hierarchical lists

### DIFF
--- a/.changeset/fuzzy-hats-compete.md
+++ b/.changeset/fuzzy-hats-compete.md
@@ -1,0 +1,5 @@
+---
+"frontend-gelinkt-notuleren": minor
+---
+
+Enable support for hierarchical lists

--- a/.changeset/slimy-lobsters-admire.md
+++ b/.changeset/slimy-lobsters-admire.md
@@ -1,0 +1,5 @@
+---
+"frontend-gelinkt-notuleren": patch
+---
+
+Update `@lblod/ember-rdfa-editor` to version 9.7.0

--- a/app/components/toolbar/list.hbs
+++ b/app/components/toolbar/list.hbs
@@ -1,2 +1,2 @@
 <Plugins::List::Unordered @controller={{@controller}}/>
-<Plugins::List::Ordered @controller={{@controller}}/>
+<Plugins::List::Ordered @controller={{@controller}} @enableHierarchicalList={{true}}/>

--- a/app/components/zitting-text-document-container.js
+++ b/app/components/zitting-text-document-container.js
@@ -30,9 +30,10 @@ import {
 } from '@lblod/ember-rdfa-editor/plugins/table';
 import { link, linkView } from '@lblod/ember-rdfa-editor/nodes/link';
 import {
-  bullet_list,
-  list_item,
-  ordered_list,
+  bulletListWithConfig,
+  listItemWithConfig,
+  listTrackingPlugin,
+  orderedListWithConfig,
 } from '@lblod/ember-rdfa-editor/plugins/list';
 import { placeholder } from '@lblod/ember-rdfa-editor/plugins/placeholder';
 import { heading } from '@lblod/ember-rdfa-editor/plugins/heading';
@@ -70,9 +71,9 @@ export default class ZittingTextDocumentContainerComponent extends Component {
       doc: docWithConfig(),
       paragraph,
       repaired_block,
-      list_item,
-      ordered_list,
-      bullet_list,
+      list_item: listItemWithConfig({ enableHierarchicalList: true }),
+      ordered_list: orderedListWithConfig({ enableHierarchicalList: true }),
+      bullet_list: bulletListWithConfig({ enableHierarchicalList: true }),
       placeholder,
       ...tableNodes({ tableGroup: 'block', cellContent: 'block+' }),
       date: date(this.config.date),
@@ -163,6 +164,7 @@ export default class ZittingTextDocumentContainerComponent extends Component {
       ...tablePlugins,
       tableKeymap,
       linkPasteHandler(this.schema.nodes.link),
+      listTrackingPlugin(),
     ];
   }
 

--- a/app/controllers/agendapoints/edit.js
+++ b/app/controllers/agendapoints/edit.js
@@ -44,9 +44,10 @@ import {
   textVariableView,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/variables';
 import {
-  bullet_list,
-  list_item,
-  ordered_list,
+  bulletListWithConfig,
+  listItemWithConfig,
+  listTrackingPlugin,
+  orderedListWithConfig,
 } from '@lblod/ember-rdfa-editor/plugins/list';
 import { placeholder } from '@lblod/ember-rdfa-editor/plugins/placeholder';
 import { heading } from '@lblod/ember-rdfa-editor/plugins/heading';
@@ -115,9 +116,9 @@ export default class AgendapointsEditController extends Controller {
       doc: docWithConfig(),
       paragraph,
       repaired_block,
-      list_item,
-      ordered_list,
-      bullet_list,
+      list_item: listItemWithConfig({ enableHierarchicalList: true }),
+      ordered_list: orderedListWithConfig({ enableHierarchicalList: true }),
+      bullet_list: bulletListWithConfig({ enableHierarchicalList: true }),
       placeholder,
       ...tableNodes({ tableGroup: 'block', cellContent: 'block+' }),
       date: date(this.config.date),
@@ -260,6 +261,7 @@ export default class AgendapointsEditController extends Controller {
         },
       ),
       linkPasteHandler(this.schema.nodes.link),
+      listTrackingPlugin(),
     ];
   }
 

--- a/app/controllers/regulatory-statements/edit.js
+++ b/app/controllers/regulatory-statements/edit.js
@@ -42,9 +42,10 @@ import {
   STRUCTURE_SPECS,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/article-structure-plugin/structures';
 import {
-  bullet_list,
-  list_item,
-  ordered_list,
+  bulletListWithConfig,
+  listItemWithConfig,
+  listTrackingPlugin,
+  orderedListWithConfig,
 } from '@lblod/ember-rdfa-editor/plugins/list';
 import { placeholder } from '@lblod/ember-rdfa-editor/plugins/placeholder';
 import { heading } from '@lblod/ember-rdfa-editor/plugins/heading';
@@ -112,9 +113,9 @@ export default class RegulatoryStatementsRoute extends Controller {
       document_title,
       table_of_contents: table_of_contents(this.config.tableOfContents),
       repaired_block,
-      list_item,
-      ordered_list,
-      bullet_list,
+      list_item: listItemWithConfig({ enableHierarchicalList: true }),
+      ordered_list: orderedListWithConfig({ enableHierarchicalList: true }),
+      bullet_list: bulletListWithConfig({ enableHierarchicalList: true }),
       placeholder,
       templateComment,
       ...tableNodes({ tableGroup: 'block', cellContent: 'block+' }),
@@ -181,6 +182,7 @@ export default class RegulatoryStatementsRoute extends Controller {
       ),
       linkPasteHandler(this.schema.nodes.link),
       emberApplication({ application: getOwner(this) }),
+      listTrackingPlugin(),
     ];
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@lblod/ember-acmidm-login": "^2.0.0-beta.1",
         "@lblod/ember-environment-banner": "^0.5.0",
         "@lblod/ember-mock-login": "0.7.0",
-        "@lblod/ember-rdfa-editor": "9.6.1",
+        "@lblod/ember-rdfa-editor": "9.7.0",
         "@lblod/ember-rdfa-editor-lblod-plugins": "^17.1.0",
         "@release-it-plugins/lerna-changelog": "^6.0.0",
         "broccoli-asset-rev": "^3.0.0",
@@ -4941,9 +4941,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-9.6.1.tgz",
-      "integrity": "sha512-XDWCJMG92RnTzs/EdcJlbdblYLZ/RJVG6oNrlLmKqQxIeGsbDdUcvI8TMIpa0o47GePEFeBEpVvaizgQDQq0ag==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-9.7.0.tgz",
+      "integrity": "sha512-bMmC0sL5NuIg5R7V2fCGJQDioggIpudNE26gow1uJ02AjtFWSREDmPByLMUhAndPswudwR+2wbA+Nejt6teypg==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.23.7",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@lblod/ember-acmidm-login": "^2.0.0-beta.1",
     "@lblod/ember-environment-banner": "^0.5.0",
     "@lblod/ember-mock-login": "0.7.0",
-    "@lblod/ember-rdfa-editor": "9.6.1",
+    "@lblod/ember-rdfa-editor": "9.7.0",
     "@lblod/ember-rdfa-editor-lblod-plugins": "^17.1.0",
     "@release-it-plugins/lerna-changelog": "^6.0.0",
     "broccoli-asset-rev": "^3.0.0",


### PR DESCRIPTION
### Overview
This PR includes two changes:
- Update of `@lblod/ember-rdfa-editor` to 9.7.0
- Support for hierarchical lists
