### PR TITLE
Meeting participants improvements

### DIFF
--- a/.changeset/brave-nails-march.md
+++ b/.changeset/brave-nails-march.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': minor
+---
+
+(functionaris-selector) improve filter of functionaris query

--- a/.changeset/four-impalas-fail.md
+++ b/.changeset/four-impalas-fail.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': minor
+---
+
+Improve filtering of possible-participants (meeting-form) query

--- a/.changeset/gold-grapes-sniff.md
+++ b/.changeset/gold-grapes-sniff.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': minor
+---
+
+(mandataris-selector) improve filter of mandatee queries

--- a/.changeset/thin-hotels-confess.md
+++ b/.changeset/thin-hotels-confess.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': minor
+---
+
+(meeting-form) adjust possible-participants query to include additional relationships to avoid patchy load of mandatee-table

--- a/app/components/meeting-form.js
+++ b/app/components/meeting-form.js
@@ -146,8 +146,16 @@ export default class MeetingForm extends Component {
     let queryParams = {
       include: 'is-bestuurlijke-alias-van,status',
       sort: 'is-bestuurlijke-alias-van.achternaam',
-      'filter[bekleedt][bevat-in][:uri:]': this.bestuursorgaan.uri,
-      'filter[bekleedt][bestuursfunctie][:id:]': stringifiedDefaultTypeIds,
+      filter: {
+        bekleedt: {
+          'bevat-in': {
+            ':uri:': this.bestuursorgaan.uri,
+          },
+          bestuursfunctie: {
+            ':id:': stringifiedDefaultTypeIds,
+          },
+        },
+      },
       page: { size: 100 }, //arbitrary number, later we will make sure there is previous last. (also like this in the plugin)
     };
     const mandatees = await this.store.query('mandataris', queryParams);

--- a/app/components/meeting-form.js
+++ b/app/components/meeting-form.js
@@ -149,7 +149,13 @@ export default class MeetingForm extends Component {
     const startOfMeeting =
       this.zitting.gestartOpTijdstip ?? this.zitting.geplandeStart;
     let queryParams = {
-      include: 'is-bestuurlijke-alias-van,status',
+      include: [
+        'is-bestuurlijke-alias-van',
+        'is-bestuurlijke-alias-van.geboorte',
+        'status',
+        'bekleedt',
+        'bekleedt.bestuursfunctie',
+      ].join(','),
       sort: 'is-bestuurlijke-alias-van.achternaam',
       filter: {
         bekleedt: {

--- a/app/components/meeting-form.js
+++ b/app/components/meeting-form.js
@@ -3,11 +3,14 @@ import { action } from '@ember/object';
 import { tracked } from 'tracked-built-ins';
 import { task, all, restartableTask } from 'ember-concurrency';
 import { service } from '@ember/service';
-import isValidMandateeForMeeting from 'frontend-gelinkt-notuleren/utils/is-valid-mandatee-for-meeting';
 import { articlesBasedOnClassifcationMap } from '../utils/classification-utils';
 import { trackedFunction } from 'ember-resources/util/function';
 import { trackedTask } from 'ember-resources/util/ember-concurrency';
 import InstallatieVergaderingModel from 'frontend-gelinkt-notuleren/models/installatievergadering';
+import {
+  MANDATARIS_STATUS_EFFECTIEF,
+  MANDATARIS_STATUS_WAARNEMEND,
+} from '../utils/constants';
 
 /** @typedef {import("../models/agendapunt").default[]} Agendapunt */
 
@@ -143,6 +146,8 @@ export default class MeetingForm extends Component {
     const stringifiedDefaultTypeIds = aanwezigenRoles
       .map((t) => t.id)
       .join(',');
+    const startOfMeeting =
+      this.zitting.gestartOpTijdstip ?? this.zitting.geplandeStart;
     let queryParams = {
       include: 'is-bestuurlijke-alias-van,status',
       sort: 'is-bestuurlijke-alias-van.achternaam',
@@ -155,15 +160,22 @@ export default class MeetingForm extends Component {
             ':id:': stringifiedDefaultTypeIds,
           },
         },
+        status: {
+          ':id:': [
+            MANDATARIS_STATUS_EFFECTIEF,
+            MANDATARIS_STATUS_WAARNEMEND,
+          ].join(','),
+        },
+        ':lte:start': startOfMeeting.toISOString(),
+        ':or:': {
+          ':has-no:einde': true,
+          ':gt:einde': startOfMeeting.toISOString(),
+        },
       },
       page: { size: 100 }, //arbitrary number, later we will make sure there is previous last. (also like this in the plugin)
     };
     const mandatees = await this.store.query('mandataris', queryParams);
-    return Array.from(
-      mandatees.filter((mandatee) =>
-        isValidMandateeForMeeting(mandatee, this.zitting),
-      ),
-    );
+    return Array.from(mandatees);
   });
 
   possibleParticipantsData = trackedTask(

--- a/app/components/participation-list/functionaris-selector.js
+++ b/app/components/participation-list/functionaris-selector.js
@@ -40,10 +40,14 @@ export default class ParticipationListFunctionarisSelectorComponent extends Comp
       : this.args.meeting.geplandeStart;
     let queryParams = {
       sort: 'is-bestuurlijke-alias-van.achternaam',
-      'filter[bekleedt][bevat-in][:id:]': bestuursorganen
-        .map((b) => b.id)
-        .join(','),
-      'filter[:lte:start]': startOfMeeting.toISOString(),
+      filter: {
+        bekleedt: {
+          'bevat-in': {
+            ':id:': bestuursorganen.map((b) => b.id).join(','),
+          },
+        },
+        ':lte:start': startOfMeeting.toISOString(),
+      },
     };
     const candidateOptions = await this.store.query(
       'functionaris',

--- a/app/components/participation-list/mandataris-selector.js
+++ b/app/components/participation-list/mandataris-selector.js
@@ -35,8 +35,14 @@ export default class ParticipationListMandatarisSelectorComponent extends Compon
     let queryParams = {
       sort: 'is-bestuurlijke-alias-van.achternaam',
       include: 'status',
-      'filter[bekleedt][bevat-in][:uri:]': adminBody.uri,
-      'filter[is-bestuurlijke-alias-van]': searchData,
+      filter: {
+        bekleedt: {
+          'bevat-in': {
+            ':uri:': adminBody.uri,
+          },
+        },
+        'is-bestuurlijke-alias-van': searchData,
+      },
       page: { size: 100 },
     };
     return this.store.query('mandataris', queryParams);
@@ -46,11 +52,22 @@ export default class ParticipationListMandatarisSelectorComponent extends Compon
     const queryParams = {
       sort: 'is-bestuurlijke-alias-van.achternaam',
       include: 'status',
-      'filter[bekleedt][bevat-in][is-tijdsspecialisatie-van][classificatie][:uri:]':
-        GOVERNOR_CLASSIFICATION,
-      'filter[is-bestuurlijke-alias-van]': searchData,
-      'filter[bekleedt][bevat-in][is-tijdsspecialisatie-van][bestuurseenheid][:uri:]':
-        adminUnit.uri,
+      filter: {
+        bekleedt: {
+          'bevat-in': {
+            'is-tijdsspecialisatie-van': {
+              classificatie: {
+                ':uri:': GOVERNOR_CLASSIFICATION,
+              },
+              bestuurseenheid: {
+                ':uri:': adminUnit.uri,
+              },
+            },
+          },
+        },
+        'is-bestuurlijke-alias-van': searchData,
+      },
+      page: { size: 100 },
     };
     return this.store.query('mandataris', queryParams);
   }

--- a/app/components/participation-list/mandatarissen-table.hbs
+++ b/app/components/participation-list/mandatarissen-table.hbs
@@ -23,5 +23,3 @@
     }}
   </tbody>
 </table>
-
-{{yield}}

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -12,3 +12,9 @@ export const DURING_POS_ID = '4790eec5-acd2-4c1d-8e91-90bb2998f87c';
 export const AFTER_POS_ID = '267a09cc-5380-492d-93ad-697b9e99f032';
 //attachment types
 export const REGULATORY_TYPE_ID = '14e264b4-92db-483f-9dd1-3e806ad6d26c';
+
+//mandatee status
+export const MANDATARIS_STATUS_WAARNEMEND =
+  'e1ca6edd-55e1-4288-92a5-53f4cf71946a';
+export const MANDATARIS_STATUS_EFFECTIEF =
+  '21063a5b-912c-4241-841c-cc7fb3c73e75';


### PR DESCRIPTION
### Overview
This PR includes some improvements regarding the querying/displaying of mandatees in a meeting. Specifically, the following improvements are:
- Removal of a (duplicate) erroneous yield from the `mandatarissen-table` component
- `meeting-form.js`: improve filter of `possible-participants` query: the query now includes filtering on the `status`, `start` and `einde` fields, the post-query `isValidMandateeForMeeting` filter is no longer necessary
- `meeting-form.js`: adjust `possible-participants` query to include additional relationships to avoid spotty/patchy load of mandatee table
- `mandataris-selector.js`: improve filter of mandatee query:  the query now includes filtering on the `status`, `start` and `einde` fields, the post-query `isValidMandateeForMeeting` filter is no longer necessary
- `functionaris-selector.js`: improve filter of functionaris query: the query now includes filtering on the `start` and `einde` fields

UX improvements TODOs (can be done in this PR or another):

- [ ] Add loading indicators where applicable (e.g. when the mandatee table is loading)
- [ ] (optional) Use sparse fieldsets where possible, to improve the query performance
- [ ] Add `include` option to some queries where applicable, to reduce spotty/patchy loading (e.g. for tables)

##### connected issues and PRs:
None

### Setup

### How to test/reproduce
- Start the application
- Log in and open a meeting
- When opening the attendee modal, notice that the mandatee table should no longer be loaded in a spotty way
- The `functionaris-selector` and `mandatee-selector` should work as expected

### Challenges/uncertainties
-  `mandataris-table` component: we should probably add a loading indicator when this data is loading. We should also determine if we keep the `possible-participants` query in `meeting-form.js` or if we move it to `participation-list/modal.js`.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
