### PR TITLE
GN-5005: reworked snippet data-model + support for ordered snippets

### DIFF
--- a/.changeset/angry-lemons-hang.md
+++ b/.changeset/angry-lemons-hang.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Update `@lblod/ember-rdfa-editor-lblod-plugins` to version 24.0.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@lblod/ember-environment-banner": "^0.5.0",
         "@lblod/ember-mock-login": "^0.10.0",
         "@lblod/ember-rdfa-editor": "10.6.0",
-        "@lblod/ember-rdfa-editor-lblod-plugins": "23.1.0",
+        "@lblod/ember-rdfa-editor-lblod-plugins": "22.5.1-dev.8c31d5140e8cdd7c847e6713ec64155547581ce2",
         "@release-it-plugins/lerna-changelog": "^6.0.0",
         "broccoli-asset-rev": "^3.0.0",
         "broccoli-plugin": "^4.0.7",
@@ -7429,17 +7429,15 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor-lblod-plugins": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-23.1.0.tgz",
-      "integrity": "sha512-f9TdOXT5/QfvX6rxdx6ISO6mG5l3nLzWCAgLsbhsPzxqmXGkl5xRhS3XLb5SLnekyk6UNaVTCSR3oaoRbtEd8A==",
+      "version": "22.5.1-dev.8c31d5140e8cdd7c847e6713ec64155547581ce2",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-22.5.1-dev.8c31d5140e8cdd7c847e6713ec64155547581ce2.tgz",
+      "integrity": "sha512-ORNPIqR+LwEe/0WprSy7nVZT9193iQZhxsKHnSodH7AFN5f51YPAdvk281m/63BsuoJ70zoLz6htZ5Zxgw9mNw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@codemirror/lang-html": "^6.4.9",
         "@codemirror/state": "^6.4.1",
         "@codemirror/view": "^6.28.3",
         "@curvenote/prosemirror-utils": "^1.0.5",
-        "@embroider/macros": "^1.16.5",
         "@lblod/marawa": "0.8.0-beta.6",
         "@rdfjs/data-model": "^2.0.2",
         "@rdfjs/dataset": "^2.0.2",
@@ -7450,12 +7448,12 @@
         "codemirror": "^6.0.1",
         "crypto-browserify": "^3.12.0",
         "date-fns": "^2.30.0",
-        "ember-auto-import": "~2.7.0",
+        "ember-auto-import": "~2.6.3",
         "ember-cli-babel": "^8.2.0",
         "ember-cli-htmlbars": "^6.3.0",
         "ember-concurrency": "^3.1.1",
         "ember-mu-transform-helpers": "^2.1.2",
-        "ember-resources": "^7.0.2",
+        "ember-resources": "^6.5.1",
         "ember-template-imports": "^4.1.1",
         "ember-velcro": "^2.2.0",
         "fetch-sparql-endpoint": "^3.3.3",
@@ -7464,7 +7462,6 @@
         "proj4": "^2.11.0",
         "rdf-ext": "^2.5.2",
         "rdf-validate-shacl": "^0.4.5",
-        "reactiveweb": "^1.3.0",
         "stream-browserify": "^3.0.0",
         "tracked-built-ins": "^3.3.0",
         "tracked-toolbox": "^2.0.0",
@@ -7477,7 +7474,7 @@
         "@appuniversum/ember-appuniversum": "^3.4.1",
         "@ember/string": "3.x",
         "@glint/template": "^1.4.0",
-        "@lblod/ember-rdfa-editor": "^10.4.0",
+        "@lblod/ember-rdfa-editor": "^10.0.2",
         "ember-concurrency": "^3.1.0",
         "ember-element-helper": "^0.8.6",
         "ember-intl": "^7.0.0",
@@ -7503,7 +7500,6 @@
       "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-4.2.0.tgz",
       "integrity": "sha512-nTrQe5AQtCrW4enLRvbD/vTLHqyW2tz+vsLXQe4IEaUhepuMGVKJJr+I8n34Vu6fPjmPLwTjzNC8izMIDMtHPw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "broccoli-plugin": "^4.0.2",
         "merge-trees": "^2.0.0"
