### PR TITLE
Ensure unsaved-changes dialog does not show up when saving intro/outro of a meeting

### DIFF
--- a/.changeset/fair-carpets-argue.md
+++ b/.changeset/fair-carpets-argue.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Ensure that exiting dialog does not show up when saving and exiting the intro/outro of a meeting

--- a/app/controllers/meetings/edit/intro.js
+++ b/app/controllers/meetings/edit/intro.js
@@ -23,6 +23,10 @@ export default class MeetingsEditIntroController extends Controller {
     this.editor = editor;
   }
 
+  clearEditor() {
+    this.editor = null;
+  }
+
   @action
   closeModal() {
     this.router.transitionTo('meetings.edit');
@@ -38,5 +42,6 @@ export default class MeetingsEditIntroController extends Controller {
     const zitting = this.model;
     zitting.intro = this.editor.htmlContent;
     await zitting.save();
+    this.clearEditor();
   });
 }

--- a/app/controllers/meetings/edit/outro.js
+++ b/app/controllers/meetings/edit/outro.js
@@ -22,6 +22,10 @@ export default class MeetingsEditOutroController extends Controller {
     this.editor = editor;
   }
 
+  clearEditor() {
+    this.editor = null;
+  }
+
   @action
   closeModal() {
     this.router.transitionTo('meetings.edit');
@@ -37,5 +41,6 @@ export default class MeetingsEditOutroController extends Controller {
     const zitting = this.model;
     zitting.outro = this.editor.htmlContent;
     await zitting.save();
+    this.clearEditor();
   });
 }


### PR DESCRIPTION
### Overview
This PR ensures that the unsaved-changes dialog does not show up when selecting the `save and exit` button while editing the intro/outro of a meeting.

##### connected issues and PRs:
None

### How to test/reproduce
- Start the application
- Open a meeting and edit the intro or outro
- Select the `save and exit` button
- Ensure that the unsaved-changes dialog no longer shows up

### Challenges/uncertainties
This PR includes some changes in the logic of the intro and outro pages. It ensures that the `dirty` property is equal to `false` after having saved the document by clearing the `editor` property. The `editor` property then gets reinstated when a new editor instance is created just after saving.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
