### PR TITLE
GN-4976: exclude ember-leaflet assets from fingerprinting

### DIFF
--- a/.changeset/nice-avocados-study.md
+++ b/.changeset/nice-avocados-study.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Exlude ember-leaflet assets from fingerprinting

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -36,6 +36,15 @@ module.exports = function (defaults) {
     babel: {
       sourceMaps: 'inline',
     },
+    fingerprint: {
+      exclude: [
+        'images/layers-2x.png',
+        'images/layers.png',
+        'images/marker-icon-2x.png',
+        'images/marker-icon.png',
+        'images/marker-shadow.png',
+      ],
+    },
   });
 
   return app.toTree();


### PR DESCRIPTION
### Overview
This PR excludes ember-leaflet assets from fingerprinting

##### connected issues and PRs:
[GN-4976](https://binnenland.atlassian.net/browse/GN-4976?atlOrigin=eyJpIjoiMTM5ZjEzZmUzZWFmNDZjYWI3ZTJmZWI5OWI1MmJhN2YiLCJwIjoiaiJ9)
Check-out https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/464 for more information.
