### PR TITLE
Enable rdfa-aware setting on remaining (non rdfa-aware) nodes

### DIFF
--- a/.changeset/chilled-bears-trade.md
+++ b/.changeset/chilled-bears-trade.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': minor
+---
+
+agendapoint editor: enable rdfa-aware `doc`, `heading` and `link` nodes

--- a/.changeset/eleven-panthers-melt.md
+++ b/.changeset/eleven-panthers-melt.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': minor
+---
+
+meeting intro/outro editors: enable rdfa-aware nodes

--- a/.changeset/empty-rocks-check.md
+++ b/.changeset/empty-rocks-check.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': minor
+---
+
+regulatory-statement editor: enable rdfa-aware `link` nodes

--- a/app/components/zitting-text-document-container.js
+++ b/app/components/zitting-text-document-container.js
@@ -14,13 +14,13 @@ import {
 import { highlight } from '@lblod/ember-rdfa-editor/plugins/highlight/marks/highlight';
 import { color } from '@lblod/ember-rdfa-editor/plugins/color/marks/color';
 import {
-  block_rdfa,
+  blockRdfaWithConfig,
   docWithConfig,
   hard_break,
   horizontal_rule,
-  invisible_rdfa,
+  invisibleRdfaWithConfig,
   paragraph,
-  repaired_block,
+  repairedBlockWithConfig,
   text,
 } from '@lblod/ember-rdfa-editor/nodes';
 import {
@@ -36,11 +36,10 @@ import {
   orderedListWithConfig,
 } from '@lblod/ember-rdfa-editor/plugins/list';
 import { placeholder } from '@lblod/ember-rdfa-editor/plugins/placeholder';
-import { heading } from '@lblod/ember-rdfa-editor/plugins/heading';
+import { headingWithConfig } from '@lblod/ember-rdfa-editor/plugins/heading';
 import { blockquote } from '@lblod/ember-rdfa-editor/plugins/blockquote';
 import { code_block } from '@lblod/ember-rdfa-editor/plugins/code';
 import { image } from '@lblod/ember-rdfa-editor/plugins/image';
-import { inline_rdfa } from '@lblod/ember-rdfa-editor/marks';
 import {
   date,
   dateView,
@@ -49,6 +48,10 @@ import {
 import { service } from '@ember/service';
 import { linkPasteHandler } from '@lblod/ember-rdfa-editor/plugins/link';
 import { tracked } from '@glimmer/tracking';
+import {
+  inlineRdfaWithConfig,
+  inlineRdfaWithConfigView,
+} from '@lblod/ember-rdfa-editor/nodes/inline-rdfa';
 
 export default class ZittingTextDocumentContainerComponent extends Component {
   @service intl;
@@ -68,28 +71,28 @@ export default class ZittingTextDocumentContainerComponent extends Component {
 
   schema = new Schema({
     nodes: {
-      doc: docWithConfig(),
+      doc: docWithConfig({ rdfaAware: true }),
       paragraph,
-      repaired_block,
+      repaired_block: repairedBlockWithConfig({ rdfaAware: true }),
       list_item: listItemWithConfig({ enableHierarchicalList: true }),
       ordered_list: orderedListWithConfig({ enableHierarchicalList: true }),
       bullet_list: bulletListWithConfig({ enableHierarchicalList: true }),
       placeholder,
       ...tableNodes({ tableGroup: 'block', cellContent: 'block+' }),
       date: date(this.config.date),
-      heading,
+      heading: headingWithConfig({ rdfaAware: true }),
       blockquote,
       horizontal_rule,
       code_block,
       text,
       image,
       hard_break,
-      invisible_rdfa,
-      block_rdfa,
+      invisible_rdfa: invisibleRdfaWithConfig({ rdfaAware: true }),
+      block_rdfa: blockRdfaWithConfig({ rdfaAware: true }),
+      inline_rdfa: inlineRdfaWithConfig({ rdfaAware: true }),
       link: link(this.config.link),
     },
     marks: {
-      inline_rdfa,
       em,
       strong,
       underline,
@@ -134,6 +137,7 @@ export default class ZittingTextDocumentContainerComponent extends Component {
     return {
       link: {
         interactive: true,
+        rdfaAware: true,
       },
       date: {
         placeholder: {
@@ -173,6 +177,7 @@ export default class ZittingTextDocumentContainerComponent extends Component {
       return {
         link: linkView(this.config.link)(controller),
         date: dateView(this.config.date)(controller),
+        inline_rdfa: inlineRdfaWithConfigView({ rdfaAware: true })(controller),
       };
     };
   }

--- a/app/controllers/agendapoints/edit.js
+++ b/app/controllers/agendapoints/edit.js
@@ -53,7 +53,7 @@ import {
   orderedListWithConfig,
 } from '@lblod/ember-rdfa-editor/plugins/list';
 import { placeholder } from '@lblod/ember-rdfa-editor/plugins/placeholder';
-import { heading } from '@lblod/ember-rdfa-editor/plugins/heading';
+import { headingWithConfig } from '@lblod/ember-rdfa-editor/plugins/heading';
 import { blockquote } from '@lblod/ember-rdfa-editor/plugins/blockquote';
 import { code_block } from '@lblod/ember-rdfa-editor/plugins/code';
 import { image, imageView } from '@lblod/ember-rdfa-editor/plugins/image';
@@ -130,7 +130,7 @@ export default class AgendapointsEditController extends Controller {
   SnippetInsert = SnippetInsertRdfaComponent;
   schema = new Schema({
     nodes: {
-      doc: docWithConfig(),
+      doc: docWithConfig({ rdfaAware: true }),
       paragraph,
       repaired_block: repairedBlockWithConfig({ rdfaAware: true }),
       structure,
@@ -148,7 +148,7 @@ export default class AgendapointsEditController extends Controller {
       location,
       codelist,
       roadsign_regulation,
-      heading,
+      heading: headingWithConfig({ rdfaAware: true }),
       blockquote,
       snippet_placeholder: snippetPlaceholder,
       snippet: snippet(this.config.snippet),
@@ -207,6 +207,7 @@ export default class AgendapointsEditController extends Controller {
       },
       link: {
         interactive: true,
+        rdfaAware: true,
       },
       roadsignRegulation: {
         endpoint: ENV.mowRegistryEndpoint,

--- a/app/controllers/regulatory-statements/edit.js
+++ b/app/controllers/regulatory-statements/edit.js
@@ -258,6 +258,7 @@ export default class RegulatoryStatementsRoute extends Controller {
       },
       link: {
         interactive: true,
+        rdfaAware: true,
       },
       structures: STRUCTURE_SPECS,
       worship: {


### PR DESCRIPTION
### Overview
This PR includes some changes in the rdfa-aware configuration (it enables the rdfa-aware setting where possible):
- agendapoint editor: enable rdfa-aware setting for `link`, `heading` and `doc` nodes
- RS editor: enable rdfa-aware setting for `link` node
- meeting intro/outro editor: enable rdfa-aware setting on all applicable nodes

##### connected issues and PRs:
None

### How to test/reproduce
- Start the application
- Open an agendapoint/regulatory-statement and notice that all applicable nodes are now rdfa-aware. Older documents should be correctly parsed.
- The intro/outro sections of a meeting should now also be rdfa-aware.

### Challenges/uncertainties
Unsure if I need to rebase this PR to an older version?

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