@@ -7513,17 +7509,14 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/ember-auto-import": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/ember-auto-import/-/ember-auto-import-2.7.4.tgz",
-      "integrity": "sha512-6CdXSegJJc8nwwK7+1lIcBUnMVrJRNd4ZdMgcKbCAwPvcGxMgRVBddSzrX/+q/UuflvTEO26Dk1g7Z6KHMXUhw==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/ember-auto-import/-/ember-auto-import-2.6.3.tgz",
+      "integrity": "sha512-uLhrRDJYWCRvQ4JQ1e64XlSrqAKSd6PXaJ9ZsZI6Tlms9T4DtQFxNXasqji2ZRJBVrxEoLCRYX3RTldsQ0vNGQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.7",
         "@babel/plugin-proposal-class-properties": "^7.16.7",
         "@babel/plugin-proposal-decorators": "^7.16.7",
-        "@babel/plugin-proposal-private-methods": "^7.16.7",
-        "@babel/plugin-transform-class-static-block": "^7.16.7",
         "@babel/preset-env": "^7.16.7",
         "@embroider/macros": "^1.0.0",
         "@embroider/shared-internals": "^2.0.0",
@@ -7545,7 +7538,6 @@
         "js-string-escape": "^1.0.1",
         "lodash": "^4.17.19",
         "mini-css-extract-plugin": "^2.5.2",
-        "minimatch": "^3.0.0",
         "parse5": "^6.0.1",
         "resolve": "^1.20.0",
         "resolve-package-path": "^4.0.3",
@@ -7558,12 +7550,42 @@
         "node": "12.* || 14.* || >= 16"
       }
     },
