### PR TITLE
GN-4853: Search and sort templates alphabetically

### DIFF
--- a/.changeset/shaggy-pugs-shave.md
+++ b/.changeset/shaggy-pugs-shave.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+GN-4853: Seach and sort templates alphabetically

--- a/app/components/document-creator/form.hbs
+++ b/app/components/document-creator/form.hbs
@@ -27,6 +27,8 @@
         @options={{@options}}
         @selected={{@selectedTemplate}}
         @onChange={{@onSelectTemplate}}
+        @searchEnabled={{true}}
+        @searchField='title'
         as |option|
       >
         {{option.title}}

--- a/app/services/regulatory-attachments-fetcher.js
+++ b/app/services/regulatory-attachments-fetcher.js
@@ -32,6 +32,7 @@ export default class RegulatoryAttachmentsFetcher extends Service {
         }
         FILTER( ! BOUND(?validThrough) || ?validThrough > NOW())
       }
+      ORDER BY LCASE(REPLACE(STR(?title), '^ +| +$', ''))
     `;
     const details = {
       query: sparqlQuery,


### PR DESCRIPTION
### Overview

1. Allows to search for template in the dropdown when creating new regulatory statement
2. Sorts templates by title when fetching them from backend

##### connected issues and PRs:

https://binnenland.atlassian.net/browse/GN-4853

### Setup

1. Checkout
3. `ember s --proxy https://dev.gelinkt-notuleren.lblod.info` 
4. Go to http://localhost:4200/inbox/regulatory-statements/new

### How to test/reproduce

https://github.com/lblod/frontend-gelinkt-notuleren/assets/769698/88fc987f-8e73-4c76-8230-82f853a2672f


### Checks PR readiness
- [X] UI: works on smaller screen sizes
- [X] UI: feedback for any loading/error states
- [X] Check cancel/go-back flows
- [X] Check database state correct when deleting/updating (especially regarding relationships)
- [X] changelog
- [X] npm lint
- [X] no new deprecations
