### PR TITLE
GN-4962: remove seperate edit button for agenda items

### DIFF
--- a/.changeset/spotty-paws-fail.md
+++ b/.changeset/spotty-paws-fail.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': minor
+---
+
+Remove seperate edit button for agenda items and make agenda item titles clickable

--- a/app/components/agenda-manager/agenda-table/row.hbs
+++ b/app/components/agenda-manager/agenda-table/row.hbs
@@ -32,7 +32,13 @@
       />
     </td>
     <td>
-      <p>{{limit-content @item.titel 40}}</p>
+      <AuButton
+        @skin='link'
+        {{on 'click' @edit}}
+        title={{t 'manage-agenda-zitting-modal.edit-item-message'}}
+      >
+        {{limit-content @item.titel 40}}
+      </AuButton>
     </td>
     <td>
       {{if
@@ -40,16 +46,6 @@
         (t 'manage-agenda-zitting-modal.gepland-openbaar-true-label')
         (t 'manage-agenda-zitting-modal.gepland-openbaar-false-label')
       }}
-    </td>
-    <td class='au-u-table-right'>
-      <AuButton
-        @skin='link'
-        @icon='pencil'
-        @iconAlignment='left'
-        {{on 'click' @edit}}
-      >
-        {{t 'manage-agenda-zitting-modal.edit-item-button'}}
-      </AuButton>
     </td>
   </DraggableObject>
 {{/if}}

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -279,7 +279,7 @@ manage-agenda-zitting-modal:
   gepland-openbaar: Planned visibility
   actions-label: Actions
   create-item-button: Add agenda item
-  edit-item-button: Edit agenda item
+  edit-item-message: Edit agenda item
   ap-published-msg: Agenda point is published
   no-data-message: No agenda items found.
   gepland-openbaar-true-label: Public

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -280,7 +280,7 @@ manage-agenda-zitting-modal:
   gepland-openbaar: Geplande openbaarheid
   actions-label: Acties
   create-item-button: Voeg agendapunt toe
-  edit-item-button: Bewerk agendapunt
+  edit-item-message: Bewerk agendapunt
   ap-published-msg: Agendapunt gepubliceerd
   no-data-message: Geen agendapunten gevonden.
   gepland-openbaar-true-label: Openbaar


### PR DESCRIPTION
### Overview
This PR adjusts the meeting design/UX in two ways:
- Removal of the edit button next to agenda items
- Make the title of agenda items clickable

##### connected issues and PRs:
[GN-4962](https://binnenland.atlassian.net/browse/GN-4962?atlOrigin=eyJpIjoiZDUwNjYwN2ZjY2M2NDUwODg4YTFiNjUxMGQ0MjE5NTciLCJwIjoiaiJ9)

### How to test/reproduce
- Start the app
- Open a meeting
- Notice that the edit button next to agenda items is gone
- If you click on the title of an agenda item, it should open the edit modal.



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
