### PR TITLE
Don't make unnecessary history changes when updating RS inside agendapoints

### DIFF
--- a/.changeset/wild-dogs-admire.md
+++ b/.changeset/wild-dogs-admire.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Don't make unnecesary history changes when updating regulatory statements inside agendapoints

--- a/app/components/editor-plugins/regulatory-statements/view.js
+++ b/app/components/editor-plugins/regulatory-statements/view.js
@@ -29,8 +29,10 @@ export default class ReadOnlyContentSectionComponent extends Component {
     if (this.node.attrs.title !== this.currentVersion.title) {
       this.args.updateAttribute('title', this.currentVersion.title);
     }
-    if (this.content !== this.currentVersion.htmlSafeContent) {
+    if (this.node.attrs.oldContent !== this.currentVersion.htmlSafeContent.toString()) {
       this.args.updateAttribute('content', this.currentVersion.htmlSafeContent);
+    } else {
+      this.args.updateAttribute('content', this.currentVersion.htmlSafeContent, true);
     }
   }
   get node() {

--- a/app/components/editor-plugins/regulatory-statements/view.js
+++ b/app/components/editor-plugins/regulatory-statements/view.js
@@ -29,10 +29,17 @@ export default class ReadOnlyContentSectionComponent extends Component {
     if (this.node.attrs.title !== this.currentVersion.title) {
       this.args.updateAttribute('title', this.currentVersion.title);
     }
-    if (this.node.attrs.oldContent !== this.currentVersion.htmlSafeContent.toString()) {
+    if (
+      this.node.attrs.oldContent !==
+      this.currentVersion.htmlSafeContent.toString()
+    ) {
       this.args.updateAttribute('content', this.currentVersion.htmlSafeContent);
     } else {
-      this.args.updateAttribute('content', this.currentVersion.htmlSafeContent, true);
+      this.args.updateAttribute(
+        'content',
+        this.currentVersion.htmlSafeContent,
+        true,
+      );
     }
   }
   get node() {

--- a/app/components/editor-plugins/regulatory-statements/view.js
+++ b/app/components/editor-plugins/regulatory-statements/view.js
@@ -24,22 +24,17 @@ export default class ReadOnlyContentSectionComponent extends Component {
         include: 'current-version',
       })
     ).firstObject;
+
     this.currentVersion =
       await this.regulatoryStatementContainer.currentVersion;
     if (this.node.attrs.title !== this.currentVersion.title) {
       this.args.updateAttribute('title', this.currentVersion.title);
     }
     if (
-      this.node.attrs.oldContent !==
+      this.node.attrs.content.toString() !==
       this.currentVersion.htmlSafeContent.toString()
     ) {
       this.args.updateAttribute('content', this.currentVersion.htmlSafeContent);
-    } else {
-      this.args.updateAttribute(
-        'content',
-        this.currentVersion.htmlSafeContent,
-        true,
-      );
     }
   }
   get node() {

--- a/app/editor-plugins/regulatory-statements-plugin/index.js
+++ b/app/editor-plugins/regulatory-statements-plugin/index.js
@@ -21,6 +21,7 @@ const emberNodeConfig = {
     resource: {},
     title: { default: '' },
     content: { default: '' },
+    oldContent: { default: ''}
   },
   toDOM: (node) => {
     const parser = new DOMParser();
@@ -33,6 +34,8 @@ const emberNodeConfig = {
         property: 'eli:related_to',
         rev: 'dct:isPartOf',
         typeof: 'besluitpublicatie:Documentonderdeel',
+        'data-rs-content':  node.attrs['content'],
+        'data-rs-title': node.attrs['title']
       },
       ['h5', {}, `Reglementaire bijlage: ${node.attrs['title']}`],
       ['div', {}, ...html.body.childNodes],
@@ -42,9 +45,13 @@ const emberNodeConfig = {
     {
       tag: 'div',
       getAttrs(element) {
+        const oldContent = element.dataset.rsContent;
+        const title = element.dataset.rsTitle
         if (element.dataset['emberNode'] === 'regulatory-statement-view') {
           return {
             resource: element.getAttribute('resource'),
+            oldContent,
+            title
           };
         } else if (
           element.dataset.inlineComponent ===
@@ -55,6 +62,8 @@ const emberNodeConfig = {
           const propsParsed = JSON.parse(element.dataset.props);
           return {
             resource: propsParsed['uri'],
+            oldContent,
+            title
           };
         }
         return false;

--- a/app/editor-plugins/regulatory-statements-plugin/index.js
+++ b/app/editor-plugins/regulatory-statements-plugin/index.js
@@ -3,6 +3,7 @@ import {
   createEmberNodeView,
 } from '@lblod/ember-rdfa-editor/utils/ember-node';
 import ReadOnlyContentSectionComponent from 'frontend-gelinkt-notuleren/components/editor-plugins/regulatory-statements/view';
+import { htmlSafe } from '@ember/template';
 
 /**
  * @typedef {import('@lblod/ember-rdfa-editor/utils/ember-node').EmberNodeConfig} EmberNodeConfig
@@ -50,8 +51,8 @@ const emberNodeConfig = {
         if (element.dataset['emberNode'] === 'regulatory-statement-view') {
           return {
             resource: element.getAttribute('resource'),
-            oldContent,
             title,
+            content: htmlSafe(oldContent),
           };
         } else if (
           element.dataset.inlineComponent ===
@@ -62,8 +63,8 @@ const emberNodeConfig = {
           const propsParsed = JSON.parse(element.dataset.props);
           return {
             resource: propsParsed['uri'],
-            oldContent,
             title,
+            content: htmlSafe(oldContent),
           };
         }
         return false;

--- a/app/editor-plugins/regulatory-statements-plugin/index.js
+++ b/app/editor-plugins/regulatory-statements-plugin/index.js
@@ -21,7 +21,7 @@ const emberNodeConfig = {
     resource: {},
     title: { default: '' },
     content: { default: '' },
-    oldContent: { default: ''}
+    oldContent: { default: '' },
   },
   toDOM: (node) => {
     const parser = new DOMParser();
@@ -34,8 +34,8 @@ const emberNodeConfig = {
         property: 'eli:related_to',
         rev: 'dct:isPartOf',
         typeof: 'besluitpublicatie:Documentonderdeel',
-        'data-rs-content':  node.attrs['content'],
-        'data-rs-title': node.attrs['title']
+        'data-rs-content': node.attrs['content'],
+        'data-rs-title': node.attrs['title'],
       },
       ['h5', {}, `Reglementaire bijlage: ${node.attrs['title']}`],
       ['div', {}, ...html.body.childNodes],
@@ -46,12 +46,12 @@ const emberNodeConfig = {
       tag: 'div',
       getAttrs(element) {
         const oldContent = element.dataset.rsContent;
-        const title = element.dataset.rsTitle
+        const title = element.dataset.rsTitle;
         if (element.dataset['emberNode'] === 'regulatory-statement-view') {
           return {
             resource: element.getAttribute('resource'),
             oldContent,
-            title
+            title,
           };
         } else if (
           element.dataset.inlineComponent ===
@@ -63,7 +63,7 @@ const emberNodeConfig = {
           return {
             resource: propsParsed['uri'],
             oldContent,
-            title
+            title,
           };
         }
         return false;

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@lblod/ember-acmidm-login": "^2.1.0",
     "@lblod/ember-environment-banner": "^0.5.0",
     "@lblod/ember-mock-login": "^0.10.0",
-    "@lblod/ember-rdfa-editor": "10.0.3-dev.255c7e61d050c67134789bf7e2962258a8cc8978",
+    "@lblod/ember-rdfa-editor": "10.0.3",
     "@lblod/ember-rdfa-editor-lblod-plugins": "22.1.0",
     "@release-it-plugins/lerna-changelog": "^6.0.0",
     "broccoli-asset-rev": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@lblod/ember-acmidm-login": "^2.1.0",
     "@lblod/ember-environment-banner": "^0.5.0",
     "@lblod/ember-mock-login": "^0.10.0",
-    "@lblod/ember-rdfa-editor": "10.0.3",
+    "@lblod/ember-rdfa-editor": "10.0.3-dev.255c7e61d050c67134789bf7e2962258a8cc8978",
     "@lblod/ember-rdfa-editor-lblod-plugins": "22.1.0",
     "@release-it-plugins/lerna-changelog": "^6.0.0",
     "broccoli-asset-rev": "^3.0.0",


### PR DESCRIPTION
…

### Overview
When checking for RS updates we were making unnecesary changes and adding them to the history, which resulted in the editor thinking there were changes when there were not. This interfiered with the saving action.
I limited these changes, and I added a way of updating properties without adding them to the history

##### connected issues and PRs:
GN-4961
https://github.com/lblod/ember-rdfa-editor/pull/1214


### Setup
Link the ember-rdfa-editor with the branch of the PR I linked

### How to test/reproduce
Go to the agendapoints, create a new agendapoint with a RS, save it and check that it doesn't say that it has unsaved changes anymore, modify the RS go back to the agendapoint and check that now you have a unsaved change to save

### Challenges/uncertainties
Maybe in the future we shouldn't require user action in order to update the RS



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
