### PR TITLE
Add snippet placeholder

### DIFF
--- a/.changeset/nine-wombats-stare.md
+++ b/.changeset/nine-wombats-stare.md
@@ -1,0 +1,5 @@
+---
+"frontend-gelinkt-notuleren": minor
+---
+
+Add support for snippet placeholder nodes in regulatory statements

--- a/app/controllers/regulatory-statements/edit.js
+++ b/app/controllers/regulatory-statements/edit.js
@@ -93,7 +93,8 @@ import {
   OCMW,
 } from '../../utils/bestuurseenheid-classificatie-codes';
 
-import SnippetInsertComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/snippet-plugin/snippet-insert';
+import SnippetInsertRdfaComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/snippet-plugin/snippet-insert-rdfa';
+
 export default class RegulatoryStatementsRoute extends Controller {
   @service documentService;
   @service store;
@@ -104,7 +105,7 @@ export default class RegulatoryStatementsRoute extends Controller {
   @service intl;
   editor;
   @tracked citationPlugin = citationPlugin(this.config.citation);
-  SnippetInsert = SnippetInsertComponent;
+  SnippetInsert = SnippetInsertRdfaComponent;
 
   schema = new Schema({
     nodes: {

--- a/app/controllers/regulatory-statements/edit.js
+++ b/app/controllers/regulatory-statements/edit.js
@@ -85,6 +85,10 @@ import {
   table_of_contents,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/table-of-contents-plugin/nodes';
 import { document_title } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/document-title-plugin/nodes';
+import {
+  snippetPlaceholder,
+  snippetPlaceholderView,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/nodes/snippet-placeholder';
 
 import generateExportFromEditorDocument from 'frontend-gelinkt-notuleren/utils/generate-export-from-editor-document';
 import ENV from 'frontend-gelinkt-notuleren/config/environment';
@@ -140,6 +144,7 @@ export default class RegulatoryStatementsRoute extends Controller {
       invisible_rdfa,
       block_rdfa,
       link: link(this.config.link),
+      snippet_placeholder: snippetPlaceholder,
     },
     marks: {
       inline_rdfa,
@@ -169,6 +174,7 @@ export default class RegulatoryStatementsRoute extends Controller {
         codelist: codelistView(controller),
         text_variable: textVariableView(controller),
         templateComment: templateCommentView(controller),
+        snippet_placeholder: snippetPlaceholderView(controller),
       };
     };
   }

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -40,6 +40,7 @@
 @import "template-comments-plugin";
 @import "article-structure-plugin";
 @import "worship-plugin";
+@import "snippet-plugin";
 @import "project/p-annotations"; // @TODO: refactor in ember-rdfa-editor
 
 // give treatment (behandeling) content the same style as other say-documents

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,8 +28,8 @@
         "@lblod/ember-acmidm-login": "^2.0.0-beta.1",
         "@lblod/ember-environment-banner": "^0.5.0",
         "@lblod/ember-mock-login": "0.7.0",
-        "@lblod/ember-rdfa-editor": "9.7.1",
-        "@lblod/ember-rdfa-editor-lblod-plugins": "^17.1.1",
+        "@lblod/ember-rdfa-editor": "9.7.1-dev.67f7224891c720868d2e8ef0e92ce46d76959257",
+        "@lblod/ember-rdfa-editor-lblod-plugins": "17.1.1-dev.cadbcee954ade2283156a07199d212d7c9be852c",
         "@release-it-plugins/lerna-changelog": "^6.0.0",
         "broccoli-asset-rev": "^3.0.0",
         "broccoli-plugin": "^4.0.7",
@@ -4942,9 +4942,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor": {
-      "version": "9.7.1",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-9.7.1.tgz",
-      "integrity": "sha512-BNQDwdSuqD+4tQsU4hR3bsvqlGameOhlxkF28D/WCRp3QtO1Ra67fDPemg5S5tUjiGIz5+3wv27NOfhrDGpApQ==",
+      "version": "9.7.1-dev.67f7224891c720868d2e8ef0e92ce46d76959257",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-9.7.1-dev.67f7224891c720868d2e8ef0e92ce46d76959257.tgz",
+      "integrity": "sha512-PRKSju6sgYr0iWVmQTpH9XbkJ8Jx365s6KcrZubtSAKkchSdCX2L4qXWR7qzDFXN34wdGpdwISoHN9VR0N54Yg==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.23.7",
@@ -4971,7 +4971,7 @@
         "ember-auto-import": "^2.6.3",
         "ember-cli-babel": "^8.2.0",
         "ember-cli-htmlbars": "^6.2.0",
-        "ember-focus-trap": "~1.0.1",
+        "ember-focus-trap": "^1.1.0",
         "ember-template-imports": "^3.4.2",
         "ember-truth-helpers": "^3.0.0",
         "ember-velcro": "^2.1.0",
@@ -5015,9 +5015,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor-lblod-plugins": {
-      "version": "17.1.1",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-17.1.1.tgz",
-      "integrity": "sha512-HBTWS+rnRYe8skcserx0xC3zJV95hjiqFkMu55TNG8fzoO4oLag7ZAhQfDRzuT1KqSmykjBNso+2nFXy3nkhJQ==",
+      "version": "17.1.1-dev.cadbcee954ade2283156a07199d212d7c9be852c",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-17.1.1-dev.cadbcee954ade2283156a07199d212d7c9be852c.tgz",
+      "integrity": "sha512-H4mxZrWZ9TLPwC9Yfzj3xkDzBBqJPxzku2OJPMrxvWnhrOJdCtvhL2GyrvRh8q02wm/zx2N3z9q5+opWpkoFdw==",
       "dev": true,
       "dependencies": {
         "@codemirror/lang-html": "^6.4.3",
@@ -5041,6 +5041,7 @@
         "ember-mu-transform-helpers": "^2.0.0",
         "ember-resources": "^6.1.1",
         "ember-template-imports": "^3.4.2",
+        "ember-truth-helpers": "^3.0.0",
         "ember-velcro": "^2.1.0",
         "fetch-sparql-endpoint": "^3.0.0",
         "n2words": "^1.18.0",
@@ -5059,7 +5060,7 @@
         "@appuniversum/ember-appuniversum": "^3.4.1",
         "@ember/string": "3.x",
         "@glint/template": "^1.1.0",
-        "@lblod/ember-rdfa-editor": "^9.6.0",
+        "@lblod/ember-rdfa-editor": "^9.7.0 || 9.7.0-dev.321de5f78663980e776632137c59d03fd231148b",
         "ember-concurrency": "^2.3.7 || ^3.1.0",
         "ember-intl": "^5.7.2 || ^6.1.0",
         "ember-modifier": "^3.2.7",

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "@lblod/ember-acmidm-login": "^2.0.0-beta.1",
     "@lblod/ember-environment-banner": "^0.5.0",
     "@lblod/ember-mock-login": "0.7.0",
-    "@lblod/ember-rdfa-editor": "9.7.1",
-    "@lblod/ember-rdfa-editor-lblod-plugins": "^17.1.1",
+    "@lblod/ember-rdfa-editor": "9.7.1-dev.67f7224891c720868d2e8ef0e92ce46d76959257",
+    "@lblod/ember-rdfa-editor-lblod-plugins": "17.1.1-dev.cadbcee954ade2283156a07199d212d7c9be852c",
     "@release-it-plugins/lerna-changelog": "^6.0.0",
     "broccoli-asset-rev": "^3.0.0",
     "broccoli-plugin": "^4.0.7",
@@ -116,8 +116,8 @@
       "ember-concurrency": "^2.3.7",
       "ember-modifier": "^3.2.7"
     },
-    "@lblod/ember-rdfa-editor": {
-      "ember-focus-trap": "^1.1.0"
+    "@lblod/ember-rdfa-editor-lblod-plugins": {
+      "@lblod/ember-rdfa-editor": "9.7.1-dev.67f7224891c720868d2e8ef0e92ce46d76959257"
     }
   },
   "engines": {


### PR DESCRIPTION
### Overview
Add snippet placeholder nodespec and view so they are rendered correctly in RS editor. Required to use rdfa aware snippet insert component.

##### connected issues and PRs:
[binnenland.atlassian.net/browse/GN-4782](https://binnenland.atlassian.net/browse/GN-4782)
Uses: https://github.com/lblod/ember-rdfa-editor/pull/1188
And: https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/419
RB part: https://github.com/lblod/frontend-reglementaire-bijlage/pull/241

### Setup
You'll need to get templates from the latest RB in order to have snippet placeholders, so need to change `regulatoryStatementEndpoint` and `regulatoryStatementFileEndpoint` to point to local and run the RB stack.

### How to test/reproduce
In RB, publish a template with a snippet placeholder, and verify that in GN you can select it and insert a relevant snippet.

### Challenges/uncertainties
I don't know if it was a conscious choice not to use the rdfa aware version of the snippet insert component, but I assumed it was just an oversight.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
