### PR TITLE
GN-4937: add support for snippet previews

### DIFF
--- a/.changeset/three-rice-brake.md
+++ b/.changeset/three-rice-brake.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Update `@lblod/ember-rdfa-editor-lblod-plugins` to version 22.3.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@lblod/ember-environment-banner": "^0.5.0",
         "@lblod/ember-mock-login": "^0.10.0",
         "@lblod/ember-rdfa-editor": "10.1.0",
-        "@lblod/ember-rdfa-editor-lblod-plugins": "22.2.3-dev.806b2598cde7ac68553f1a3fc19a9e8985ec0807",
+        "@lblod/ember-rdfa-editor-lblod-plugins": "22.3.0",
         "@release-it-plugins/lerna-changelog": "^6.0.0",
         "broccoli-asset-rev": "^3.0.0",
         "broccoli-plugin": "^4.0.7",
@@ -4554,9 +4554,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor-lblod-plugins": {
-      "version": "22.2.3-dev.806b2598cde7ac68553f1a3fc19a9e8985ec0807",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-22.2.3-dev.806b2598cde7ac68553f1a3fc19a9e8985ec0807.tgz",
-      "integrity": "sha512-Nw7OWuc8xutlRv4Y7fn24RleEObxLcXyfVUeJNKmRT2Qe3687CT8+E6xGqAm+Zq2X9gfFnmqbClXN7q4U8ko8A==",
+      "version": "22.3.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-22.3.0.tgz",
+      "integrity": "sha512-SsRxwHxsKivNmZGbAmF3+VRiab9bdsrepWsgGC3vVHSktiYMItgJOJs1ia5d3mviMvLD8DCqf5+iCspJBfi1JA==",
       "dev": true,
       "dependencies": {
         "@codemirror/lang-html": "^6.4.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@lblod/ember-environment-banner": "^0.5.0",
         "@lblod/ember-mock-login": "^0.10.0",
         "@lblod/ember-rdfa-editor": "10.1.0",
-        "@lblod/ember-rdfa-editor-lblod-plugins": "22.2.2",
+        "@lblod/ember-rdfa-editor-lblod-plugins": "22.2.3-dev.806b2598cde7ac68553f1a3fc19a9e8985ec0807",
         "@release-it-plugins/lerna-changelog": "^6.0.0",
         "broccoli-asset-rev": "^3.0.0",
         "broccoli-plugin": "^4.0.7",
@@ -4554,9 +4554,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor-lblod-plugins": {
-      "version": "22.2.2",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-22.2.2.tgz",
-      "integrity": "sha512-D3oJbbPYWYHijCyPMmpHs5lwjmUYQ3UINwF+UYsDO+DC3OwQ7RzYM79f3pJasv+A+NoBIiEmRB4BDAAGM1JhGQ==",
+      "version": "22.2.3-dev.806b2598cde7ac68553f1a3fc19a9e8985ec0807",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-22.2.3-dev.806b2598cde7ac68553f1a3fc19a9e8985ec0807.tgz",
+      "integrity": "sha512-Nw7OWuc8xutlRv4Y7fn24RleEObxLcXyfVUeJNKmRT2Qe3687CT8+E6xGqAm+Zq2X9gfFnmqbClXN7q4U8ko8A==",
       "dev": true,
       "dependencies": {
         "@codemirror/lang-html": "^6.4.9",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@lblod/ember-environment-banner": "^0.5.0",
     "@lblod/ember-mock-login": "^0.10.0",
     "@lblod/ember-rdfa-editor": "10.1.0",
-    "@lblod/ember-rdfa-editor-lblod-plugins": "22.2.3-dev.806b2598cde7ac68553f1a3fc19a9e8985ec0807",
+    "@lblod/ember-rdfa-editor-lblod-plugins": "22.3.0",
     "@release-it-plugins/lerna-changelog": "^6.0.0",
     "broccoli-asset-rev": "^3.0.0",
     "broccoli-plugin": "^4.0.7",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@lblod/ember-environment-banner": "^0.5.0",
     "@lblod/ember-mock-login": "^0.10.0",
     "@lblod/ember-rdfa-editor": "10.1.0",
-    "@lblod/ember-rdfa-editor-lblod-plugins": "22.2.2",
+    "@lblod/ember-rdfa-editor-lblod-plugins": "22.2.3-dev.806b2598cde7ac68553f1a3fc19a9e8985ec0807",
     "@release-it-plugins/lerna-changelog": "^6.0.0",
     "broccoli-asset-rev": "^3.0.0",
     "broccoli-plugin": "^4.0.7",


### PR DESCRIPTION
### Overview
This (draft) PR updates the editor-plugins to the dev commit found on https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/468. It implements collapsible snippet previews.

##### connected issues and PRs:
[GN-4937](https://binnenland.atlassian.net/browse/GN-4937?atlOrigin=eyJpIjoiOTg4ZDg4YmU5ZDViNDJhN2E4ZTM2NjBiZjg4MjNjMzUiLCJwIjoiaiJ9)
https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/468

### How to test/reproduce
- Start the application
- Create a regulatory statement based on a template containing a snippet placeholder
- Open the 'Insert snippet' modal, and notice that you can preview each of the snippets listed


### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
