### PR TITLE
GN-4820: Bump editor and enable copy/pasting variable nodes correctly

### DIFF
--- a/.changeset/clever-pandas-suffer.md
+++ b/.changeset/clever-pandas-suffer.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+GN-4820: Bump editor and enable copy/pasting variable nodes correctly

--- a/app/components/rdfa-editor-container.js
+++ b/app/components/rdfa-editor-container.js
@@ -6,6 +6,7 @@ import applyDevTools from 'prosemirror-dev-tools';
 import { modifier } from 'ember-modifier';
 import { firefoxCursorFix } from '@lblod/ember-rdfa-editor/plugins/firefox-cursor-fix';
 import { lastKeyPressedPlugin } from '@lblod/ember-rdfa-editor/plugins/last-key-pressed';
+import recreateUuidsOnPaste from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/recreateUuidsOnPaste';
 import { chromeHacksPlugin } from '@lblod/ember-rdfa-editor/plugins/chrome-hacks-plugin';
 import {
   editableNodePlugin,
@@ -55,6 +56,7 @@ export default class RdfaEditorContainerComponent extends Component {
         chromeHacksPlugin(),
         (this.args.shouldEditRdfa || this.args.shouldShowRdfa) &&
           editableNodePlugin(),
+        recreateUuidsOnPaste,
       )
       .filter((nullCheck) => nullCheck);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@lblod/ember-acmidm-login": "^2.0.0-beta.1",
         "@lblod/ember-environment-banner": "^0.5.0",
         "@lblod/ember-mock-login": "0.7.0",
-        "@lblod/ember-rdfa-editor": "9.10.0",
+        "@lblod/ember-rdfa-editor": "9.12.0",
         "@lblod/ember-rdfa-editor-lblod-plugins": "19.3.0",
         "@release-it-plugins/lerna-changelog": "^6.0.0",
         "broccoli-asset-rev": "^3.0.0",
@@ -4935,9 +4935,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor": {
-      "version": "9.10.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-9.10.0.tgz",
-      "integrity": "sha512-XgL9ZCmBGswpwG0o/0RGmFKJo/JkiYBZezyI5iMNJikIUNIiZQt1837pb9WHFlJjwok0e65ObZn4FeJa0HKy6w==",
+      "version": "9.12.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-9.12.0.tgz",
+      "integrity": "sha512-dLIpf86CIDAoy0lvd56ZJqpWbTrzUAfcPaOrfa3qejZkm5+lSuhrv8rMgpR0ZglG2mg4lTxSgC2juqs9B5dG4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@lblod/ember-acmidm-login": "^2.0.0-beta.1",
     "@lblod/ember-environment-banner": "^0.5.0",
     "@lblod/ember-mock-login": "0.7.0",
-    "@lblod/ember-rdfa-editor": "9.10.0",
+    "@lblod/ember-rdfa-editor": "9.12.0",
     "@lblod/ember-rdfa-editor-lblod-plugins": "19.3.0",
     "@release-it-plugins/lerna-changelog": "^6.0.0",
     "broccoli-asset-rev": "^3.0.0",


### PR DESCRIPTION
### Overview

GN-4820: Bump editor and enable copy/pasting variable nodes correctly

##### connected issues and PRs:

* https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/435
* https://github.com/lblod/ember-rdfa-editor/pull/1195


### Setup

1. Checkout
2. `npm i` 

### How to test/reproduce

See if copy/pasting variable works


https://github.com/lblod/frontend-gelinkt-notuleren/assets/769698/e965b1f5-7bca-4700-b084-9919dd92cd43


### Checks PR readiness
- [X] UI: works on smaller screen sizes
- [X] UI: feedback for any loading/error states
- [X] Check cancel/go-back flows
- [X] Check database state correct when deleting/updating (especially regarding relationships)
- [X] changelog
- [X] npm lint
- [X] no new deprecations
