### PR TITLE
GN-4954: fix links in meeting sidebar

### DIFF
--- a/.changeset/tiny-islands-call.md
+++ b/.changeset/tiny-islands-call.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Fix links in meeting sidebar

--- a/app/components/common/meeting-section.hbs
+++ b/app/components/common/meeting-section.hbs
@@ -1,4 +1,4 @@
-<div class='au-c-meeting-section'>
+<div class='au-c-meeting-section' ...attributes>
   <AuHeading
     @level='2'
     @skin='3'

--- a/app/components/meeting-form.hbs
+++ b/app/components/meeting-form.hbs
@@ -146,6 +146,7 @@
       <Common::MeetingSection
         @title={{t 'meeting-form.first-section-title'}}
         @helpText={{t 'meeting-form.first-section-not-filled-warning'}}
+        id="sectionOne"
       >
         <Zitting::ManageZittingsdata
           @zitting={{@zitting}}
@@ -167,6 +168,7 @@
           <Common::MeetingSection
             @title={{t 'meeting-form.second-section-title'}}
             @helpText={{t 'meeting-form.second-section-not-filled-warning'}}
+            id="sectionTwo"
           >
             <ParticipationList
               @chairman={{this.voorzitter}}
@@ -187,6 +189,7 @@
           <Common::MeetingSection
             @title={{t 'meeting-form.third-section-title'}}
             @helpText={{t 'meeting-form.third-section-not-filled-warning'}}
+            id="sectionThree"
           >
             <AgendaManager
               @zittingId={{@zitting.id}}
@@ -199,6 +202,7 @@
           <Common::MeetingSection
             @title={{t 'meeting-form.fourth-section-title'}}
             @helpText={{t 'manage-free-text.before'}}
+            id="sectionFour"
           >
             <Common::MeetingSubSection
               @title={{t 'behandeling-van-agendapunten.content-title'}}
@@ -228,6 +232,7 @@
           <Common::MeetingSection
             @title={{t 'meeting-form.fifth-section-title'}}
             @helpText={{t 'meeting-form.fifth-section-not-filled-warning'}}
+            id="sectionFive"
           >
             {{#if this.fetchTreatments.isRunning}}
               <AuLoader @padding='small' />
@@ -254,6 +259,7 @@
         <Common::MeetingSection
           @title={{t 'meeting-form.sixth-section-title'}}
           @helpText={{t 'manage-free-text.after'}}
+          id="sectionSix"
         >
           <Common::MeetingSubSection
             @title={{t 'behandeling-van-agendapunten.content-title'}}

--- a/app/components/meeting-form.hbs
+++ b/app/components/meeting-form.hbs
@@ -146,7 +146,7 @@
       <Common::MeetingSection
         @title={{t 'meeting-form.first-section-title'}}
         @helpText={{t 'meeting-form.first-section-not-filled-warning'}}
-        id="sectionOne"
+        id='sectionOne'
       >
         <Zitting::ManageZittingsdata
           @zitting={{@zitting}}
@@ -168,7 +168,7 @@
           <Common::MeetingSection
             @title={{t 'meeting-form.second-section-title'}}
             @helpText={{t 'meeting-form.second-section-not-filled-warning'}}
-            id="sectionTwo"
+            id='sectionTwo'
           >
             <ParticipationList
               @chairman={{this.voorzitter}}
@@ -189,7 +189,7 @@
           <Common::MeetingSection
             @title={{t 'meeting-form.third-section-title'}}
             @helpText={{t 'meeting-form.third-section-not-filled-warning'}}
-            id="sectionThree"
+            id='sectionThree'
           >
             <AgendaManager
               @zittingId={{@zitting.id}}
@@ -202,7 +202,7 @@
           <Common::MeetingSection
             @title={{t 'meeting-form.fourth-section-title'}}
             @helpText={{t 'manage-free-text.before'}}
-            id="sectionFour"
+            id='sectionFour'
           >
             <Common::MeetingSubSection
               @title={{t 'behandeling-van-agendapunten.content-title'}}
@@ -232,7 +232,7 @@
           <Common::MeetingSection
             @title={{t 'meeting-form.fifth-section-title'}}
             @helpText={{t 'meeting-form.fifth-section-not-filled-warning'}}
-            id="sectionFive"
+            id='sectionFive'
           >
             {{#if this.fetchTreatments.isRunning}}
               <AuLoader @padding='small' />
@@ -259,7 +259,7 @@
         <Common::MeetingSection
           @title={{t 'meeting-form.sixth-section-title'}}
           @helpText={{t 'manage-free-text.after'}}
-          id="sectionSix"
+          id='sectionSix'
         >
           <Common::MeetingSubSection
             @title={{t 'behandeling-van-agendapunten.content-title'}}


### PR DESCRIPTION
### Overview
This PR re-adds the corrects ids to the different meeting section to ensure the sidebar links work as expected.

##### connected issues and PRs:
[GN-4954](https://binnenland.atlassian.net/browse/GN-4954)


### How to test/reproduce
- Open a meeting
- The different links included in the left sidebar should navigate you to the correct section

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
