### PR TITLE
AuToggleSwitch must include the label as a block

### DIFF
--- a/.changeset/yellow-mirrors-clap.md
+++ b/.changeset/yellow-mirrors-clap.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Fixed switch labels

--- a/app/components/document-attachments.hbs
+++ b/app/components/document-attachments.hbs
@@ -60,13 +60,14 @@
               </td>
               <td>
                 <AuToggleSwitch
-                  @label={{t 'attachments.regulatory'}}
                   @checked={{eq attachment.type.id this.regulatoryTypeId}}
                   @onChange={{perform
                     this.updateAttachmentIsRegulatory
                     attachment
                   }}
-                />
+                >
+                  {{t 'attachments.regulatory'}}
+                </AuToggleSwitch>
               </td>
               <td class='au-u-text-right'>
                 <AuButton

--- a/app/components/signatures/notulen/behandelingen-list.hbs
+++ b/app/components/signatures/notulen/behandelingen-list.hbs
@@ -1,11 +1,9 @@
 <div
   class='au-o-box au-u-padding-top-small au-u-padding-bottom-small au-c-editor-preview-treatment-toggle-box'
 >
-  <AuToggleSwitch
-    @label={{t 'publish.toggle-all-public-label'}}
-    @checked={{@allBehandelingPublic}}
-    @onChange={{@toggleAll}}
-  />
+  <AuToggleSwitch @checked={{@allBehandelingPublic}} @onChange={{@toggleAll}}>
+    {{t 'publish.toggle-all-public-label'}}
+  </AuToggleSwitch>
 </div>
 {{#each @prepublishedBehandelingen as |preview|}}
   {{#let
@@ -43,12 +41,11 @@
           {{/if}}
         {{else}}
           <AuToggleSwitch
-            @label={{t
-              'meetings.publish.document.make-agendapoint-content-public'
-            }}
             @checked={{isPublicBehandeling}}
             @onChange={{fn @toggle preview}}
-          />
+          >
+            {{t 'meetings.publish.document.make-agendapoint-content-public'}}
+          </AuToggleSwitch>
           <AuHr />
           {{#if isPublicBehandeling}}
             <p><strong>{{t 'behandeling-list.public-now'}}</strong></p>


### PR DESCRIPTION
### Overview
The API of the AuToggleSwitch changed with the new version, so it broke

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-4834

### How to test/reproduce
Go to the document publication screen, you should see a label in all the switches


### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
