### PR TITLE
GN-4977: add meeting details modal to inauguration meeting creation flow

### DIFF
--- a/.changeset/popular-pugs-eat.md
+++ b/.changeset/popular-pugs-eat.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': minor
+---
+
+Add meeting details modal to inauguration-meeting creation flow

--- a/app/controllers/inbox/meetings.js
+++ b/app/controllers/inbox/meetings.js
@@ -1,7 +1,6 @@
 import { service } from '@ember/service';
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
-import { action } from '@ember/object';
 import InstallatieVergaderingModel from 'frontend-gelinkt-notuleren/models/installatievergadering';
 export default class InboxMeetingsController extends Controller {
   @service store;
@@ -20,56 +19,4 @@ export default class InboxMeetingsController extends Controller {
   isInaugurationMeeting = (meeting) => {
     return meeting instanceof InstallatieVergaderingModel;
   };
-
-  @action
-  async createInaugurationMeeting() {
-    let now = new Date();
-    const bestuursorgaan = (
-      await this.store.query('bestuursorgaan', {
-        include: [
-          'is-tijdsspecialisatie-van.bestuurseenheid',
-          'is-tijdsspecialisatie-van.classificatie',
-        ].join(','),
-        filter: {
-          'is-tijdsspecialisatie-van': {
-            bestuurseenheid: {
-              id: this.currentSession.group.id,
-            },
-            classificatie: {
-              ':uri:':
-                'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000005',
-            },
-          },
-        },
-      })
-    )[0];
-    const inaugurationmeeting = this.store.createRecord(
-      'installatievergadering',
-      {
-        geplandeStart: now,
-        gestartOpTijdstip: now,
-        bestuursorgaan,
-      },
-    );
-    await inaugurationmeeting.save();
-    const promises = [];
-    let previousAgendapoint;
-    for (let i = 0; i < 9; i++) {
-      const agendapoint = this.store.createRecord('agendapunt', {
-        position: i,
-        geplandOpenbaar: true,
-        titel: `Naam Agendapunt ${i}`,
-        zitting: inaugurationmeeting,
-        vorigeAgendapunt: previousAgendapoint,
-      });
-      const treatment = this.store.createRecord('behandeling-van-agendapunt', {
-        openbaar: true,
-        onderwerp: agendapoint,
-      });
-      promises.push(agendapoint.save(), treatment.saveAndPersistDocument());
-      previousAgendapoint = agendapoint;
-    }
-    await Promise.all(promises);
-    this.router.replaceWith('meetings.edit', inaugurationmeeting.id);
-  }
 }

--- a/app/controllers/inbox/meetings/new.js
+++ b/app/controllers/inbox/meetings/new.js
@@ -3,7 +3,6 @@ import { action } from '@ember/object';
 import { dropTask } from 'ember-concurrency';
 import { service } from '@ember/service';
 import InstallatieVergaderingModel from '../../../models/installatievergadering';
-import { trackedFunction } from 'ember-resources/util/function';
 
 export default class InboxMeetingsNewController extends Controller {
   @service router;

--- a/app/controllers/inbox/meetings/new.js
+++ b/app/controllers/inbox/meetings/new.js
@@ -2,10 +2,15 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { dropTask } from 'ember-concurrency';
 import { service } from '@ember/service';
+import InstallatieVergaderingModel from '../../../models/installatievergadering';
+import { trackedFunction } from 'ember-resources/util/function';
 
 export default class InboxMeetingsNewController extends Controller {
   @service router;
+  @service store;
   @service intl;
+
+  queryParams = ['type'];
 
   get meeting() {
     return this.model;
@@ -17,6 +22,18 @@ export default class InboxMeetingsNewController extends Controller {
   @action
   handleUpdateMeetingOpLocatie(event) {
     this.meeting.opLocatie = event.target.value;
+  }
+
+  get isInaugurationMeeting() {
+    return this.meeting instanceof InstallatieVergaderingModel;
+  }
+
+  get title() {
+    if (this.isInaugurationMeeting) {
+      return this.intl.t('inbox.meetings.new.inauguration-meeting.title');
+    } else {
+      return this.intl.t('inbox.meetings.new.common-meeting.title');
+    }
   }
 
   saveMeetingTask = dropTask(async (event) => {
@@ -31,13 +48,36 @@ export default class InboxMeetingsNewController extends Controller {
         ),
       );
     }
-
     if (this.meeting.isValid) {
       this.meeting.gestartOpTijdstip = this.meeting.geplandeStart;
       await this.meeting.save();
+      if (this.isInaugurationMeeting) {
+        await this.setUpInaugurationMeeting();
+      }
       this.router.replaceWith('meetings.edit', this.meeting.id);
     }
   });
+
+  async setUpInaugurationMeeting() {
+    const promises = [];
+    let previousAgendapoint;
+    for (let i = 0; i < 9; i++) {
+      const agendapoint = this.store.createRecord('agendapunt', {
+        position: i,
+        geplandOpenbaar: true,
+        titel: `Naam Agendapunt ${i}`,
+        zitting: this.meeting,
+        vorigeAgendapunt: previousAgendapoint,
+      });
+      const treatment = this.store.createRecord('behandeling-van-agendapunt', {
+        openbaar: true,
+        onderwerp: agendapoint,
+      });
+      promises.push(agendapoint.save(), treatment.saveAndPersistDocument());
+      previousAgendapoint = agendapoint;
+    }
+    await Promise.all(promises);
+  }
 
   @action
   updateAdministrativeBody(administrativeBody) {

--- a/app/routes/inbox/meetings/new.js
+++ b/app/routes/inbox/meetings/new.js
@@ -20,7 +20,6 @@ export default class InboxMeetingsNewRoute extends Route {
   }
 
   model(params) {
-    console.log(params);
     const type = params.type;
     switch (type) {
       case 'common':

--- a/app/routes/inbox/meetings/new.js
+++ b/app/routes/inbox/meetings/new.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
+import { format } from 'date-fns/fp';
 
 export default class InboxMeetingsNewRoute extends Route {
   @service currentSession;
@@ -46,6 +47,10 @@ export default class InboxMeetingsNewRoute extends Route {
           'is-tijdsspecialisatie-van.classificatie',
         ].join(','),
         filter: {
+          ':or:': {
+            ':gte:binding-einde': format('yyyy-mm-dd')(now),
+            ':has-no:binding-einde': true,
+          },
           'is-tijdsspecialisatie-van': {
             bestuurseenheid: {
               id: this.currentSession.group.id,

--- a/app/routes/inbox/meetings/new.js
+++ b/app/routes/inbox/meetings/new.js
@@ -6,17 +6,62 @@ export default class InboxMeetingsNewRoute extends Route {
   @service router;
   @service store;
 
+  queryParams = {
+    type: {
+      refreshModel: true,
+    },
+  };
+
   beforeModel() {
     if (!this.currentSession.canWrite) {
       this.router.replaceWith('inbox.meetings');
     }
   }
 
-  model() {
+  model(params) {
+    console.log(params);
+    const type = params.type;
+    switch (type) {
+      case 'common':
+        return this.createCommonMeeting();
+      case 'inauguration-meeting':
+        return this.createInaugurationMeeting();
+    }
+  }
+
+  async createCommonMeeting() {
     let now = new Date();
     return this.store.createRecord('zitting', {
       geplandeStart: now,
       gestartOpTijdstip: now,
+    });
+  }
+
+  async createInaugurationMeeting() {
+    let now = new Date();
+    const bestuursorgaan = (
+      await this.store.query('bestuursorgaan', {
+        include: [
+          'is-tijdsspecialisatie-van.bestuurseenheid',
+          'is-tijdsspecialisatie-van.classificatie',
+        ].join(','),
+        filter: {
+          'is-tijdsspecialisatie-van': {
+            bestuurseenheid: {
+              id: this.currentSession.group.id,
+            },
+            classificatie: {
+              ':uri:':
+                'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000005',
+            },
+          },
+        },
+      })
+    )[0];
+    return this.store.createRecord('installatievergadering', {
+      geplandeStart: now,
+      gestartOpTijdstip: now,
+      bestuursorgaan,
     });
   }
 }

--- a/app/templates/inbox/meetings.hbs
+++ b/app/templates/inbox/meetings.hbs
@@ -25,16 +25,20 @@
               @icon='chevron-down'
               role='menu'
             >
-              <AuLink @route='inbox.meetings.new' role='menuitem'>
+              <AuLink
+                @route='inbox.meetings.new'
+                @query={{hash type='common'}}
+                role='menuitem'
+              >
                 {{t 'inbox.meetings.new.common-meeting.title'}}
               </AuLink>
-              <AuButton
-                @skin='link'
-                {{on 'click' this.createInaugurationMeeting}}
+              <AuLink
+                @route='inbox.meetings.new'
+                @query={{hash type='inauguration-meeting'}}
                 role='menuitem'
               >
                 {{t 'inbox.meetings.new.inauguration-meeting.title'}}
-              </AuButton>
+              </AuLink>
             </AuDropdown>
           {{/unless}}
         </Group>

--- a/app/templates/inbox/meetings/new.hbs
+++ b/app/templates/inbox/meetings/new.hbs
@@ -1,7 +1,7 @@
-{{page-title (t 'inbox.meetings.new.common-meeting.title')}}
+{{page-title this.title}}
 
 <AuModal
-  @title={{t 'inbox.meetings.new.common-meeting.title'}}
+  @title={{this.title}}
   @modalOpen={{true}}
   @closeModal={{this.cancelMeetingCreation}}
   as |Modal|
@@ -13,23 +13,43 @@
       {{on 'submit' (perform this.saveMeetingTask)}}
     >
       <div>
-        {{#let (unique-id) this.meeting.errors.bestuursorgaan as |id errors|}}
-          <AuLabel @error={{if errors true false}} for={{id}}>
+        {{#if this.isInaugurationMeeting}}
+          <p class='au-c-label'>
             {{t 'inbox.meetings.new.common-meeting.administrative-body'}}
-            <RequiredField />
-          </AuLabel>
-          <AdministrativeBodySelect
-            @id={{id}}
-            @selected={{this.meeting.bestuursorgaan}}
-            @onChange={{this.updateAdministrativeBody}}
-            @error={{if errors true false}}
-          />
-          {{#each errors as |error|}}
-            <AuHelpText @error={{true}}>
-              {{error.message}}
-            </AuHelpText>
-          {{/each}}
-        {{/let}}
+          </p>
+          <p>
+            {{#let this.meeting.bestuursorgaan as |bestuursorgaan|}}
+              {{bestuursorgaan.isTijdsspecialisatieVan.naam}}
+              ({{t 'administrative-body-select.period'}}:
+              {{plain-date bestuursorgaan.bindingStart}}
+              -
+              {{#if bestuursorgaan.bindingEinde}}
+                {{plain-date bestuursorgaan.bindingEinde}}
+              {{else}}
+                {{t 'administrative-body-select.not-applicable'}}
+              {{/if}})
+            {{/let}}
+          </p>
+        {{else}}
+          {{#let (unique-id) this.meeting.errors.bestuursorgaan as |id errors|}}
+            <AuLabel @error={{if errors true false}} for={{id}}>
+              {{t 'inbox.meetings.new.common-meeting.administrative-body'}}
+              <RequiredField />
+            </AuLabel>
+            <AdministrativeBodySelect
+              @id={{id}}
+              @selected={{this.meeting.bestuursorgaan}}
+              @onChange={{this.updateAdministrativeBody}}
+              @error={{if errors true false}}
+            />
+            {{#each errors as |error|}}
+              <AuHelpText @error={{true}}>
+                {{error.message}}
+              </AuHelpText>
+            {{/each}}
+          {{/let}}
+        {{/if}}
+
       </div>
       <div>
         {{#let (unique-id) as |id|}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "buffer": "^6.0.3",
         "changesets-release-it-plugin": "^0.1.2",
         "concurrently": "^8.0.1",
-        "date-fns": "^2.28.0",
+        "date-fns": "^2.30.0",
         "ember-a11y-refocus": "^3.0.0",
         "ember-auto-import": "^2.6.3",
         "ember-browser-update": "^0.1.0",
@@ -31182,29 +31182,24 @@
     },
     "node_modules/npm/node_modules/@colors/colors": {
       "version": "1.5.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.1.90"
       }
     },
     "node_modules/npm/node_modules/@gar/promisify": {
       "version": "1.1.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/@isaacs/string-locale-compare": {
       "version": "1.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
       "version": "5.6.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -31255,7 +31250,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/ci-detect": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -31264,7 +31258,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/config": {
       "version": "4.2.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -31283,7 +31276,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/disparity-colors": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -31295,7 +31287,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/fs": {
       "version": "2.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -31308,7 +31299,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/git": {
       "version": "3.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -31328,7 +31318,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
       "version": "1.0.7",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -31344,7 +31333,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/installed-package-contents/node_modules/npm-bundled": {
       "version": "1.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -31353,7 +31341,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/map-workspaces": {
       "version": "2.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -31368,7 +31355,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
       "version": "3.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -31383,7 +31369,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/move-file": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -31396,13 +31381,11 @@
     },
     "node_modules/npm/node_modules/@npmcli/name-from-folder": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/node-gyp": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -31411,7 +31394,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/package-json": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -31423,7 +31405,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/promise-spawn": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -31435,7 +31416,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/query": {
       "version": "1.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -31449,7 +31429,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/run-script": {
       "version": "4.2.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -31465,7 +31444,6 @@
     },
     "node_modules/npm/node_modules/@tootallnate/once": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -31474,13 +31452,11 @@
     },
     "node_modules/npm/node_modules/abbrev": {
       "version": "1.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/agent-base": {
       "version": "6.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -31492,7 +31468,6 @@
     },
     "node_modules/npm/node_modules/agentkeepalive": {
       "version": "4.2.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -31506,7 +31481,6 @@
     },
     "node_modules/npm/node_modules/aggregate-error": {
       "version": "3.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -31519,7 +31493,6 @@
     },
     "node_modules/npm/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -31528,7 +31501,6 @@
     },
     "node_modules/npm/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -31543,19 +31515,16 @@
     },
     "node_modules/npm/node_modules/aproba": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/archy": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/are-we-there-yet": {
       "version": "3.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -31568,19 +31537,16 @@
     },
     "node_modules/npm/node_modules/asap": {
       "version": "2.0.6",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/balanced-match": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/bin-links": {
       "version": "3.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -31597,7 +31563,6 @@
     },
     "node_modules/npm/node_modules/bin-links/node_modules/npm-normalize-package-bin": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -31606,7 +31571,6 @@
     },
     "node_modules/npm/node_modules/binary-extensions": {
       "version": "2.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -31615,7 +31579,6 @@
     },
     "node_modules/npm/node_modules/brace-expansion": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -31624,7 +31587,6 @@
     },
     "node_modules/npm/node_modules/builtins": {
       "version": "5.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -31633,7 +31595,6 @@
     },
     "node_modules/npm/node_modules/cacache": {
       "version": "16.1.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -31662,7 +31623,6 @@
     },
     "node_modules/npm/node_modules/chalk": {
       "version": "4.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -31678,7 +31638,6 @@
     },
     "node_modules/npm/node_modules/chownr": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -31687,7 +31646,6 @@
     },
     "node_modules/npm/node_modules/cidr-regex": {
       "version": "3.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -31699,7 +31657,6 @@
     },
     "node_modules/npm/node_modules/clean-stack": {
       "version": "2.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -31708,7 +31665,6 @@
     },
     "node_modules/npm/node_modules/cli-columns": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -31721,7 +31677,6 @@
     },
     "node_modules/npm/node_modules/cli-table3": {
       "version": "0.6.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -31736,7 +31691,6 @@
     },
     "node_modules/npm/node_modules/clone": {
       "version": "1.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -31745,7 +31699,6 @@
     },
     "node_modules/npm/node_modules/cmd-shim": {
       "version": "5.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -31757,7 +31710,6 @@
     },
     "node_modules/npm/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -31769,13 +31721,11 @@
     },
     "node_modules/npm/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/color-support": {
       "version": "1.1.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -31784,7 +31734,6 @@
     },
     "node_modules/npm/node_modules/columnify": {
       "version": "1.6.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -31797,25 +31746,21 @@
     },
     "node_modules/npm/node_modules/common-ancestor-path": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/concat-map": {
       "version": "0.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/console-control-strings": {
       "version": "1.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/cssesc": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -31827,7 +31772,6 @@
     },
     "node_modules/npm/node_modules/debug": {
       "version": "4.3.4",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -31844,13 +31788,11 @@
     },
     "node_modules/npm/node_modules/debug/node_modules/ms": {
       "version": "2.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/debuglog": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -31859,7 +31801,6 @@
     },
     "node_modules/npm/node_modules/defaults": {
       "version": "1.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -31868,13 +31809,11 @@
     },
     "node_modules/npm/node_modules/delegates": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/depd": {
       "version": "1.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -31883,7 +31822,6 @@
     },
     "node_modules/npm/node_modules/dezalgo": {
       "version": "1.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -31893,7 +31831,6 @@
     },
     "node_modules/npm/node_modules/diff": {
       "version": "5.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -31902,23 +31839,19 @@
     },
     "node_modules/npm/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/encoding": {
       "version": "0.1.13",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
       }
     },
     "node_modules/npm/node_modules/env-paths": {
       "version": "2.2.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -31927,19 +31860,16 @@
     },
     "node_modules/npm/node_modules/err-code": {
       "version": "2.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/fastest-levenshtein": {
       "version": "1.0.12",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/fs-minipass": {
       "version": "2.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -31951,19 +31881,16 @@
     },
     "node_modules/npm/node_modules/fs.realpath": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/function-bind": {
       "version": "1.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/gauge": {
       "version": "4.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -31982,7 +31909,6 @@
     },
     "node_modules/npm/node_modules/glob": {
       "version": "8.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -32001,13 +31927,11 @@
     },
     "node_modules/npm/node_modules/graceful-fs": {
       "version": "4.2.10",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/has": {
       "version": "1.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -32019,7 +31943,6 @@
     },
     "node_modules/npm/node_modules/has-flag": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -32028,13 +31951,11 @@
     },
     "node_modules/npm/node_modules/has-unicode": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/hosted-git-info": {
       "version": "5.2.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -32046,13 +31967,11 @@
     },
     "node_modules/npm/node_modules/http-cache-semantics": {
       "version": "4.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/npm/node_modules/http-proxy-agent": {
       "version": "5.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -32066,7 +31985,6 @@
     },
     "node_modules/npm/node_modules/https-proxy-agent": {
       "version": "5.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -32079,7 +31997,6 @@
     },
     "node_modules/npm/node_modules/humanize-ms": {
       "version": "1.2.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -32088,10 +32005,8 @@
     },
     "node_modules/npm/node_modules/iconv-lite": {
       "version": "0.6.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -32101,7 +32016,6 @@
     },
     "node_modules/npm/node_modules/ignore-walk": {
       "version": "5.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -32113,7 +32027,6 @@
     },
     "node_modules/npm/node_modules/imurmurhash": {
       "version": "0.1.4",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -32122,7 +32035,6 @@
     },
     "node_modules/npm/node_modules/indent-string": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -32131,13 +32043,11 @@
     },
     "node_modules/npm/node_modules/infer-owner": {
       "version": "1.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/inflight": {
       "version": "1.0.6",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -32147,13 +32057,11 @@
     },
     "node_modules/npm/node_modules/inherits": {
       "version": "2.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/ini": {
       "version": "3.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -32162,7 +32070,6 @@
     },
     "node_modules/npm/node_modules/init-package-json": {
       "version": "3.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -32180,13 +32087,11 @@
     },
     "node_modules/npm/node_modules/ip": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/ip-regex": {
       "version": "4.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -32195,7 +32100,6 @@
     },
     "node_modules/npm/node_modules/is-cidr": {
       "version": "4.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -32207,7 +32111,6 @@
     },
     "node_modules/npm/node_modules/is-core-module": {
       "version": "2.10.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -32219,7 +32122,6 @@
     },
     "node_modules/npm/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -32228,25 +32130,21 @@
     },
     "node_modules/npm/node_modules/is-lambda": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/isexe": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/json-stringify-nice": {
       "version": "1.1.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -32255,7 +32153,6 @@
     },
     "node_modules/npm/node_modules/jsonparse": {
       "version": "1.3.1",
-      "dev": true,
       "engines": [
         "node >= 0.2.0"
       ],
@@ -32264,19 +32161,16 @@
     },
     "node_modules/npm/node_modules/just-diff": {
       "version": "5.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/just-diff-apply": {
       "version": "5.4.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/libnpmaccess": {
       "version": "6.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -32291,7 +32185,6 @@
     },
     "node_modules/npm/node_modules/libnpmdiff": {
       "version": "4.0.5",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -32310,7 +32203,6 @@
     },
     "node_modules/npm/node_modules/libnpmexec": {
       "version": "4.0.14",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -32335,7 +32227,6 @@
     },
     "node_modules/npm/node_modules/libnpmfund": {
       "version": "3.0.5",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -32347,7 +32238,6 @@
     },
     "node_modules/npm/node_modules/libnpmhook": {
       "version": "8.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -32360,7 +32250,6 @@
     },
     "node_modules/npm/node_modules/libnpmorg": {
       "version": "4.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -32373,7 +32262,6 @@
     },
     "node_modules/npm/node_modules/libnpmpack": {
       "version": "4.1.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -32387,7 +32275,6 @@
     },
     "node_modules/npm/node_modules/libnpmpublish": {
       "version": "6.0.5",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -32403,7 +32290,6 @@
     },
     "node_modules/npm/node_modules/libnpmsearch": {
       "version": "5.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -32415,7 +32301,6 @@
     },
     "node_modules/npm/node_modules/libnpmteam": {
       "version": "4.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -32428,7 +32313,6 @@
     },
     "node_modules/npm/node_modules/libnpmversion": {
       "version": "3.0.7",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -32444,7 +32328,6 @@
     },
     "node_modules/npm/node_modules/lru-cache": {
       "version": "7.13.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -32453,7 +32336,6 @@
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
       "version": "10.2.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -32480,7 +32362,6 @@
     },
     "node_modules/npm/node_modules/minimatch": {
       "version": "5.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -32492,7 +32373,6 @@
     },
     "node_modules/npm/node_modules/minipass": {
       "version": "3.3.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -32504,7 +32384,6 @@
     },
     "node_modules/npm/node_modules/minipass-collect": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -32516,7 +32395,6 @@
     },
     "node_modules/npm/node_modules/minipass-fetch": {
       "version": "2.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -32533,7 +32411,6 @@
     },
     "node_modules/npm/node_modules/minipass-flush": {
       "version": "1.0.5",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -32545,7 +32422,6 @@
     },
     "node_modules/npm/node_modules/minipass-json-stream": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -32555,7 +32431,6 @@
     },
     "node_modules/npm/node_modules/minipass-pipeline": {
       "version": "1.2.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -32567,7 +32442,6 @@
     },
     "node_modules/npm/node_modules/minipass-sized": {
       "version": "1.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -32579,7 +32453,6 @@
     },
     "node_modules/npm/node_modules/minizlib": {
       "version": "2.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -32592,7 +32465,6 @@
     },
     "node_modules/npm/node_modules/mkdirp": {
       "version": "1.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -32604,7 +32476,6 @@
     },
     "node_modules/npm/node_modules/mkdirp-infer-owner": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -32618,19 +32489,16 @@
     },
     "node_modules/npm/node_modules/ms": {
       "version": "2.1.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/mute-stream": {
       "version": "0.0.8",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/negotiator": {
       "version": "0.6.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -32639,7 +32507,6 @@
     },
     "node_modules/npm/node_modules/node-gyp": {
       "version": "9.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -32663,7 +32530,6 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -32673,7 +32539,6 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/glob": {
       "version": "7.2.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -32693,7 +32558,6 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/minimatch": {
       "version": "3.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -32705,7 +32569,6 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/nopt": {
       "version": "5.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -32720,7 +32583,6 @@
     },
     "node_modules/npm/node_modules/nopt": {
       "version": "6.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -32735,7 +32597,6 @@
     },
     "node_modules/npm/node_modules/normalize-package-data": {
       "version": "4.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -32750,7 +32611,6 @@
     },
     "node_modules/npm/node_modules/npm-audit-report": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -32762,7 +32622,6 @@
     },
     "node_modules/npm/node_modules/npm-bundled": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -32774,7 +32633,6 @@
     },
     "node_modules/npm/node_modules/npm-bundled/node_modules/npm-normalize-package-bin": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -32783,7 +32641,6 @@
     },
     "node_modules/npm/node_modules/npm-install-checks": {
       "version": "5.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -32795,13 +32652,11 @@
     },
     "node_modules/npm/node_modules/npm-normalize-package-bin": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/npm-package-arg": {
       "version": "9.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -32816,7 +32671,6 @@
     },
     "node_modules/npm/node_modules/npm-packlist": {
       "version": "5.1.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -32834,7 +32688,6 @@
     },
     "node_modules/npm/node_modules/npm-packlist/node_modules/npm-normalize-package-bin": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -32843,7 +32696,6 @@
     },
     "node_modules/npm/node_modules/npm-pick-manifest": {
       "version": "7.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -32858,7 +32710,6 @@
     },
     "node_modules/npm/node_modules/npm-pick-manifest/node_modules/npm-normalize-package-bin": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -32867,7 +32718,6 @@
     },
     "node_modules/npm/node_modules/npm-profile": {
       "version": "6.2.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -32880,7 +32730,6 @@
     },
     "node_modules/npm/node_modules/npm-registry-fetch": {
       "version": "13.3.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -32898,13 +32747,11 @@
     },
     "node_modules/npm/node_modules/npm-user-validate": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/npm/node_modules/npmlog": {
       "version": "6.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -32919,7 +32766,6 @@
     },
     "node_modules/npm/node_modules/once": {
       "version": "1.4.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -32928,7 +32774,6 @@
     },
     "node_modules/npm/node_modules/opener": {
       "version": "1.5.2",
-      "dev": true,
       "inBundle": true,
       "license": "(WTFPL OR MIT)",
       "bin": {
@@ -32937,7 +32782,6 @@
     },
     "node_modules/npm/node_modules/p-map": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -32952,7 +32796,6 @@
     },
     "node_modules/npm/node_modules/pacote": {
       "version": "13.6.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -32987,7 +32830,6 @@
     },
     "node_modules/npm/node_modules/parse-conflict-json": {
       "version": "2.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -33001,7 +32843,6 @@
     },
     "node_modules/npm/node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -33010,7 +32851,6 @@
     },
     "node_modules/npm/node_modules/postcss-selector-parser": {
       "version": "6.0.10",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -33023,7 +32863,6 @@
     },
     "node_modules/npm/node_modules/proc-log": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -33032,7 +32871,6 @@
     },
     "node_modules/npm/node_modules/promise-all-reject-late": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -33041,7 +32879,6 @@
     },
     "node_modules/npm/node_modules/promise-call-limit": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -33050,13 +32887,11 @@
     },
     "node_modules/npm/node_modules/promise-inflight": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/promise-retry": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -33069,7 +32904,6 @@
     },
     "node_modules/npm/node_modules/promzard": {
       "version": "0.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -33078,7 +32912,6 @@
     },
     "node_modules/npm/node_modules/qrcode-terminal": {
       "version": "0.12.0",
-      "dev": true,
       "inBundle": true,
       "bin": {
         "qrcode-terminal": "bin/qrcode-terminal.js"
@@ -33086,7 +32919,6 @@
     },
     "node_modules/npm/node_modules/read": {
       "version": "1.0.7",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -33098,7 +32930,6 @@
     },
     "node_modules/npm/node_modules/read-cmd-shim": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -33107,7 +32938,6 @@
     },
     "node_modules/npm/node_modules/read-package-json": {
       "version": "5.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -33122,7 +32952,6 @@
     },
     "node_modules/npm/node_modules/read-package-json-fast": {
       "version": "2.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -33135,7 +32964,6 @@
     },
     "node_modules/npm/node_modules/read-package-json/node_modules/npm-normalize-package-bin": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -33144,7 +32972,6 @@
     },
     "node_modules/npm/node_modules/readable-stream": {
       "version": "3.6.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -33158,7 +32985,6 @@
     },
     "node_modules/npm/node_modules/readdir-scoped-modules": {
       "version": "1.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -33170,7 +32996,6 @@
     },
     "node_modules/npm/node_modules/retry": {
       "version": "0.12.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -33179,7 +33004,6 @@
     },
     "node_modules/npm/node_modules/rimraf": {
       "version": "3.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -33194,7 +33018,6 @@
     },
     "node_modules/npm/node_modules/rimraf/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -33204,7 +33027,6 @@
     },
     "node_modules/npm/node_modules/rimraf/node_modules/glob": {
       "version": "7.2.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -33224,7 +33046,6 @@
     },
     "node_modules/npm/node_modules/rimraf/node_modules/minimatch": {
       "version": "3.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -33236,7 +33057,6 @@
     },
     "node_modules/npm/node_modules/safe-buffer": {
       "version": "5.2.1",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -33256,14 +33076,11 @@
     },
     "node_modules/npm/node_modules/safer-buffer": {
       "version": "2.1.2",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/semver": {
       "version": "7.3.7",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -33278,7 +33095,6 @@
     },
     "node_modules/npm/node_modules/semver/node_modules/lru-cache": {
       "version": "6.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -33290,19 +33106,16 @@
     },
     "node_modules/npm/node_modules/set-blocking": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/signal-exit": {
       "version": "3.0.7",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/smart-buffer": {
       "version": "4.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -33312,7 +33125,6 @@
     },
     "node_modules/npm/node_modules/socks": {
       "version": "2.7.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -33326,7 +33138,6 @@
     },
     "node_modules/npm/node_modules/socks-proxy-agent": {
       "version": "7.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -33340,7 +33151,6 @@
     },
     "node_modules/npm/node_modules/spdx-correct": {
       "version": "3.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -33350,13 +33160,11 @@
     },
     "node_modules/npm/node_modules/spdx-exceptions": {
       "version": "2.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "CC-BY-3.0"
     },
     "node_modules/npm/node_modules/spdx-expression-parse": {
       "version": "3.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -33366,13 +33174,11 @@
     },
     "node_modules/npm/node_modules/spdx-license-ids": {
       "version": "3.0.11",
-      "dev": true,
       "inBundle": true,
       "license": "CC0-1.0"
     },
     "node_modules/npm/node_modules/ssri": {
       "version": "9.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -33384,7 +33190,6 @@
     },
     "node_modules/npm/node_modules/string_decoder": {
       "version": "1.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -33393,7 +33198,6 @@
     },
     "node_modules/npm/node_modules/string-width": {
       "version": "4.2.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -33407,7 +33211,6 @@
     },
     "node_modules/npm/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -33419,7 +33222,6 @@
     },
     "node_modules/npm/node_modules/supports-color": {
       "version": "7.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -33431,7 +33233,6 @@
     },
     "node_modules/npm/node_modules/tar": {
       "version": "6.1.11",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -33448,19 +33249,16 @@
     },
     "node_modules/npm/node_modules/text-table": {
       "version": "0.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tiny-relative-date": {
       "version": "1.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/treeverse": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -33469,7 +33267,6 @@
     },
     "node_modules/npm/node_modules/unique-filename": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -33481,7 +33278,6 @@
     },
     "node_modules/npm/node_modules/unique-slug": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -33493,13 +33289,11 @@
     },
     "node_modules/npm/node_modules/util-deprecate": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/validate-npm-package-license": {
       "version": "3.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -33509,7 +33303,6 @@
     },
     "node_modules/npm/node_modules/validate-npm-package-name": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -33521,13 +33314,11 @@
     },
     "node_modules/npm/node_modules/walk-up-path": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/wcwidth": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -33536,7 +33327,6 @@
     },
     "node_modules/npm/node_modules/which": {
       "version": "2.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -33551,7 +33341,6 @@
     },
     "node_modules/npm/node_modules/wide-align": {
       "version": "1.1.5",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -33560,13 +33349,11 @@
     },
     "node_modules/npm/node_modules/wrappy": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/write-file-atomic": {
       "version": "4.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -33579,7 +33366,6 @@
     },
     "node_modules/npm/node_modules/yallist": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "buffer": "^6.0.3",
     "changesets-release-it-plugin": "^0.1.2",
     "concurrently": "^8.0.1",
-    "date-fns": "^2.28.0",
+    "date-fns": "^2.30.0",
     "ember-a11y-refocus": "^3.0.0",
     "ember-auto-import": "^2.6.3",
     "ember-browser-update": "^0.1.0",


### PR DESCRIPTION
### Overview
This PR adds a meeting details modal to the inauguration meeting creation flow to allow users to specify the location and time of the meeting.
Differences compared to common meeting creation modal:
- Administrative unit is not editable
- Modal title is slightly different

Additionally, this PR also includes a modification in how the governing body (bestuurseenheid) is selected for the inauguration meeting:
- The `binding-einde` should be undefined or gte than the current date. (is this correct?)

##### connected issues and PRs:
[GN-4977](https://binnenland.atlassian.net/browse/GN-4977)

### How to test/reproduce
- Start the app
- Visit the meeting inbox
- Test if both the common meeting and inauguration meeting creation flows works as expected

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
