### PR TITLE
Fix bug with empty lines being removed on save

### DIFF
--- a/.changeset/quick-elephants-laugh.md
+++ b/.changeset/quick-elephants-laugh.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Fix removal of empty lines on save, they are now maintained

--- a/app/components/zitting-text-document-container.js
+++ b/app/components/zitting-text-document-container.js
@@ -128,7 +128,7 @@ export default class ZittingTextDocumentContainerComponent extends Component {
 
   @action
   rdfaEditorInit(editor) {
-    editor.initialize(this.text);
+    editor.initialize(this.text, { doNotClean: true });
     this.editor = editor;
     this.args.onEditorInit(editor);
   }

--- a/app/controllers/agendapoints/edit.js
+++ b/app/controllers/agendapoints/edit.js
@@ -351,7 +351,7 @@ export default class AgendapointsEditController extends Controller {
   @action
   handleRdfaEditorInit(editor) {
     this.controller = editor;
-    editor.initialize(this.editorDocument.content || '');
+    editor.initialize(this.editorDocument.content || '', { doNotClean: true });
   }
 
   @action

--- a/app/controllers/regulatory-statements/edit.js
+++ b/app/controllers/regulatory-statements/edit.js
@@ -377,7 +377,7 @@ export default class RegulatoryStatementsRoute extends Controller {
 
   @action
   handleRdfaEditorInit(controller) {
-    controller.initialize(this.editorDocument.content);
+    controller.initialize(this.editorDocument.content, { doNotClean: true });
     this.controller = controller;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@lblod/ember-acmidm-login": "^2.1.0",
         "@lblod/ember-environment-banner": "^0.5.0",
         "@lblod/ember-mock-login": "^0.10.0",
-        "@lblod/ember-rdfa-editor": "10.3.0",
+        "@lblod/ember-rdfa-editor": "10.4.0-dev.d5b99c1843ff85a4e03c2cb8de08d1329d8184e3",
         "@lblod/ember-rdfa-editor-lblod-plugins": "22.4.1",
         "@release-it-plugins/lerna-changelog": "^6.0.0",
         "broccoli-asset-rev": "^3.0.0",
@@ -4465,9 +4465,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-10.3.0.tgz",
-      "integrity": "sha512-ip8e7q5inZyz6MQXBmx9MyzHRVrLkyHlntVrBmMx0z11RKfijCA+8G+LTTLo95udR/L5VNFVF+CPgkE3FEmwNA==",
+      "version": "10.4.0-dev.d5b99c1843ff85a4e03c2cb8de08d1329d8184e3",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-10.4.0-dev.d5b99c1843ff85a4e03c2cb8de08d1329d8184e3.tgz",
+      "integrity": "sha512-fk0hYWqSMLLuPwsJW/HveWB1kvM/XgtqZaRhO3KSDBTJ6Y/y4dpSVLYR6Yf66TJxUx7CVezmFM4rs4LtAfmW3Q==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.24.7",
@@ -4522,7 +4522,6 @@
         "tracked-built-ins": "^3.3.0",
         "tracked-toolbox": "^2.0.0",
         "uuid": "^9.0.1",
-        "vm-browserify": "^1.1.2",
         "yup": "^1.4.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@lblod/ember-acmidm-login": "^2.1.0",
     "@lblod/ember-environment-banner": "^0.5.0",
     "@lblod/ember-mock-login": "^0.10.0",
-    "@lblod/ember-rdfa-editor": "10.3.0",
+    "@lblod/ember-rdfa-editor": "10.4.0-dev.d5b99c1843ff85a4e03c2cb8de08d1329d8184e3",
     "@lblod/ember-rdfa-editor-lblod-plugins": "22.4.1",
     "@release-it-plugins/lerna-changelog": "^6.0.0",
     "broccoli-asset-rev": "^3.0.0",


### PR DESCRIPTION
### Overview
Uses a new version of the editor with the option to skip html cleaning steps on initialize.

##### connected issues and PRs:
Editor PR to add the option: https://github.com/lblod/ember-rdfa-editor/pull/1217
RB PR: https://github.com/lblod/frontend-reglementaire-bijlage/pull/278

### Setup
N/A

### How to test/reproduce
Create empty lines in an agendapoint, regulatory statement or meeting notes. Click save. These lines are no longer removed from the editor content.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
