### PR TITLE
GN-4827: Remove RDFA Tools from RDFA Editor

### DIFF
--- a/.changeset/thick-jars-give.md
+++ b/.changeset/thick-jars-give.md
@@ -1,0 +1,5 @@
+---
+"frontend-gelinkt-notuleren": patch
+---
+
+GN-4827: Remove RDFA Tools from RDFA Editor

--- a/app/components/rdfa-editor-container.hbs
+++ b/app/components/rdfa-editor-container.hbs
@@ -103,7 +103,6 @@
                 {{/if}}
                 {{yield to='sidebar'}}
                 {{#if @shouldEditRdfa}}
-                  <Plugins::Link::LinkEditor @controller={{this.controller}} />
                   <this.RdfaEditor
                     @node={{this.activeNode}}
                     @controller={{this.controller}}

--- a/app/templates/regulatory-statements/edit.hbs
+++ b/app/templates/regulatory-statements/edit.hbs
@@ -110,7 +110,7 @@
     @widgets={{this.widgets}}
     @nodeViews={{this.nodeViews}}
     @plugins={{this.plugins}}
-    @shouldEditRdfa={{true}}
+    @shouldEditRdfa={{false}}
   >
     <:toolbar>
       <Plugins::Formatting::FormattingToggle @controller={{this.controller}} />


### PR DESCRIPTION
### Overview

GN-4827: Remove RDFA Tools from RDFA Editor

Do not render

* `RdfaEditor`
* `AttributeEditor` 
* `DebugInfo`

They are not meant for GN users

##### connected issues and PRs:

https://binnenland.atlassian.net/browse/GN-4827

### Setup

1. Checkout

### How to test/reproduce

1. `ember s --proxy https://dev.gelinkt-notuleren.lblod.info`
2. Check that RDFA tools are not available in RB editor


### Checks PR readiness
- [X] UI: works on smaller screen sizes
- [X] UI: feedback for any loading/error states
- [X] Check cancel/go-back flows
- [X] Check database state correct when deleting/updating (especially regarding relationships)
- [X] changelog
- [X] npm lint
- [X] no new deprecations

