### PR TITLE
Re-add snippet placeholder nodespecs

### DIFF
--- a/.changeset/nine-wombats-stare.md
+++ b/.changeset/nine-wombats-stare.md
@@ -1,0 +1,5 @@
+---
+"frontend-gelinkt-notuleren": minor
+---
+
+Add support for snippet placeholder nodes in regulatory statements

--- a/app/controllers/regulatory-statements/edit.js
+++ b/app/controllers/regulatory-statements/edit.js
@@ -95,7 +95,8 @@ import {
   OCMW,
 } from '../../utils/bestuurseenheid-classificatie-codes';
 
-import SnippetInsertComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/snippet-plugin/snippet-insert';
+import SnippetInsertRdfaComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/snippet-plugin/snippet-insert-rdfa';
+
 export default class RegulatoryStatementsRoute extends Controller {
   @service documentService;
   @service store;
@@ -106,7 +107,7 @@ export default class RegulatoryStatementsRoute extends Controller {
   @service intl;
   editor;
   @tracked citationPlugin = citationPlugin(this.config.citation);
-  SnippetInsert = SnippetInsertComponent;
+  SnippetInsert = SnippetInsertRdfaComponent;
 
   schema = new Schema({
     nodes: {

--- a/app/controllers/regulatory-statements/edit.js
+++ b/app/controllers/regulatory-statements/edit.js
@@ -87,6 +87,10 @@ import {
   table_of_contents,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/table-of-contents-plugin/nodes';
 import { document_title } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/document-title-plugin/nodes';
+import {
+  snippetPlaceholder,
+  snippetPlaceholderView,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/nodes/snippet-placeholder';
 
 import generateExportFromEditorDocument from 'frontend-gelinkt-notuleren/utils/generate-export-from-editor-document';
 import ENV from 'frontend-gelinkt-notuleren/config/environment';
@@ -143,6 +147,7 @@ export default class RegulatoryStatementsRoute extends Controller {
       block_rdfa: blockRdfaWithConfig({ rdfaAware: true }),
       inline_rdfa: inlineRdfaWithConfig({ rdfaAware: true }),
       link: link(this.config.link),
+      snippet_placeholder: snippetPlaceholder,
     },
     marks: {
       em,
@@ -172,6 +177,7 @@ export default class RegulatoryStatementsRoute extends Controller {
         text_variable: textVariableView(controller),
         templateComment: templateCommentView(controller),
         inline_rdfa: inlineRdfaWithConfigView({ rdfaAware: true })(controller),
+        snippet_placeholder: snippetPlaceholderView(controller),
       };
     };
   }

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -43,6 +43,7 @@
 @import "template-comments-plugin";
 @import "confidentiality-plugin";
 @import "worship-plugin";
+@import "snippet-plugin";
 @import "project/p-annotations"; // @TODO: refactor in ember-rdfa-editor
 
 // give treatment (behandeling) content the same style as other say-documents


### PR DESCRIPTION
### Overview
These commits were in `futurenow` after #653 was merged, but are no longer there or in `master`.

As far as I can tell from examining the git history, these are the only commits that are missing.

##### connected issues and PRs:
#653 

### Setup
N/A

### How to test/reproduce
Snippet placeholders work correctly in Regulatory statements.

### Challenges/uncertainties
It wasn't clear what rebase erased these commits, so the analysis was manual. I suggest `git push --force-with-lease` for anyone push-forcing to avoid this in the future.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
