### PR TITLE
Fixed document service not targeting the correct predicates

### DIFF
--- a/.changeset/twelve-snakes-joke.md
+++ b/.changeset/twelve-snakes-joke.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Fixed copy agendapunt description button

--- a/app/services/document-service.js
+++ b/app/services/document-service.js
@@ -20,7 +20,7 @@ export default class DocumentService extends Service {
     const triples = this.extractTriplesFromDocument(editorDocument);
     const decisionUris = triples.filter(
       (t) =>
-        t.predicate === 'a' &&
+        t.predicate === 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type' &&
         t.object === 'http://data.vlaanderen.be/ns/besluit#Besluit',
     );
     const firstDecision = decisionUris[0];
@@ -51,7 +51,7 @@ export default class DocumentService extends Service {
     const triples = this.extractTriplesFromDocument(editorDocument);
     const decisionUris = triples.filter(
       (t) =>
-        t.predicate === 'a' &&
+        t.predicate === 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type' &&
         t.object === 'http://data.vlaanderen.be/ns/besluit#Besluit',
     );
     const decisions = decisionUris.map((decisionUriTriple) => {
@@ -74,7 +74,7 @@ export default class DocumentService extends Service {
     const documentpartUris = triples
       .filter(
         (t) =>
-          t.predicate === 'a' &&
+          t.predicate === 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type' &&
           t.object ===
             'https://data.vlaanderen.be/doc/applicatieprofiel/besluit-publicatie#Documentonderdeel',
       )


### PR DESCRIPTION
### Overview
With the change of the editor, we stopped using relative uris like `a` and started using `'http://www.w3.org/1999/02/22-rdf-syntax-ns#type'` instead. We already make this fix on the plugins repo but failed to do here. We might need to do it somewhere else but don't know where so if someone knows another place is targeting relative uris let me know.

##### connected issues and PRs:
GN-4864

### Setup
None

### How to test/reproduce
Create an agendapoint, write a description on it, then go to a meeting and try to add the agendapoint and copy its description. It should be copied correctly while previously it was not

### Challenges/uncertainties
As I said we could be missing the same fix on other places 



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
