### PR TITLE
Wrong text block on Free text section

### DIFF
--- a/.changeset/slimy-lobsters-accept.md
+++ b/.changeset/slimy-lobsters-accept.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Remove wrongly placed text block in the free text section title

--- a/app/components/meeting-form.hbs
+++ b/app/components/meeting-form.hbs
@@ -216,7 +216,6 @@
             class='au-c-onboarding-wrapper au-u-margin-top-huge'
           >
             {{t 'meeting-form.fourth-section-title'}}
-            {{t 'voting-edit.first-step-explanation'}}
             <span class='au-c-onboarding'>
               <AuIcon @icon='info-circle' />
               {{t 'manage-free-text.before'}}


### PR DESCRIPTION
### Overview
There was a wrong text block in the free text section

##### connected issues and PRs:
None, self discovered bug


### How to test/reproduce
Go to the meeting screen, the free text section should only include the correct text

### Challenges/uncertainties
It would be good if someone with familiarity with the meeting screen goes through and tries to see if anything else has changed, if we got this text maybe something else has also gone wrong.
I ran prettier and it didn't change back.



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [x] npm lint
- [x] no new deprecations
