### PR TITLE
GN-5032: ensure `versioned-notulen` resources related to signed resources are marked as `deleted` when all signatures are removed

### DIFF
--- a/.changeset/wicked-lamps-press.md
+++ b/.changeset/wicked-lamps-press.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+When deleting a signature, and all signatures have been removed, ensure that the `deleted` status is set on the `fullNotulen` resource, not the `publicNotulen` resource

--- a/app/controllers/meetings/publish/notulen.js
+++ b/app/controllers/meetings/publish/notulen.js
@@ -15,6 +15,7 @@ export default class MeetingsPublishNotulenController extends Controller {
 
   behandelingContainerId = 'behandeling-van-agendapunten-container';
   @tracked notulen;
+  @tracked fullNotulen;
   @tracked fullNotulenContent;
   // Since content can be in a file or in the triplestore, handle content independently from the
   // notulen itself
@@ -38,6 +39,8 @@ export default class MeetingsPublishNotulenController extends Controller {
   resetController() {
     this.notulen = null;
     this.notulenContent = null;
+    this.fullNotulen = null;
+    this.fullNotulenContent = null;
     this.errors = null;
     this.validationErrors = null;
     this.signedResources = [];
@@ -213,6 +216,7 @@ export default class MeetingsPublishNotulenController extends Controller {
           this.errors = [`Error fetching file contents: ${statusText}`];
         },
       );
+      this.fullNotulen = fullNotulen;
     } else {
       // this means there are no signatures
       try {
@@ -270,8 +274,8 @@ export default class MeetingsPublishNotulenController extends Controller {
     // so it is still in the signedResources array.
     // we could reload the model here, but then we're reloading twice in one call, which seems unnecessary
     if (this.signedResources.length === 1) {
-      this.notulen.deleted = true;
-      await this.notulen.save();
+      this.fullNotulen.deleted = true;
+      await this.fullNotulen.save();
     }
     await this.loadNotulen.perform();
   });


### PR DESCRIPTION
### Overview
This PR includes some modifications to the `meetings/publish/notulen` controller in how the deletion of signatures is handled.
Specifically, it ensures that the correct `versioned-notulen` resource is marked as deleted when all signatures are removed (the `full` kind, not the `public` kind).

##### connected issues and PRs:
[GN-5302](https://binnenland.atlassian.net/browse/GN-5032)
https://github.com/lblod/app-gelinkt-notuleren/pull/193

### How to test/reproduce
- Create a meeting
- Set the start and end dates
- Add an agendapoint
- Visit the publishing page
- Open up the `document`/`notulen` publish section
- Sign the `document`/`notulen`
- Remove the signature
- Change the end date (or other data) of the meeting
- Revisit the `document`/`notuleren` publish screen
- Click on the `sign` button
- Note that the preview is correctly updated with the new end date/data

### Challenges/uncertainties
We'll probably need to make a migration/query for existing meetings which were affected. We can probably do this by updating `full` `versioned-notulen` objects which do not have a `deleted` status, but are only linked to `signed-resources` which do have the `deleted` status. Update: https://github.com/lblod/app-gelinkt-notuleren/pull/193



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
