### PR TITLE
Fix rendering issue on agendapoint revisions page

### DIFF
--- a/.changeset/flat-apes-glow.md
+++ b/.changeset/flat-apes-glow.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Fix rendering of documents on revisions page

--- a/app/templates/agendapoints/revisions.hbs
+++ b/app/templates/agendapoints/revisions.hbs
@@ -81,7 +81,7 @@
             <div class='say-editor'>
               <div class='say-editor__paper'>
                 <div class='say-editor__inner say-content'>
-                  {{html-safe this.revisionDetail.htmlSafeContent}}
+                  {{this.revisionDetail.htmlSafeContent}}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
### Overview
This PR ensures that the revisions of an agendapoint are correctly rendered on the 'revisions' page.

##### connected issues and PRs:
None

### How to test/reproduce
- Start-up the application
- Open an agendapoint and visit the revisions page
- Ensure that the revisions are correctly rendered

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
