### PR TITLE
GN-4825: Correctly shows "Insert snippet" button

### DIFF
--- a/.changeset/giant-camels-glow.md
+++ b/.changeset/giant-camels-glow.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+GN-4825: Show "Insert snippet" when required

--- a/app/components/rdfa-editor-container.js
+++ b/app/components/rdfa-editor-container.js
@@ -15,6 +15,11 @@ import AttributeEditor from '@lblod/ember-rdfa-editor/components/_private/attrib
 import RdfaEditor from '@lblod/ember-rdfa-editor/components/_private/rdfa-editor';
 import DebugInfo from '@lblod/ember-rdfa-editor/components/_private/debug-info';
 
+/**
+ * `shouldShowRdfa` - boolean that indicates whether the editor should be in "RDFA aware" mode, or in old RDFA display mode.
+ *                    `true` - RDFA aware mode, `false | undefined` - old RDFA display mode
+ * `shouldEditRdfa` - boolean that indicates whether the "RDFA aware" debug tools will be available
+ */
 export default class RdfaEditorContainerComponent extends Component {
   @service features;
   @tracked controller;
@@ -48,7 +53,8 @@ export default class RdfaEditorContainerComponent extends Component {
         firefoxCursorFix(),
         lastKeyPressedPlugin,
         chromeHacksPlugin(),
-        this.args.shouldEditRdfa && editableNodePlugin(),
+        (this.args.shouldEditRdfa || this.args.shouldShowRdfa) &&
+          editableNodePlugin(),
       )
       .filter((nullCheck) => nullCheck);
   }
@@ -89,7 +95,10 @@ export default class RdfaEditorContainerComponent extends Component {
   }
 
   get activeNode() {
-    if (this.controller && this.args.shouldEditRdfa) {
+    if (
+      this.controller &&
+      (this.args.shouldEditRdfa || this.args.shouldShowRdfa)
+    ) {
       return getActiveEditableNode(this.controller.activeEditorState);
     }
     return null;


### PR DESCRIPTION
### Overview

"Insert snippet" plugin depends on "activeNode". "activeNode" is derived by `editableNodePlugin`. `editableNodePlugin` is not enabled when `shouldEditRdfa` is `false`. Fixed that.


### Setup

1. Checkout
2. `ember s --proxy https://gelinkt-notuleren.lblod.info` 
3. Mock login

### How to test/reproduce

https://github.com/lblod/frontend-gelinkt-notuleren/assets/769698/d8dbe1b1-72a3-4098-95e6-60e7c35502ab

### Checks PR readiness
- [X] UI: works on smaller screen sizes
- [X] UI: feedback for any loading/error states
- [X] Check cancel/go-back flows
- [X] Check database state correct when deleting/updating (especially regarding relationships)
- [X] changelog
- [X] npm lint
- [X] no new deprecations
