### PR TITLE
bump plugins to 22.2.1

### DIFF
--- a/.changeset/yellow-cougars-serve.md
+++ b/.changeset/yellow-cougars-serve.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': minor
+---
+
+BUmp plugins to 2.22.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@lblod/ember-environment-banner": "^0.5.0",
         "@lblod/ember-mock-login": "^0.10.0",
         "@lblod/ember-rdfa-editor": "10.0.3",
-        "@lblod/ember-rdfa-editor-lblod-plugins": "22.1.0",
+        "@lblod/ember-rdfa-editor-lblod-plugins": "22.2.1",
         "@release-it-plugins/lerna-changelog": "^6.0.0",
         "broccoli-asset-rev": "^3.0.0",
         "broccoli-plugin": "^4.0.7",
@@ -4554,9 +4554,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor-lblod-plugins": {
-      "version": "22.1.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-22.1.0.tgz",
-      "integrity": "sha512-ZevqQ25MlvhWynWgMQC3J2IttS82OxlJRWiFhxqbGeYW7plIVrEUF2gQK2NajyJay2sy9bw/JzcFiQaQpUDopQ==",
+      "version": "22.2.1",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-22.2.1.tgz",
+      "integrity": "sha512-9KJlrrX9spuIuPKyc2XdMlaqiTUjWfnE+bfFms51Bb5Smrtrz3CMf3wbSGmcsyXaPA1tLeHGni6Tl6hqnZ0uwg==",
       "dev": true,
       "dependencies": {
         "@codemirror/lang-html": "^6.4.9",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@lblod/ember-environment-banner": "^0.5.0",
     "@lblod/ember-mock-login": "^0.10.0",
     "@lblod/ember-rdfa-editor": "10.0.3",
-    "@lblod/ember-rdfa-editor-lblod-plugins": "22.2.0-dev.227387b683b3b49314683b2c299c45c492393eb8",
+    "@lblod/ember-rdfa-editor-lblod-plugins": "22.2.1",
     "@release-it-plugins/lerna-changelog": "^6.0.0",
     "broccoli-asset-rev": "^3.0.0",
     "broccoli-plugin": "^4.0.7",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@lblod/ember-environment-banner": "^0.5.0",
     "@lblod/ember-mock-login": "^0.10.0",
     "@lblod/ember-rdfa-editor": "10.0.3",
-    "@lblod/ember-rdfa-editor-lblod-plugins": "22.1.0",
+    "@lblod/ember-rdfa-editor-lblod-plugins": "22.2.0-dev.227387b683b3b49314683b2c299c45c492393eb8",
     "@release-it-plugins/lerna-changelog": "^6.0.0",
     "broccoli-asset-rev": "^3.0.0",
     "broccoli-plugin": "^4.0.7",


### PR DESCRIPTION
### Overview
Bump plugins to 22.2.1 this will be keep on a experimental version until we merge and release the PR

##### connected issues and PRs:
https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/466


### Checks PR readiness
- [x] changelog
