### PR TITLE
Fix link URL input selection

### DIFF
--- a/.changeset/real-spiders-dance.md
+++ b/.changeset/real-spiders-dance.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Fix bug where selection in link url text was not visible

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -768,18 +768,6 @@ div[typeof='besluitpublicatie:Documentonderdeel'] {
   }
 }
 
-.ProseMirror-selectednode {
-  div[typeof='besluitpublicatie:Documentonderdeel'] {
-    outline: 0;
-    box-shadow: 0 0 0 2px var(--au-blue-600);
-    border-radius: 4px;
-    overflow: hidden;
-  }
-  ::selection {
-    background-color: #0000;
-  }
-}
-
 #ember-basic-dropdown-wormhole {
   z-index: 20000;
 }


### PR DESCRIPTION
### Overview
Remove selection styling hacks that seem not relevant and broke links. This was introduced here: https://github.com/lblod/frontend-gelinkt-notuleren/pull/448 In order to tweak the styling of embedded regulatory statements in agenda points. Since it no longer seems possible to select these PM nodes, this styling never actually gets applied to these. The background color was however being applied to any selection, not just those in embedded regulatory statements, so was causing the input for the url of a link to have an invisible selection.

##### connected issues and PRs:
N/A

### Setup
N/A

### How to test/reproduce
Insert a link, add a URL, then select part of the URL to see that it is highlighted. It's also worth checking that embedded regulatory statements behave as before.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
