### PR TITLE
GN-4953: fix issue with meeting absentees not shown

### DIFF
--- a/.changeset/gorgeous-dragons-bathe.md
+++ b/.changeset/gorgeous-dragons-bathe.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Fix meeting absentees not shown

--- a/app/components/participation-list.js
+++ b/app/components/participation-list.js
@@ -127,7 +127,7 @@ export default class ParticipationListComponent extends Component {
         label: this.intl.t('participation-list.not-present-label'),
         value:
           this.absentees
-            ?.map((m) => m.isBestuurlijkeAliasVan.fullName)
+            ?.map((m) => m.get('isBestuurlijkeAliasVan.fullName'))
             .join(', ') || '',
       },
     ];


### PR DESCRIPTION
### Overview
This PR fixes an issue in the `participation-list` component which displays the attendance of the different mandatees in a meeting. It corrects the approach in how absentees are fetched/retrieved.

##### connected issues and PRs:
[GN-4953](https://binnenland.atlassian.net/browse/GN-4953)

### How to test/reproduce
- Open the app
- Open a meeting
- Modify the attendance of a meeting (and add some absentees)
- The absentees should show up correctly

### Challenges/uncertainties
When relationships of a model are correctly loaded in the ember-data store, you can not retrieve these using javascript '.' getters. You can either use the `.get('...')` or `.belongsTo('...')` methods.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