+    "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/ember-resources": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/ember-resources/-/ember-resources-6.5.1.tgz",
+      "integrity": "sha512-8eEdbSE0sioqjpB2CWw/dKF4Ftfe9tbebuSUfMDBmP3xxTIvxTDbvDnbd8A0IbQ0z/iQt6Va+/5cadzvkbMZtg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.17.8",
+        "@embroider/addon-shim": "^1.2.0",
+        "@embroider/macros": "^1.12.3",
+        "ember-async-data": "^1.0.1"
+      },
+      "peerDependencies": {
+        "@ember/test-waiters": "^3.0.0",
+        "@glimmer/component": "^1.1.2",
+        "@glimmer/tracking": "^1.1.2",
+        "@glint/template": "^1.0.0-beta.3 || ^1.0.0",
+        "ember-concurrency": "^2.0.0 || ^3.0.0",
+        "ember-source": "^3.28.0 || ^4.0.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@ember/test-waiters": {
+          "optional": true
+        },
+        "@glimmer/component": {
+          "optional": true
+        },
+        "ember-concurrency": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/fs-extra": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -7578,7 +7600,6 @@
       "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
       "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/symlink-or-copy": "^1.2.0",
         "heimdalljs-logger": "^0.1.7",
@@ -7595,7 +7616,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -7608,7 +7628,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
       "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -7621,7 +7640,6 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -7631,7 +7649,6 @@
       "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-3.0.0.tgz",
       "integrity": "sha512-41TvKmDGVpm2iuH7o+DAOt06yyu/cSHpX3uzAwetzASvlNtVddgIjXIb2DfB/Wa20B1Jo86+1Dv1CraSU7hWdw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/minimatch": "^3.0.4",
         "ensure-posix-path": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@lblod/ember-environment-banner": "^0.5.0",
         "@lblod/ember-mock-login": "^0.10.0",
         "@lblod/ember-rdfa-editor": "10.6.0",
-        "@lblod/ember-rdfa-editor-lblod-plugins": "22.5.1-dev.8c31d5140e8cdd7c847e6713ec64155547581ce2",
+        "@lblod/ember-rdfa-editor-lblod-plugins": "24.0.0",
         "@release-it-plugins/lerna-changelog": "^6.0.0",
         "broccoli-asset-rev": "^3.0.0",
         "broccoli-plugin": "^4.0.7",
@@ -7429,15 +7429,16 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor-lblod-plugins": {
-      "version": "22.5.1-dev.8c31d5140e8cdd7c847e6713ec64155547581ce2",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-22.5.1-dev.8c31d5140e8cdd7c847e6713ec64155547581ce2.tgz",
-      "integrity": "sha512-ORNPIqR+LwEe/0WprSy7nVZT9193iQZhxsKHnSodH7AFN5f51YPAdvk281m/63BsuoJ70zoLz6htZ5Zxgw9mNw==",
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-24.0.0.tgz",
+      "integrity": "sha512-GjSFItYjKnN/zyHMY0VdhTzgAKJBZlCYMtObegIIFBKK05AuCm7CFi0/pJ6wCsgk7b0aOrdWwJyj3rQoIgA8Tw==",
       "dev": true,
       "dependencies": {
         "@codemirror/lang-html": "^6.4.9",
         "@codemirror/state": "^6.4.1",
         "@codemirror/view": "^6.28.3",
         "@curvenote/prosemirror-utils": "^1.0.5",
+        "@embroider/macros": "^1.16.5",
         "@lblod/marawa": "0.8.0-beta.6",
         "@rdfjs/data-model": "^2.0.2",
         "@rdfjs/dataset": "^2.0.2",
@@ -7448,12 +7449,12 @@
         "codemirror": "^6.0.1",
         "crypto-browserify": "^3.12.0",
         "date-fns": "^2.30.0",
-        "ember-auto-import": "~2.6.3",
+        "ember-auto-import": "~2.7.0",
         "ember-cli-babel": "^8.2.0",
         "ember-cli-htmlbars": "^6.3.0",
         "ember-concurrency": "^3.1.1",
         "ember-mu-transform-helpers": "^2.1.2",
-        "ember-resources": "^6.5.1",
+        "ember-resources": "^7.0.2",
         "ember-template-imports": "^4.1.1",
         "ember-velcro": "^2.2.0",
         "fetch-sparql-endpoint": "^3.3.3",
@@ -7462,6 +7463,7 @@
         "proj4": "^2.11.0",
         "rdf-ext": "^2.5.2",
         "rdf-validate-shacl": "^0.4.5",
+        "reactiveweb": "^1.3.0",
         "stream-browserify": "^3.0.0",
         "tracked-built-ins": "^3.3.0",
         "tracked-toolbox": "^2.0.0",
@@ -7474,7 +7476,7 @@
         "@appuniversum/ember-appuniversum": "^3.4.1",
         "@ember/string": "3.x",
         "@glint/template": "^1.4.0",
-        "@lblod/ember-rdfa-editor": "^10.0.2",
+        "@lblod/ember-rdfa-editor": "^10.4.0",
         "ember-concurrency": "^3.1.0",
         "ember-element-helper": "^0.8.6",
         "ember-intl": "^7.0.0",
@@ -7509,14 +7511,16 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/ember-auto-import": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/ember-auto-import/-/ember-auto-import-2.6.3.tgz",
-      "integrity": "sha512-uLhrRDJYWCRvQ4JQ1e64XlSrqAKSd6PXaJ9ZsZI6Tlms9T4DtQFxNXasqji2ZRJBVrxEoLCRYX3RTldsQ0vNGQ==",
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/ember-auto-import/-/ember-auto-import-2.7.4.tgz",
+      "integrity": "sha512-6CdXSegJJc8nwwK7+1lIcBUnMVrJRNd4ZdMgcKbCAwPvcGxMgRVBddSzrX/+q/UuflvTEO26Dk1g7Z6KHMXUhw==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.16.7",
         "@babel/plugin-proposal-class-properties": "^7.16.7",
         "@babel/plugin-proposal-decorators": "^7.16.7",
+        "@babel/plugin-proposal-private-methods": "^7.16.7",
+        "@babel/plugin-transform-class-static-block": "^7.16.7",
         "@babel/preset-env": "^7.16.7",
         "@embroider/macros": "^1.0.0",
         "@embroider/shared-internals": "^2.0.0",
@@ -7538,6 +7542,7 @@
         "js-string-escape": "^1.0.1",
         "lodash": "^4.17.19",
         "mini-css-extract-plugin": "^2.5.2",
+        "minimatch": "^3.0.0",
         "parse5": "^6.0.1",
         "resolve": "^1.20.0",
         "resolve-package-path": "^4.0.3",
@@ -7548,37 +7553,6 @@
       },
       "engines": {
         "node": "12.* || 14.* || >= 16"
-      }
-    },
-    "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/ember-resources": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/ember-resources/-/ember-resources-6.5.1.tgz",
-      "integrity": "sha512-8eEdbSE0sioqjpB2CWw/dKF4Ftfe9tbebuSUfMDBmP3xxTIvxTDbvDnbd8A0IbQ0z/iQt6Va+/5cadzvkbMZtg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.17.8",
-        "@embroider/addon-shim": "^1.2.0",
-        "@embroider/macros": "^1.12.3",
-        "ember-async-data": "^1.0.1"
-      },
-      "peerDependencies": {
-        "@ember/test-waiters": "^3.0.0",
-        "@glimmer/component": "^1.1.2",
-        "@glimmer/tracking": "^1.1.2",
-        "@glint/template": "^1.0.0-beta.3 || ^1.0.0",
-        "ember-concurrency": "^2.0.0 || ^3.0.0",
-        "ember-source": "^3.28.0 || ^4.0.0 || ^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@ember/test-waiters": {
-          "optional": true
-        },
-        "@glimmer/component": {
-          "optional": true
-        },
-        "ember-concurrency": {
-          "optional": true
-        }
       }
     },
     "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/fs-extra": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@lblod/ember-environment-banner": "^0.5.0",
     "@lblod/ember-mock-login": "^0.10.0",
     "@lblod/ember-rdfa-editor": "10.6.0",
