### PR TITLE
GN-4958: add `snippet` node and nodeview to regulatory-statement editor config

### DIFF
--- a/.changeset/great-actors-peel.md
+++ b/.changeset/great-actors-peel.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Ensure snippets can be correctly inserted on the regulatory statement editor page

--- a/app/controllers/regulatory-statements/edit.js
+++ b/app/controllers/regulatory-statements/edit.js
@@ -93,7 +93,10 @@ import {
   snippetPlaceholder,
   snippetPlaceholderView,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/nodes/snippet-placeholder';
-
+import {
+  snippet,
+  snippetView,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/nodes/snippet';
 import generateExportFromEditorDocument from 'frontend-gelinkt-notuleren/utils/generate-export-from-editor-document';
 import ENV from 'frontend-gelinkt-notuleren/config/environment';
 import {
@@ -141,6 +144,8 @@ export default class RegulatoryStatementsRoute extends Controller {
       ...STRUCTURE_NODES,
       heading: headingWithConfig({ rdfaAware: true }),
       blockquote,
+      snippet_placeholder: snippetPlaceholder,
+      snippet: snippet(this.config.snippet),
       horizontal_rule,
       code_block,
       text,
@@ -149,7 +154,6 @@ export default class RegulatoryStatementsRoute extends Controller {
       block_rdfa: blockRdfaWithConfig({ rdfaAware: true }),
       inline_rdfa: inlineRdfaWithConfig({ rdfaAware: true }),
       link: link(this.config.link),
-      snippet_placeholder: snippetPlaceholder,
     },
     marks: {
       em,
@@ -180,6 +184,7 @@ export default class RegulatoryStatementsRoute extends Controller {
         templateComment: templateCommentView(controller),
         inline_rdfa: inlineRdfaWithConfigView({ rdfaAware: true })(controller),
         snippet_placeholder: snippetPlaceholderView(controller),
+        snippet: snippetView(this.config.snippet)(controller),
       };
     };
   }


### PR DESCRIPTION
### Overview
This PR ensures that the `snippet` node-spec and nodeview are correctly added to the regulatory-statement editor configuration.

##### connected issues and PRs:
[GN-4958](https://binnenland.atlassian.net/browse/GN-4958)

### How to test/reproduce
- Open the application
- Create a regulatory statement based on a template which contains snippet placeholders
- You should be able to use the snippet placeholder to insert a snippet without issues

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
