### PR TITLE
GN-5000: adjust rdfa-annotation stylesheets to also include full URIs

### DIFF
--- a/.changeset/dry-lions-smell.md
+++ b/.changeset/dry-lions-smell.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Adjust rdfa-annotation stylesheets to also match full URIs instead of only prefixed ones

--- a/app/styles/project/_c-editor-preview.scss
+++ b/app/styles/project/_c-editor-preview.scss
@@ -29,7 +29,8 @@
   [property='besluit:geplandOpenbaar'],
   [property='http://data.vlaanderen.be/ns/besluit#geplandOpenbaar'],
   [property='besluit:openbaar'],
-  [property='http://data.vlaanderen.be/ns/besluit#openbaar']  {
+  [property='http://data.vlaanderen.be/ns/besluit#openbaar']
+  {
     @include au-font-size($au-h6);
     color: $au-gray-600;
     text-transform: initial;
@@ -44,7 +45,8 @@
   [property='besluit:heeftAgendapunt'],
   [property='http://data.vlaanderen.be/ns/besluit#heeftAgendapunt'],
   [typeof='besluit:Agendapunt'],
-  [typeof='http://data.vlaanderen.be/ns/besluit#Agendapunt'] {
+  [typeof='http://data.vlaanderen.be/ns/besluit#Agendapunt']
+  {
     [property='besluit:geplandOpenbaar'] i,
     [property='http://data.vlaanderen.be/ns/besluit#geplandOpenbaar'] i,
     [property='besluit:geplandOpenbaar'] em,
@@ -52,7 +54,8 @@
     [property='besluit:openbaar'] i,
     [property='http://data.vlaanderen.be/ns/besluit#openbaar'] i,
     [property='besluit:openbaar'] em,
-    [property='http://data.vlaanderen.be/ns/besluit#openbaar'] em {
+    [property='http://data.vlaanderen.be/ns/besluit#openbaar'] em
+    {
       display: none;
     }
   }
@@ -118,7 +121,8 @@
   [property='eli:description'],
   [property='http://data.europa.eu/eli/ontology#description'],
   [property='besluit:openbaar'],
-  [property='http://data.vlaanderen.be/ns/besluit#openbaar'] {
+  [property='http://data.vlaanderen.be/ns/besluit#openbaar']
+  {
     position: relative;
     background-color: rgba($au-blue-700, 0.2);
     box-shadow: inset -4px 0 0 0 $au-blue-700;

--- a/app/styles/project/_c-editor-preview.scss
+++ b/app/styles/project/_c-editor-preview.scss
@@ -27,7 +27,9 @@
 .au-c-rdfa-publication {
   // Labels
   [property='besluit:geplandOpenbaar'],
-  [property='besluit:openbaar'] {
+  [property='http://data.vlaanderen.be/ns/besluit#geplandOpenbaar'],
+  [property='besluit:openbaar'],
+  [property='http://data.vlaanderen.be/ns/besluit#openbaar']  {
     @include au-font-size($au-h6);
     color: $au-gray-600;
     text-transform: initial;
@@ -36,13 +38,21 @@
 
   // Hide webuniversum icons
   [typeof='besluit:BehandelingVanAgendapunt'],
+  [typeof='http://data.vlaanderen.be/ns/besluit#BehandelingVanAgendapunt']
   [property='ext:behandelt'],
+  [property='http://mu.semte.ch/vocabularies/ext/behandelt'],
   [property='besluit:heeftAgendapunt'],
-  [typeof='besluit:Agendapunt'] {
+  [property='http://data.vlaanderen.be/ns/besluit#heeftAgendapunt'],
+  [typeof='besluit:Agendapunt'],
+  [typeof='http://data.vlaanderen.be/ns/besluit#Agendapunt'] {
     [property='besluit:geplandOpenbaar'] i,
+    [property='http://data.vlaanderen.be/ns/besluit#geplandOpenbaar'] i,
     [property='besluit:geplandOpenbaar'] em,
+    [property='http://data.vlaanderen.be/ns/besluit#geplandOpenbaar'] em,
     [property='besluit:openbaar'] i,
-    [property='besluit:openbaar'] em {
+    [property='http://data.vlaanderen.be/ns/besluit#openbaar'] i,
+    [property='besluit:openbaar'] em,
+    [property='http://data.vlaanderen.be/ns/besluit#openbaar'] em {
       display: none;
     }
   }
@@ -64,19 +74,24 @@
     padding-right: 11.4rem;
 
     [property='dc:subject'],
+    [property='http://purl.org/dc/elements/1.1/subject'],
     [property='eli:title'],
+    [property='http://data.europa.eu/eli/ontology#title'],
     [property='eli:description'],
+    [property='http://data.europa.eu/eli/ontology#description'],
     [property='besluit:openbaar'],
+    [property='http://data.vlaanderen.be/ns/besluit#openbaar'],
     div[property^='ext:insert'],
     div[property^='ext:insert'],
     [data-flagged-remove='complete'],
     [data-flagged-remove='complete'] {
       margin-top: 0.5rem;
 
-      &:after {
+      &::after {
         @include au-font-size($au-base, 1);
         position: absolute;
         right: -11.5rem;
+        top: 0rem;
         width: 9rem;
         font-size: 1.3rem;
         text-transform: uppercase;
@@ -97,9 +112,13 @@
   }
 
   [property='dc:subject'],
+  [property='http://purl.org/dc/elements/1.1/subject'],
   [property='eli:title'],
+  [property='http://data.europa.eu/eli/ontology#title'],
   [property='eli:description'],
-  [property='besluit:openbaar'] {
+  [property='http://data.europa.eu/eli/ontology#description'],
+  [property='besluit:openbaar'],
+  [property='http://data.vlaanderen.be/ns/besluit#openbaar'] {
     position: relative;
     background-color: rgba($au-blue-700, 0.2);
     box-shadow: inset -4px 0 0 0 $au-blue-700;

--- a/app/styles/project/_c-template.scss
+++ b/app/styles/project/_c-template.scss
@@ -122,7 +122,8 @@
   [property='besluit:geplandOpenbaar'],
   [property='http://data.vlaanderen.be/ns/besluit#geplandOpenbaar'],
   [property='besluit:openbaar'],
-  [property='http://data.vlaanderen.be/ns/besluit#openbaar'] {
+  [property='http://data.vlaanderen.be/ns/besluit#openbaar']
+  {
     @include au-font-size($au-h6, $important: true);
     color: $au-gray-600 !important;
     text-transform: initial !important;
@@ -136,7 +137,8 @@
   [property='besluit:heeftAgendapunt'],
   [property='http://data.vlaanderen.be/ns/besluit#heeftAgendapunt'],
   [typeof='besluit:Agendapunt'],
-  [typeof='http://data.vlaanderen.be/ns/besluit#Agendapunt'] {
+  [typeof='http://data.vlaanderen.be/ns/besluit#Agendapunt']
+  {
     display: block !important;
     position: relative;
   }
@@ -145,7 +147,8 @@
   [property='besluit:geplandOpenbaar'],
   [property='http://data.vlaanderen.be/ns/besluit#geplandOpenbaar'],
   [property='besluit:openbaar'],
-  [property='http://data.vlaanderen.be/ns/besluit#openbaar'] {
+  [property='http://data.vlaanderen.be/ns/besluit#openbaar']
+  {
     &:before {
       content: '' !important;
       color: $au-gray-600 !important;
@@ -197,7 +200,8 @@
   }
 
   [property='besluit:heeftAanwezige'],
-  [property='http://data.vlaanderen.be/ns/besluit#heeftAanwezige'] {
+  [property='http://data.vlaanderen.be/ns/besluit#heeftAanwezige']
+  {
     display: block;
     margin-bottom: $au-unit-small;
   }
@@ -222,7 +226,8 @@
   }
 
   [typeof='besluit:BehandelingVanAgendapunt'],
-  [typeof='http://data.vlaanderen.be/ns/besluit#BehandelingVanAgendapunt'] {
+  [typeof='http://data.vlaanderen.be/ns/besluit#BehandelingVanAgendapunt']
+  {
     margin-top: $au-unit;
     padding-top: $au-unit;
     border-top: 0.1rem dotted $au-gray-300;
@@ -232,7 +237,8 @@
     }
 
     [property='besluit:openbaar'],
-    [property='http://data.vlaanderen.be/ns/besluit#openbaar'] {
+    [property='http://data.vlaanderen.be/ns/besluit#openbaar']
+    {
       &:after {
         position: relative;
         left: 0;
@@ -254,7 +260,8 @@
           content: 'Openbare behandeling van agendapunt';
         }
       }
-      &[content='true']:before,&[content='false']:before{
+      &[content='true']:before,
+      &[content='false']:before {
         display: inline-block;
         content: '';
         width: 18px;
@@ -283,15 +290,18 @@
   }
 
   [typeof='besluit:Zitting'],
-  [typeof='http://data.vlaanderen.be/ns/besluit#Zitting'] {
+  [typeof='http://data.vlaanderen.be/ns/besluit#Zitting']
+  {
     > [property='dc:title'],
-    > [property='http://purl.org/dc/elements/1.1/title'] {
+    > [property='http://purl.org/dc/elements/1.1/title']
+    {
       margin-bottom: $au-unit;
     }
   }
 
   [property='dc:subject'],
-  [property='http://purl.org/dc/elements/1.1/subject'] {
+  [property='http://purl.org/dc/elements/1.1/subject']
+  {
     @include au-font-size(var(--au-h6));
     color: $au-gray-600;
     text-transform: initial;
@@ -304,14 +314,14 @@
   }
 
   [property='ext:agendapuntenTable'],
-  [property='http://mu.semte.ch/vocabularies/ext/agendapuntenTable'] {
+  [property='http://mu.semte.ch/vocabularies/ext/agendapuntenTable']
+  {
     [property='besluit:heeftAgendapunt'],
-    [property='http://data.vlaanderen.be/ns/besluit#heeftAgendapunt'] {
-        display: block;
-      }
+    [property='http://data.vlaanderen.be/ns/besluit#heeftAgendapunt']
+    {
+      display: block;
+    }
   }
-
-
 }
 
 // List
@@ -365,15 +375,16 @@
   }
 
   [property='mandaat:isBestuurlijkeAliasVan'],
-  [property='http://data.vlaanderen.be/ns/mandaat#isBestuurlijkeAliasVan'] {
+  [property='http://data.vlaanderen.be/ns/mandaat#isBestuurlijkeAliasVan']
+  {
     &:before {
       display: none !important;
     }
-
   }
 
   &[property='besluit:heeftAanwezige'],
-  &[property='http://data.vlaanderen.be/ns/besluit#heeftAanwezige'] {
+  &[property='http://data.vlaanderen.be/ns/besluit#heeftAanwezige']
+  {
     margin-right: $au-unit-tiny !important;
   }
 }
@@ -394,7 +405,8 @@
 [property='besluit:geplandOpenbaar'],
 [property='http://data.vlaanderen.be/ns/besluit#geplandOpenbaar'],
 [property='besluit:openbaar'],
-[property='http://data.vlaanderen.be/ns/besluit#openbaar'] {
+[property='http://data.vlaanderen.be/ns/besluit#openbaar']
+{
   @include au-font-size($au-h6);
   color: $au-gray-600;
   text-transform: initial;
@@ -417,7 +429,8 @@
 [property='besluit:geplandOpenbaar'],
 [property='http://data.vlaanderen.be/ns/besluit#geplandOpenbaar'],
 [property='besluit:openbaar'],
-[property='http://data.vlaanderen.be/ns/besluit#openbaar'] {
+[property='http://data.vlaanderen.be/ns/besluit#openbaar']
+{
   .au-c-template-public,
   .au-c-template-private {
     &:before {
@@ -430,7 +443,8 @@
 [property='besluit:geplandOpenbaar'][content='true'],
 [property='http://data.vlaanderen.be/ns/besluit#geplandOpenbaar'][content='true'],
 [property='besluit:openbaar'][content='true'],
-[property='http://data.vlaanderen.be/ns/besluit#openbaar'][content='true'] {
+[property='http://data.vlaanderen.be/ns/besluit#openbaar'][content='true']
+{
   &:before {
     background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8cGF0aCBmaWxsPSIjNjk3MTdDIiBkPSJNMTIsNSBDMTUuOTA0LDUgMTkuNzM2LDcuMjM2IDIxLjg5NCwxMS41NTMgQzIyLjAzNDYyMTQsMTEuODM0NDEwOCAyMi4wMzQ2MjE0LDEyLjE2NTU4OTIgMjEuODk0LDEyLjQ0NyBDMTkuNzM2LDE2Ljc2NCAxNS45MDMsMTkgMTIsMTkgQzguMDk2LDE5IDQuMjY0LDE2Ljc2NCAyLjEwNiwxMi40NDcgQzEuOTY1Mzc4NjEsMTIuMTY1NTg5MiAxLjk2NTM3ODYxLDExLjgzNDQxMDggMi4xMDYsMTEuNTUzIEM0LjI2NCw3LjIzNiA4LjA5Nyw1IDEyLDUgWiBNMTIsNyBDOS4wMyw3IDUuOTk4LDguNjIgNC4xMywxMiBDNS45OTgsMTUuMzggOS4wMzEsMTcgMTIsMTcgQzE0Ljk2OSwxNyAxOC4wMDIsMTUuMzggMTkuODcsMTIgQzE4LjAwMiw4LjYyIDE0Ljk2OSw3IDEyLDcgWiBNMTIsOSBDMTMuNjU2ODU0Miw5IDE1LDEwLjM0MzE0NTggMTUsMTIgQzE1LDEzLjY1Njg1NDIgMTMuNjU2ODU0MiwxNSAxMiwxNSBDMTAuMzQzMTQ1OCwxNSA5LDEzLjY1Njg1NDIgOSwxMiBDOSwxMC4zNDMxNDU4IDEwLjM0MzE0NTgsOSAxMiw5IFoiLz4KPC9zdmc+Cg==');
   }
@@ -440,7 +454,8 @@
 [property='besluit:geplandOpenbaar'][content='false'],
 [property='http://data.vlaanderen.be/ns/besluit#geplandOpenbaar'][content='false'],
 [property='besluit:openbaar'][content='false'],
-[property='http://data.vlaanderen.be/ns/besluit#openbaar'][content='false'] {
+[property='http://data.vlaanderen.be/ns/besluit#openbaar'][content='false']
+{
   &:before {
     background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8cGF0aCBmaWxsPSIjNjk3MTdDIiBkPSJNNC43MDcsMy4yOTMgQzQuMzE0NjIxMTEsMi45MTQwMjc3OSAzLjY5MDkxNTIyLDIuOTE5NDQ3NjMgMy4zMDUxODE0MiwzLjMwNTE4MTQyIEMyLjkxOTQ0NzYzLDMuNjkwOTE1MjIgMi45MTQwMjc3OSw0LjMxNDYyMTExIDMuMjkzLDQuNzA3IEw1LjcxNyw3LjEzMSBDNC4yODcsOC4yMDcgMy4wMzksOS42ODUgMi4xMDYsMTEuNTUzIEMxLjk2NTM3ODYxLDExLjgzNDQxMDggMS45NjUzNzg2MSwxMi4xNjU1ODkyIDIuMTA2LDEyLjQ0NyBDNC4yNjQsMTYuNzY0IDguMDk2LDE5IDEyLDE5IEMxMy41NTUsMTkgMTUuMSwxOC42NDUgMTYuNTMsMTcuOTQ1IEwxOS4yOTMsMjAuNzA3IEMxOS42ODUzNzg5LDIxLjA4NTk3MjIgMjAuMzA5MDg0OCwyMS4wODA1NTI0IDIwLjY5NDgxODYsMjAuNjk0ODE4NiBDMjEuMDgwNTUyNCwyMC4zMDkwODQ4IDIxLjA4NTk3MjIsMTkuNjg1Mzc4OSAyMC43MDcsMTkuMjkzIEw0LjcwNywzLjI5MyBaIE0xNS4wMTQsMTYuNDI4IEMxNC4wMzQsMTYuODExIDEzLjAxNCwxNyAxMiwxNyBDOS4wMzEsMTcgNS45OTgsMTUuMzggNC4xMywxMiBDNC45NDcsMTAuNTIxIDUuOTg4LDkuMzggNy4xNDgsOC41NjMgTDkuMjkyLDEwLjcwNyBDOC43NDI5NDU1OCwxMS44NTQ1NDA3IDguOTc3MzQwMDUsMTMuMjIzNTk4OCA5Ljg3Njg3MDYzLDE0LjEyMzEyOTQgQzEwLjc3NjQwMTIsMTUuMDIyNjU5OSAxMi4xNDU0NTkzLDE1LjI1NzA1NDQgMTMuMjkzLDE0LjcwOCBMMTUuMDEzLDE2LjQyOCBMMTUuMDE0LDE2LjQyOCBaIE0xOC41NTIsMTMuODk2IEMxOS4wMzUsMTMuMzQgMTkuNDc4LDEyLjcwOSAxOS44NywxMiBDMTguMDAyLDguNjIgMTQuOTcsNyAxMiw3IEMxMS44ODgsNyAxMS43NzYsNy4wMDIgMTEuNjY0LDcuMDA3IEw5Ljg3OSw1LjIyMyBDMTAuNTc2MjgyNCw1LjA3NDg2NDI4IDExLjI4NzE1NTcsNS4wMDAxMjM3MSAxMiw1IEMxNS45MDMsNSAxOS43MzYsNy4yMzYgMjEuODk0LDExLjU1MyBDMjIuMDM0NjIxNCwxMS44MzQ0MTA4IDIyLjAzNDYyMTQsMTIuMTY1NTg5MiAyMS44OTQsMTIuNDQ3IEMyMS4zODE0NDU1LDEzLjQ4MjY4OTEgMjAuNzM0MTY2NywxNC40NDYwNDE2IDE5Ljk2OSwxNS4zMTIgTDE4LjU1MiwxMy44OTYgTDE4LjU1MiwxMy44OTYgWiIvPgo8L3N2Zz4K');
   }

--- a/app/styles/project/_c-template.scss
+++ b/app/styles/project/_c-template.scss
@@ -120,7 +120,9 @@
 
   // Labels
   [property='besluit:geplandOpenbaar'],
-  [property='besluit:openbaar'] {
+  [property='http://data.vlaanderen.be/ns/besluit#geplandOpenbaar'],
+  [property='besluit:openbaar'],
+  [property='http://data.vlaanderen.be/ns/besluit#openbaar'] {
     @include au-font-size($au-h6, $important: true);
     color: $au-gray-600 !important;
     text-transform: initial !important;
@@ -128,31 +130,39 @@
   }
 
   [typeof='besluit:BehandelingVanAgendapunt'],
+  [typeof='http://data.vlaanderen.be/ns/besluit#BehandelingVanAgendapunt'],
   [property='ext:behandelt'],
+  [property='http://mu.semte.ch/vocabularies/ext/behandelt'],
   [property='besluit:heeftAgendapunt'],
-  [typeof='besluit:Agendapunt'] {
+  [property='http://data.vlaanderen.be/ns/besluit#heeftAgendapunt'],
+  [typeof='besluit:Agendapunt'],
+  [typeof='http://data.vlaanderen.be/ns/besluit#Agendapunt'] {
     display: block !important;
     position: relative;
   }
 
   // Fix overlapping text
-  [property='besluit:geplandOpenbaar']:before,
-  [property='besluit:openbaar']:before {
-    content: '' !important;
-    color: $au-gray-600 !important;
-  }
+  [property='besluit:geplandOpenbaar'],
+  [property='http://data.vlaanderen.be/ns/besluit#geplandOpenbaar'],
+  [property='besluit:openbaar'],
+  [property='http://data.vlaanderen.be/ns/besluit#openbaar'] {
+    &:before {
+      content: '' !important;
+      color: $au-gray-600 !important;
+    }
 
-  [property='besluit:geplandOpenbaar'][content='false']:before,
-  [property='besluit:openbaar'][content='false']:before {
-    content: '' !important;
-    color: $au-gray-600 !important;
-  }
+    &[content='false']:before {
+      content: '' !important;
+      color: $au-gray-600 !important;
+    }
 
-  [property='besluit:geplandOpenbaar']:after,
-  [property='besluit:openbaar']:after,
-  [property='besluit:geplandOpenbaar'][content='false']:after,
-  [property='besluit:openbaar'][content='false']:after {
-    color: $au-gray-600 !important;
+    &:after {
+      color: $au-gray-600 !important;
+    }
+
+    &[content='false']:after {
+      color: $au-gray-600 !important;
+    }
   }
   // End fix overlapping text
 }
@@ -186,7 +196,8 @@
     color: var(--au-gray-900);
   }
 
-  [property='besluit:heeftAanwezige'] {
+  [property='besluit:heeftAanwezige'],
+  [property='http://data.vlaanderen.be/ns/besluit#heeftAanwezige'] {
     display: block;
     margin-bottom: $au-unit-small;
   }
@@ -210,7 +221,8 @@
     font-weight: $au-medium !important;
   }
 
-  [typeof='besluit:BehandelingVanAgendapunt'] {
+  [typeof='besluit:BehandelingVanAgendapunt'],
+  [typeof='http://data.vlaanderen.be/ns/besluit#BehandelingVanAgendapunt'] {
     margin-top: $au-unit;
     padding-top: $au-unit;
     border-top: 0.1rem dotted $au-gray-300;
@@ -219,39 +231,40 @@
       @include au-font-size($au-h5, $important: true);
     }
 
-    [property='besluit:openbaar']:after {
-      position: relative;
-      left: 0;
-      width: auto;
-    }
-
-    [property='besluit:openbaar'][content='false']:after {
-      content: 'Besloten behandeling van agendapunt';
-    }
-
-    [property='besluit:openbaar'][content='true']:after {
-      content: 'Openbare behandeling van agendapunt';
-    }
-
-    [property='besluit:openbaar'][content='false']:before,
-    [property='besluit:openbaar'][content='true']:before {
-      display: inline-block;
-      content: '';
-      width: 18px;
-      height: 18px;
-      background-size: 100%;
-      margin-right: 0.3rem;
-      vertical-align: middle;
-      position: relative;
-      bottom: 0.2ex;
-    }
-
-    [property='besluit:openbaar'][content='false']:before {
-      background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8cGF0aCBmaWxsPSIjNjk3MTdDIiBkPSJNNC43MDcsMy4yOTMgQzQuMzE0NjIxMTEsMi45MTQwMjc3OSAzLjY5MDkxNTIyLDIuOTE5NDQ3NjMgMy4zMDUxODE0MiwzLjMwNTE4MTQyIEMyLjkxOTQ0NzYzLDMuNjkwOTE1MjIgMi45MTQwMjc3OSw0LjMxNDYyMTExIDMuMjkzLDQuNzA3IEw1LjcxNyw3LjEzMSBDNC4yODcsOC4yMDcgMy4wMzksOS42ODUgMi4xMDYsMTEuNTUzIEMxLjk2NTM3ODYxLDExLjgzNDQxMDggMS45NjUzNzg2MSwxMi4xNjU1ODkyIDIuMTA2LDEyLjQ0NyBDNC4yNjQsMTYuNzY0IDguMDk2LDE5IDEyLDE5IEMxMy41NTUsMTkgMTUuMSwxOC42NDUgMTYuNTMsMTcuOTQ1IEwxOS4yOTMsMjAuNzA3IEMxOS42ODUzNzg5LDIxLjA4NTk3MjIgMjAuMzA5MDg0OCwyMS4wODA1NTI0IDIwLjY5NDgxODYsMjAuNjk0ODE4NiBDMjEuMDgwNTUyNCwyMC4zMDkwODQ4IDIxLjA4NTk3MjIsMTkuNjg1Mzc4OSAyMC43MDcsMTkuMjkzIEw0LjcwNywzLjI5MyBaIE0xNS4wMTQsMTYuNDI4IEMxNC4wMzQsMTYuODExIDEzLjAxNCwxNyAxMiwxNyBDOS4wMzEsMTcgNS45OTgsMTUuMzggNC4xMywxMiBDNC45NDcsMTAuNTIxIDUuOTg4LDkuMzggNy4xNDgsOC41NjMgTDkuMjkyLDEwLjcwNyBDOC43NDI5NDU1OCwxMS44NTQ1NDA3IDguOTc3MzQwMDUsMTMuMjIzNTk4OCA5Ljg3Njg3MDYzLDE0LjEyMzEyOTQgQzEwLjc3NjQwMTIsMTUuMDIyNjU5OSAxMi4xNDU0NTkzLDE1LjI1NzA1NDQgMTMuMjkzLDE0LjcwOCBMMTUuMDEzLDE2LjQyOCBMMTUuMDE0LDE2LjQyOCBaIE0xOC41NTIsMTMuODk2IEMxOS4wMzUsMTMuMzQgMTkuNDc4LDEyLjcwOSAxOS44NywxMiBDMTguMDAyLDguNjIgMTQuOTcsNyAxMiw3IEMxMS44ODgsNyAxMS43NzYsNy4wMDIgMTEuNjY0LDcuMDA3IEw5Ljg3OSw1LjIyMyBDMTAuNTc2MjgyNCw1LjA3NDg2NDI4IDExLjI4NzE1NTcsNS4wMDAxMjM3MSAxMiw1IEMxNS45MDMsNSAxOS43MzYsNy4yMzYgMjEuODk0LDExLjU1MyBDMjIuMDM0NjIxNCwxMS44MzQ0MTA4IDIyLjAzNDYyMTQsMTIuMTY1NTg5MiAyMS44OTQsMTIuNDQ3IEMyMS4zODE0NDU1LDEzLjQ4MjY4OTEgMjAuNzM0MTY2NywxNC40NDYwNDE2IDE5Ljk2OSwxNS4zMTIgTDE4LjU1MiwxMy44OTYgTDE4LjU1MiwxMy44OTYgWiIvPgo8L3N2Zz4K');
-    }
-
-    [property='besluit:openbaar'][content='true']:before {
-      background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8cGF0aCBmaWxsPSIjNjk3MTdDIiBkPSJNMTIsNSBDMTUuOTA0LDUgMTkuNzM2LDcuMjM2IDIxLjg5NCwxMS41NTMgQzIyLjAzNDYyMTQsMTEuODM0NDEwOCAyMi4wMzQ2MjE0LDEyLjE2NTU4OTIgMjEuODk0LDEyLjQ0NyBDMTkuNzM2LDE2Ljc2NCAxNS45MDMsMTkgMTIsMTkgQzguMDk2LDE5IDQuMjY0LDE2Ljc2NCAyLjEwNiwxMi40NDcgQzEuOTY1Mzc4NjEsMTIuMTY1NTg5MiAxLjk2NTM3ODYxLDExLjgzNDQxMDggMi4xMDYsMTEuNTUzIEM0LjI2NCw3LjIzNiA4LjA5Nyw1IDEyLDUgWiBNMTIsNyBDOS4wMyw3IDUuOTk4LDguNjIgNC4xMywxMiBDNS45OTgsMTUuMzggOS4wMzEsMTcgMTIsMTcgQzE0Ljk2OSwxNyAxOC4wMDIsMTUuMzggMTkuODcsMTIgQzE4LjAwMiw4LjYyIDE0Ljk2OSw3IDEyLDcgWiBNMTIsOSBDMTMuNjU2ODU0Miw5IDE1LDEwLjM0MzE0NTggMTUsMTIgQzE1LDEzLjY1Njg1NDIgMTMuNjU2ODU0MiwxNSAxMiwxNSBDMTAuMzQzMTQ1OCwxNSA5LDEzLjY1Njg1NDIgOSwxMiBDOSwxMC4zNDMxNDU4IDEwLjM0MzE0NTgsOSAxMiw5IFoiLz4KPC9zdmc+Cg==');
+    [property='besluit:openbaar'],
+    [property='http://data.vlaanderen.be/ns/besluit#openbaar'] {
+      &:after {
+        position: relative;
+        left: 0;
+        width: auto;
+      }
+      &[content='false'] {
+        &:before {
+          background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8cGF0aCBmaWxsPSIjNjk3MTdDIiBkPSJNNC43MDcsMy4yOTMgQzQuMzE0NjIxMTEsMi45MTQwMjc3OSAzLjY5MDkxNTIyLDIuOTE5NDQ3NjMgMy4zMDUxODE0MiwzLjMwNTE4MTQyIEMyLjkxOTQ0NzYzLDMuNjkwOTE1MjIgMi45MTQwMjc3OSw0LjMxNDYyMTExIDMuMjkzLDQuNzA3IEw1LjcxNyw3LjEzMSBDNC4yODcsOC4yMDcgMy4wMzksOS42ODUgMi4xMDYsMTEuNTUzIEMxLjk2NTM3ODYxLDExLjgzNDQxMDggMS45NjUzNzg2MSwxMi4xNjU1ODkyIDIuMTA2LDEyLjQ0NyBDNC4yNjQsMTYuNzY0IDguMDk2LDE5IDEyLDE5IEMxMy41NTUsMTkgMTUuMSwxOC42NDUgMTYuNTMsMTcuOTQ1IEwxOS4yOTMsMjAuNzA3IEMxOS42ODUzNzg5LDIxLjA4NTk3MjIgMjAuMzA5MDg0OCwyMS4wODA1NTI0IDIwLjY5NDgxODYsMjAuNjk0ODE4NiBDMjEuMDgwNTUyNCwyMC4zMDkwODQ4IDIxLjA4NTk3MjIsMTkuNjg1Mzc4OSAyMC43MDcsMTkuMjkzIEw0LjcwNywzLjI5MyBaIE0xNS4wMTQsMTYuNDI4IEMxNC4wMzQsMTYuODExIDEzLjAxNCwxNyAxMiwxNyBDOS4wMzEsMTcgNS45OTgsMTUuMzggNC4xMywxMiBDNC45NDcsMTAuNTIxIDUuOTg4LDkuMzggNy4xNDgsOC41NjMgTDkuMjkyLDEwLjcwNyBDOC43NDI5NDU1OCwxMS44NTQ1NDA3IDguOTc3MzQwMDUsMTMuMjIzNTk4OCA5Ljg3Njg3MDYzLDE0LjEyMzEyOTQgQzEwLjc3NjQwMTIsMTUuMDIyNjU5OSAxMi4xNDU0NTkzLDE1LjI1NzA1NDQgMTMuMjkzLDE0LjcwOCBMMTUuMDEzLDE2LjQyOCBMMTUuMDE0LDE2LjQyOCBaIE0xOC41NTIsMTMuODk2IEMxOS4wMzUsMTMuMzQgMTkuNDc4LDEyLjcwOSAxOS44NywxMiBDMTguMDAyLDguNjIgMTQuOTcsNyAxMiw3IEMxMS44ODgsNyAxMS43NzYsNy4wMDIgMTEuNjY0LDcuMDA3IEw5Ljg3OSw1LjIyMyBDMTAuNTc2MjgyNCw1LjA3NDg2NDI4IDExLjI4NzE1NTcsNS4wMDAxMjM3MSAxMiw1IEMxNS45MDMsNSAxOS43MzYsNy4yMzYgMjEuODk0LDExLjU1MyBDMjIuMDM0NjIxNCwxMS44MzQ0MTA4IDIyLjAzNDYyMTQsMTIuMTY1NTg5MiAyMS44OTQsMTIuNDQ3IEMyMS4zODE0NDU1LDEzLjQ4MjY4OTEgMjAuNzM0MTY2NywxNC40NDYwNDE2IDE5Ljk2OSwxNS4zMTIgTDE4LjU1MiwxMy44OTYgTDE4LjU1MiwxMy44OTYgWiIvPgo8L3N2Zz4K');
+        }
+        &:after {
+          content: 'Besloten behandeling van agendapunt';
+        }
+      }
+      &[content='true'] {
+        &:before {
+          background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8cGF0aCBmaWxsPSIjNjk3MTdDIiBkPSJNMTIsNSBDMTUuOTA0LDUgMTkuNzM2LDcuMjM2IDIxLjg5NCwxMS41NTMgQzIyLjAzNDYyMTQsMTEuODM0NDEwOCAyMi4wMzQ2MjE0LDEyLjE2NTU4OTIgMjEuODk0LDEyLjQ0NyBDMTkuNzM2LDE2Ljc2NCAxNS45MDMsMTkgMTIsMTkgQzguMDk2LDE5IDQuMjY0LDE2Ljc2NCAyLjEwNiwxMi40NDcgQzEuOTY1Mzc4NjEsMTIuMTY1NTg5MiAxLjk2NTM3ODYxLDExLjgzNDQxMDggMi4xMDYsMTEuNTUzIEM0LjI2NCw3LjIzNiA4LjA5Nyw1IDEyLDUgWiBNMTIsNyBDOS4wMyw3IDUuOTk4LDguNjIgNC4xMywxMiBDNS45OTgsMTUuMzggOS4wMzEsMTcgMTIsMTcgQzE0Ljk2OSwxNyAxOC4wMDIsMTUuMzggMTkuODcsMTIgQzE4LjAwMiw4LjYyIDE0Ljk2OSw3IDEyLDcgWiBNMTIsOSBDMTMuNjU2ODU0Miw5IDE1LDEwLjM0MzE0NTggMTUsMTIgQzE1LDEzLjY1Njg1NDIgMTMuNjU2ODU0MiwxNSAxMiwxNSBDMTAuMzQzMTQ1OCwxNSA5LDEzLjY1Njg1NDIgOSwxMiBDOSwxMC4zNDMxNDU4IDEwLjM0MzE0NTgsOSAxMiw5IFoiLz4KPC9zdmc+Cg==');
+        }
+        &:after {
+          content: 'Openbare behandeling van agendapunt';
+        }
+      }
+      &[content='true']:before,&[content='false']:before{
+        display: inline-block;
+        content: '';
+        width: 18px;
+        height: 18px;
+        background-size: 100%;
+        margin-right: 0.3rem;
+        vertical-align: middle;
+        position: relative;
+        bottom: 0.2ex;
+      }
     }
   }
 }
@@ -269,13 +282,16 @@
     margin-top: $au-unit;
   }
 
-  [typeof='besluit:Zitting'] {
-    > [property='dc:title'] {
+  [typeof='besluit:Zitting'],
+  [typeof='http://data.vlaanderen.be/ns/besluit#Zitting'] {
+    > [property='dc:title'],
+    > [property='http://purl.org/dc/elements/1.1/title'] {
       margin-bottom: $au-unit;
     }
   }
 
-  [property='dc:subject'] {
+  [property='dc:subject'],
+  [property='http://purl.org/dc/elements/1.1/subject'] {
     @include au-font-size(var(--au-h6));
     color: $au-gray-600;
     text-transform: initial;
@@ -287,9 +303,15 @@
     background-color: transparent;
   }
 
-  [property='ext:agendapuntenTable'] [property='besluit:heeftAgendapunt'] {
-    display: block;
+  [property='ext:agendapuntenTable'],
+  [property='http://mu.semte.ch/vocabularies/ext/agendapuntenTable'] {
+    [property='besluit:heeftAgendapunt'],
+    [property='http://data.vlaanderen.be/ns/besluit#heeftAgendapunt'] {
+        display: block;
+      }
   }
+
+
 }
 
 // List
@@ -342,11 +364,16 @@
     content: '';
   }
 
-  [property='mandaat:isBestuurlijkeAliasVan']:before {
-    display: none !important;
+  [property='mandaat:isBestuurlijkeAliasVan'],
+  [property='http://data.vlaanderen.be/ns/mandaat#isBestuurlijkeAliasVan'] {
+    &:before {
+      display: none !important;
+    }
+
   }
 
-  &[property='besluit:heeftAanwezige'] {
+  &[property='besluit:heeftAanwezige'],
+  &[property='http://data.vlaanderen.be/ns/besluit#heeftAanwezige'] {
     margin-right: $au-unit-tiny !important;
   }
 }
@@ -365,7 +392,9 @@
 .au-c-template-public,
 .au-c-template-private,
 [property='besluit:geplandOpenbaar'],
-[property='besluit:openbaar'] {
+[property='http://data.vlaanderen.be/ns/besluit#geplandOpenbaar'],
+[property='besluit:openbaar'],
+[property='http://data.vlaanderen.be/ns/besluit#openbaar'] {
   @include au-font-size($au-h6);
   color: $au-gray-600;
   text-transform: initial;
@@ -385,18 +414,23 @@
   }
 }
 
-[property='besluit:geplandOpenbaar'] .au-c-template-public,
-[property='besluit:geplandOpenbaar'] .au-c-template-private,
-[property='besluit:openbaar'] .au-c-template-public,
-[property='besluit:openbaar'] .au-c-template-private {
-  &:before {
-    display: none !important;
+[property='besluit:geplandOpenbaar'],
+[property='http://data.vlaanderen.be/ns/besluit#geplandOpenbaar'],
+[property='besluit:openbaar'],
+[property='http://data.vlaanderen.be/ns/besluit#openbaar'] {
+  .au-c-template-public,
+  .au-c-template-private {
+    &:before {
+      display: none !important;
+    }
   }
 }
 
 .au-c-template-public,
 [property='besluit:geplandOpenbaar'][content='true'],
-[property='besluit:openbaar'][content='true'] {
+[property='http://data.vlaanderen.be/ns/besluit#geplandOpenbaar'][content='true'],
+[property='besluit:openbaar'][content='true'],
+[property='http://data.vlaanderen.be/ns/besluit#openbaar'][content='true'] {
   &:before {
     background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8cGF0aCBmaWxsPSIjNjk3MTdDIiBkPSJNMTIsNSBDMTUuOTA0LDUgMTkuNzM2LDcuMjM2IDIxLjg5NCwxMS41NTMgQzIyLjAzNDYyMTQsMTEuODM0NDEwOCAyMi4wMzQ2MjE0LDEyLjE2NTU4OTIgMjEuODk0LDEyLjQ0NyBDMTkuNzM2LDE2Ljc2NCAxNS45MDMsMTkgMTIsMTkgQzguMDk2LDE5IDQuMjY0LDE2Ljc2NCAyLjEwNiwxMi40NDcgQzEuOTY1Mzc4NjEsMTIuMTY1NTg5MiAxLjk2NTM3ODYxLDExLjgzNDQxMDggMi4xMDYsMTEuNTUzIEM0LjI2NCw3LjIzNiA4LjA5Nyw1IDEyLDUgWiBNMTIsNyBDOS4wMyw3IDUuOTk4LDguNjIgNC4xMywxMiBDNS45OTgsMTUuMzggOS4wMzEsMTcgMTIsMTcgQzE0Ljk2OSwxNyAxOC4wMDIsMTUuMzggMTkuODcsMTIgQzE4LjAwMiw4LjYyIDE0Ljk2OSw3IDEyLDcgWiBNMTIsOSBDMTMuNjU2ODU0Miw5IDE1LDEwLjM0MzE0NTggMTUsMTIgQzE1LDEzLjY1Njg1NDIgMTMuNjU2ODU0MiwxNSAxMiwxNSBDMTAuMzQzMTQ1OCwxNSA5LDEzLjY1Njg1NDIgOSwxMiBDOSwxMC4zNDMxNDU4IDEwLjM0MzE0NTgsOSAxMiw5IFoiLz4KPC9zdmc+Cg==');
   }
@@ -404,7 +438,9 @@
 
 .au-c-template-private,
 [property='besluit:geplandOpenbaar'][content='false'],
-[property='besluit:openbaar'][content='false'] {
+[property='http://data.vlaanderen.be/ns/besluit#geplandOpenbaar'][content='false'],
+[property='besluit:openbaar'][content='false'],
+[property='http://data.vlaanderen.be/ns/besluit#openbaar'][content='false'] {
   &:before {
     background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8cGF0aCBmaWxsPSIjNjk3MTdDIiBkPSJNNC43MDcsMy4yOTMgQzQuMzE0NjIxMTEsMi45MTQwMjc3OSAzLjY5MDkxNTIyLDIuOTE5NDQ3NjMgMy4zMDUxODE0MiwzLjMwNTE4MTQyIEMyLjkxOTQ0NzYzLDMuNjkwOTE1MjIgMi45MTQwMjc3OSw0LjMxNDYyMTExIDMuMjkzLDQuNzA3IEw1LjcxNyw3LjEzMSBDNC4yODcsOC4yMDcgMy4wMzksOS42ODUgMi4xMDYsMTEuNTUzIEMxLjk2NTM3ODYxLDExLjgzNDQxMDggMS45NjUzNzg2MSwxMi4xNjU1ODkyIDIuMTA2LDEyLjQ0NyBDNC4yNjQsMTYuNzY0IDguMDk2LDE5IDEyLDE5IEMxMy41NTUsMTkgMTUuMSwxOC42NDUgMTYuNTMsMTcuOTQ1IEwxOS4yOTMsMjAuNzA3IEMxOS42ODUzNzg5LDIxLjA4NTk3MjIgMjAuMzA5MDg0OCwyMS4wODA1NTI0IDIwLjY5NDgxODYsMjAuNjk0ODE4NiBDMjEuMDgwNTUyNCwyMC4zMDkwODQ4IDIxLjA4NTk3MjIsMTkuNjg1Mzc4OSAyMC43MDcsMTkuMjkzIEw0LjcwNywzLjI5MyBaIE0xNS4wMTQsMTYuNDI4IEMxNC4wMzQsMTYuODExIDEzLjAxNCwxNyAxMiwxNyBDOS4wMzEsMTcgNS45OTgsMTUuMzggNC4xMywxMiBDNC45NDcsMTAuNTIxIDUuOTg4LDkuMzggNy4xNDgsOC41NjMgTDkuMjkyLDEwLjcwNyBDOC43NDI5NDU1OCwxMS44NTQ1NDA3IDguOTc3MzQwMDUsMTMuMjIzNTk4OCA5Ljg3Njg3MDYzLDE0LjEyMzEyOTQgQzEwLjc3NjQwMTIsMTUuMDIyNjU5OSAxMi4xNDU0NTkzLDE1LjI1NzA1NDQgMTMuMjkzLDE0LjcwOCBMMTUuMDEzLDE2LjQyOCBMMTUuMDE0LDE2LjQyOCBaIE0xOC41NTIsMTMuODk2IEMxOS4wMzUsMTMuMzQgMTkuNDc4LDEyLjcwOSAxOS44NywxMiBDMTguMDAyLDguNjIgMTQuOTcsNyAxMiw3IEMxMS44ODgsNyAxMS43NzYsNy4wMDIgMTEuNjY0LDcuMDA3IEw5Ljg3OSw1LjIyMyBDMTAuNTc2MjgyNCw1LjA3NDg2NDI4IDExLjI4NzE1NTcsNS4wMDAxMjM3MSAxMiw1IEMxNS45MDMsNSAxOS43MzYsNy4yMzYgMjEuODk0LDExLjU1MyBDMjIuMDM0NjIxNCwxMS44MzQ0MTA4IDIyLjAzNDYyMTQsMTIuMTY1NTg5MiAyMS44OTQsMTIuNDQ3IEMyMS4zODE0NDU1LDEzLjQ4MjY4OTEgMjAuNzM0MTY2NywxNC40NDYwNDE2IDE5Ljk2OSwxNS4zMTIgTDE4LjU1MiwxMy44OTYgTDE4LjU1MiwxMy44OTYgWiIvPgo8L3N2Zz4K');
   }

--- a/app/styles/project/_p-annotations.scss
+++ b/app/styles/project/_p-annotations.scss
@@ -16,12 +16,14 @@
   h6,
   .h6,
   [property='dc:title'],
-  [property='http://purl.org/dc/elements/1.1/title'] {
+  [property='http://purl.org/dc/elements/1.1/title']
+  {
     margin-bottom: 0;
   }
 
   [typeof='besluit:Agendapunt'],
-  [typeof='http://data.vlaanderen.be/ns/besluit#Agendapunt'] {
+  [typeof='http://data.vlaanderen.be/ns/besluit#Agendapunt']
+  {
     margin-bottom: $au-unit-small;
   }
 

--- a/app/styles/project/_p-annotations.scss
+++ b/app/styles/project/_p-annotations.scss
@@ -15,11 +15,13 @@
   .h5,
   h6,
   .h6,
-  [property='dc:title'] {
+  [property='dc:title'],
+  [property='http://purl.org/dc/elements/1.1/title'] {
     margin-bottom: 0;
   }
 
-  [typeof='besluit:Agendapunt'] {
+  [typeof='besluit:Agendapunt'],
+  [typeof='http://data.vlaanderen.be/ns/besluit#Agendapunt'] {
     margin-bottom: $au-unit-small;
   }
 

--- a/app/styles/project/_u-print.scss
+++ b/app/styles/project/_u-print.scss
@@ -62,21 +62,21 @@
     display: none !important;
   }
 
-  .au-c-editor-preview-treatment--private
-    .behandeling {
-      [property='dc:subject'],
+  .au-c-editor-preview-treatment--private .behandeling {
+    [property='dc:subject'],
       [property='http://purl.org/dc/elements/1.1/subject'],
       [property='eli:title'],
       [property='http://data.europa.eu/eli/ontology#title'],
       [property='eli:description'],
       [property='http://data.europa.eu/eli/ontology#description'],
       [property='besluit:openbaar'],
-      [property='http://data.vlaanderen.be/ns/besluit#openbaar'] {
-        &::after {
-          display: none !important;
-        }
+      [property='http://data.vlaanderen.be/ns/besluit#openbaar']
+    {
+      &::after {
+        display: none !important;
       }
     }
+  }
 
   a[href]:after {
     word-break: break-all !important;
@@ -474,7 +474,8 @@
   .au-c-template--notes [property='dc:subject'],
   .au-c-template--notes [property='http://purl.org/dc/elements/1.1/subject'],
   .au-c-rdfa-publication .notulen [property='dc:subject'],
-  .au-c-rdfa-publication .notulen [property='http://purl.org/dc/elements/1.1/subject'] {
+  .au-c-rdfa-publication .notulen [property='http://purl.org/dc/elements/1.1/subject']
+  {
     font-size: 16px !important;
   }
 

--- a/app/styles/project/_u-print.scss
+++ b/app/styles/project/_u-print.scss
@@ -54,23 +54,29 @@
   .au-c-template-public::before,
   .au-c-template-private::before,
   [property='besluit:geplandOpenbaar']::before,
+  [property='http://data.vlaanderen.be/ns/besluit#geplandOpenbaar']::before,
   [property='besluit:openbaar']::before,
+  [property='http://data.vlaanderen.be/ns/besluit#openbaar']::before,
   .au-c-card .au-c-badge,
-  .au-c-editor-preview-treatment-toggle-box,
-  .au-c-editor-preview-treatment--private
-    .behandeling
-    [property='dc:subject']::after,
-  .au-c-editor-preview-treatment--private
-    .behandeling
-    [property='eli:title']::after,
-  .au-c-editor-preview-treatment--private
-    .behandeling
-    [property='eli:description']::after,
-  .au-c-editor-preview-treatment--private
-    .behandeling
-    [property='besluit:openbaar']::after {
+  .au-c-editor-preview-treatment-toggle-box {
     display: none !important;
   }
+
+  .au-c-editor-preview-treatment--private
+    .behandeling {
+      [property='dc:subject'],
+      [property='http://purl.org/dc/elements/1.1/subject'],
+      [property='eli:title'],
+      [property='http://data.europa.eu/eli/ontology#title'],
+      [property='eli:description'],
+      [property='http://data.europa.eu/eli/ontology#description'],
+      [property='besluit:openbaar'],
+      [property='http://data.vlaanderen.be/ns/besluit#openbaar'] {
+        &::after {
+          display: none !important;
+        }
+      }
+    }
 
   a[href]:after {
     word-break: break-all !important;
@@ -452,15 +458,23 @@
   }
 
   .au-c-template [property='besluit:geplandOpenbaar'],
+  .au-c-template [property='http://data.vlaanderen.be/ns/besluit#geplandOpenbaar'],
   .au-c-template [property='besluit:openbaar'],
+  .au-c-template [property='http://data.vlaanderen.be/ns/besluit#openbaar'],
   .au-c-editor-preview [property='besluit:geplandOpenbaar'],
+  .au-c-editor-preview [property='http://data.vlaanderen.be/ns/besluit#geplandOpenbaar'],
   .au-c-editor-preview [property='besluit:openbaar'],
+  .au-c-editor-preview [property='http://data.vlaanderen.be/ns/besluit#openbaar'],
   .au-c-template-public,
   .au-c-template-private,
   [property='besluit:geplandOpenbaar'],
+  [property='http://data.vlaanderen.be/ns/besluit#geplandOpenbaar'],
   [property='besluit:openbaar'],
+  [property='http://data.vlaanderen.be/ns/besluit#openbaar'],
   .au-c-template--notes [property='dc:subject'],
-  .au-c-rdfa-publication .notulen [property='dc:subject'] {
+  .au-c-template--notes [property='http://purl.org/dc/elements/1.1/subject'],
+  .au-c-rdfa-publication .notulen [property='dc:subject'],
+  .au-c-rdfa-publication .notulen [property='http://purl.org/dc/elements/1.1/subject'] {
     font-size: 16px !important;
   }
 


### PR DESCRIPTION
### Overview
This PR adjusts the stylesheets of rdfa-annotations to also include full URIs.
Unsure if all these style rules are still needed.
Among others, this fixes the short description of decisions not being marked as public.

Not really proud of this PR :cry:

##### connected issues and PRs:
[GN-5000](https://binnenland.atlassian.net/browse/GN-5000?atlOrigin=eyJpIjoiNGZkZDA3YjMxYjFjNDdjYTk2NTgyYmI5MmFjZTllNWMiLCJwIjoiaiJ9)

### How to test/reproduce
- Start the application
- Open a meeting with agendapoints which contain decisions with descriptions
- Open the publish page with the 'notulen'/'document' tab
- Ensure that the 'short description' parts of the decisions are being marked as public.

### Challenges/uncertainties
As mentioned before, I am unsure if all these css rules are still necessary/used. We should probably prune them one day.
This solution is not ideal, but is what is needed right now to fix prod.



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