-    "@lblod/ember-rdfa-editor-lblod-plugins": "22.5.1-dev.8c31d5140e8cdd7c847e6713ec64155547581ce2",
+    "@lblod/ember-rdfa-editor-lblod-plugins": "24.0.0",
     "@release-it-plugins/lerna-changelog": "^6.0.0",
     "broccoli-asset-rev": "^3.0.0",
     "broccoli-plugin": "^4.0.7",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@lblod/ember-environment-banner": "^0.5.0",
     "@lblod/ember-mock-login": "^0.10.0",
     "@lblod/ember-rdfa-editor": "10.6.0",
-    "@lblod/ember-rdfa-editor-lblod-plugins": "23.1.0",
+    "@lblod/ember-rdfa-editor-lblod-plugins": "22.5.1-dev.8c31d5140e8cdd7c847e6713ec64155547581ce2",
     "@release-it-plugins/lerna-changelog": "^6.0.0",
     "broccoli-asset-rev": "^3.0.0",
     "broccoli-plugin": "^4.0.7",


### PR DESCRIPTION
### Overview
This (draft) PR updates `@lblod/ember-rdfa-editor-lblod-plugins` to the dev build of https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/482. That PR adds support for the reworked snippet data-model and ordered snippets.

TODOS:
- [x] Update to stable version of editor-plugins

##### connected issues and PRs:
[GN-5005](https://binnenland.atlassian.net/browse/GN-5005)
https://github.com/lblod/frontend-reglementaire-bijlage/pull/279
https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/482
https://github.com/lblod/app-reglementaire-bijlage/pull/84


### Setup
Check-out https://github.com/lblod/frontend-reglementaire-bijlage/pull/279

### How to test/reproduce
Check-out https://github.com/lblod/frontend-reglementaire-bijlage/pull/279

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
