### PR TITLE
date-picker: drop `keyboardInstruction` setting

### DIFF
--- a/.changeset/chilly-candles-mix.md
+++ b/.changeset/chilly-candles-mix.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Drop the redundant `keyboardInstruction` setting of date-picker, as the date-picker now uses a table element, which screen readers already know how to handle.

--- a/app/components/date-time-picker.js
+++ b/app/components/date-time-picker.js
@@ -26,7 +26,6 @@ export default class DateTimePicker extends Component {
       monthSelectLabel: this.intl.t('au-date-picker.month-select-label'),
       yearSelectLabel: this.intl.t('au-date-picker.year-select-label'),
       closeLabel: this.intl.t('au-date-picker.close-label'),
-      keyboardInstruction: this.intl.t('au-date-picker.keyboard-instruction'),
       calendarHeading: this.intl.t('au-date-picker.calendar-heading'),
       dayNames: getLocalizedDays(this.intl),
       monthNames: getLocalizedMonths(this.intl),

--- a/translations/appuniversum/en-us.yaml
+++ b/translations/appuniversum/en-us.yaml
@@ -6,6 +6,5 @@ au-date-picker:
   month-select-label: 'Month'
   year-select-label: 'Year'
   close-label: 'Close windows'
-  keyboard-instruction: 'You can use arrow keys to navigate dates'
   calendar-heading: 'Choose a date'
   placeholder: 'DD-MM-YYYY'


### PR DESCRIPTION
### Overview
Since version 1.4.0, [duet-date-picker](https://github.com/duetds/date-picker) uses basic tables to represent the dropdown calendar. Since screen readers already know how to navigate html tables, the custom `keyboardInstruction` approach/message is now redundant. See https://github.com/duetds/date-picker/pull/87 for more info.

### How to test/reproduce
- Open the app
- Open a page where the date picker is used
- Notice that the calendar used by the date picker is implemented using a basic table

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
