### PR TITLE
Add person variable

### DIFF
--- a/.changeset/smart-zebras-yell.md
+++ b/.changeset/smart-zebras-yell.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': minor
+---
+
+Add person variable

--- a/app/controllers/agendapoints/edit.js
+++ b/app/controllers/agendapoints/edit.js
@@ -39,6 +39,8 @@ import {
   locationView,
   text_variable,
   textVariableView,
+  person_variable,
+  personVariableView,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/variables';
 import {
   osloLocation,
@@ -159,6 +161,7 @@ export default class AgendapointsEditController extends Controller {
       invisible_rdfa: invisibleRdfaWithConfig({ rdfaAware: true }),
       inline_rdfa: inlineRdfaWithConfig({ rdfaAware: true }),
       link: link(this.config.link),
+      person_variable,
     },
     marks: {
       em,
@@ -238,6 +241,9 @@ export default class AgendapointsEditController extends Controller {
       lpdc: {
         endpoint: '/lpdc-service',
       },
+      lmb: {
+        endpoint: '/vendor-proxy/query',
+      },
     };
   }
 
@@ -283,6 +289,7 @@ export default class AgendapointsEditController extends Controller {
         snippet_placeholder: snippetPlaceholderView(controller),
         snippet: snippetView(this.config.snippet)(controller),
         structure: structureView(controller),
+        person_variable: personVariableView(controller),
       };
     };
   }

--- a/app/controllers/regulatory-statements/edit.js
+++ b/app/controllers/regulatory-statements/edit.js
@@ -78,6 +78,8 @@ import {
   locationView,
   text_variable,
   textVariableView,
+  person_variable,
+  personVariableView,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/variables';
 import {
   osloLocation,
@@ -154,6 +156,7 @@ export default class RegulatoryStatementsRoute extends Controller {
       block_rdfa: blockRdfaWithConfig({ rdfaAware: true }),
       inline_rdfa: inlineRdfaWithConfig({ rdfaAware: true }),
       link: link(this.config.link),
+      person_variable,
     },
     marks: {
       em,
@@ -185,6 +188,7 @@ export default class RegulatoryStatementsRoute extends Controller {
         inline_rdfa: inlineRdfaWithConfigView({ rdfaAware: true })(controller),
         snippet_placeholder: snippetPlaceholderView(controller),
         snippet: snippetView(this.config.snippet)(controller),
+        person_variable: personVariableView(controller),
       };
     };
   }
@@ -273,6 +277,9 @@ export default class RegulatoryStatementsRoute extends Controller {
           'https://publicatie.gelinkt-notuleren.vlaanderen.be/id/plaats/',
         defaultAddressUriRoot:
           'https://publicatie.gelinkt-notuleren.vlaanderen.be/id/adres/',
+      },
+      lmb: {
+        endpoint: '/vendor-proxy/query',
       },
     };
   }

--- a/app/templates/agendapoints/edit.hbs
+++ b/app/templates/agendapoints/edit.hbs
@@ -154,6 +154,10 @@
         @controller={{this.controller}}
         @config={{this.config.lpdc}}
       />
+      <LmbPlugin::Insert
+        @controller={{this.controller}}
+        @config={{this.config.lmb}}
+      />
     </:sidebarCollapsible>
     <:sidebar>
       <this.StructureControlCard @controller={{this.controller}} />
@@ -175,6 +179,10 @@
       <VariablePlugin::Location::Edit
         @controller={{this.controller}}
         @options={{this.locationEditOptions}}
+      />
+      <VariablePlugin::Person::Edit
+        @controller={{this.controller}}
+        @config={{this.config.lmb}}
       />
       <TemplateCommentsPlugin::EditCard @controller={{this.controller}} />
     </:sidebar>

--- a/app/templates/regulatory-statements/edit.hbs
+++ b/app/templates/regulatory-statements/edit.hbs
@@ -152,6 +152,10 @@
         @controller={{this.controller}}
         @config={{this.config.worship}}
       />
+      <LmbPlugin::Insert
+        @controller={{this.controller}}
+        @config={{this.config.lmb}}
+      />
     </:sidebarCollapsible>
     <:sidebar>
       <ArticleStructurePlugin::StructureCard
@@ -174,6 +178,10 @@
       <VariablePlugin::Location::Edit
         @controller={{this.controller}}
         @options={{this.locationEditOptions}}
+      />
+      <VariablePlugin::Person::Edit
+        @controller={{this.controller}}
+        @config={{this.config.lmb}}
       />
       <TemplateCommentsPlugin::EditCard @controller={{this.controller}} />
     </:sidebar>


### PR DESCRIPTION
### Overview
Implement the person variable in GN

##### connected issues and PRs:
GN-4978 and GN-4876


### Setup
If testing with local backend, you must make sure you have the vendor proxy service correctly configured

### How to test/reproduce
Go to Agendapoints and click on "Insert mandatee from LMB service", and after checking that that works insert a RS template with a person variable 

### Challenges/uncertainties
None



### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
