### PR TITLE
Add options to export HTML without template comments

### DIFF
--- a/.changeset/itchy-bobcats-think.md
+++ b/.changeset/itchy-bobcats-think.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': minor
+---
+
+Add option to export HTML 'for publishing', which removes template comments

--- a/app/components/download-document.hbs
+++ b/app/components/download-document.hbs
@@ -1,0 +1,8 @@
+<AuButton {{on 'click' this.download}} @skin='link' role='menuitem'>
+  <AuIcon @icon='export' @alignment='left' />
+  {{#if @forPublish}}
+    {{t 'utils.html-export-publish'}}
+  {{else}}
+    {{t 'utils.html-export'}}
+  {{/if}}
+</AuButton>

--- a/app/components/download-document.js
+++ b/app/components/download-document.js
@@ -1,0 +1,18 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import generateExportFromEditorDocument from 'frontend-gelinkt-notuleren/utils/generate-export-from-editor-document';
+
+export default class DownloadDocumentComponent extends Component {
+  @action
+  download() {
+    const content = this.args.content ?? this.args.document.content;
+    generateExportFromEditorDocument(
+      {
+        title: this.args.document.title,
+        context: this.args.document.context,
+        content,
+      },
+      this.args.forPublish,
+    );
+  }
+}

--- a/app/controllers/agendapoints/edit.js
+++ b/app/controllers/agendapoints/edit.js
@@ -79,7 +79,6 @@ import { color } from '@lblod/ember-rdfa-editor/plugins/color/marks/color';
 import { undo } from '@lblod/ember-rdfa-editor/plugins/history';
 
 import { TRASH_STATUS_ID } from 'frontend-gelinkt-notuleren/utils/constants';
-import generateExportFromEditorDocument from 'frontend-gelinkt-notuleren/utils/generate-export-from-editor-document';
 import ENV from 'frontend-gelinkt-notuleren/config/environment';
 import {
   regulatoryStatementNode,
@@ -352,12 +351,6 @@ export default class AgendapointsEditController extends Controller {
   handleRdfaEditorInit(editor) {
     this.controller = editor;
     editor.initialize(this.editorDocument.content || '', { doNotClean: true });
-  }
-
-  @action
-  download() {
-    this.editorDocument.content = this.controller.htmlContent;
-    generateExportFromEditorDocument(this.editorDocument);
   }
 
   copyAgendapunt = task(async () => {

--- a/app/controllers/agendapoints/revisions.js
+++ b/app/controllers/agendapoints/revisions.js
@@ -2,8 +2,8 @@ import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { task } from 'ember-concurrency';
-import generateExportFromEditorDocument from 'frontend-gelinkt-notuleren/utils/generate-export-from-editor-document';
 import { service } from '@ember/service';
+
 export default class AgendapointsRevisionsController extends Controller {
   @service router;
   @service intl;
@@ -33,11 +33,6 @@ export default class AgendapointsRevisionsController extends Controller {
     this.flushThingsToRemove();
     this.router.transitionTo('agendapoints.edit', this.documentContainer.id);
   });
-
-  @action
-  download() {
-    generateExportFromEditorDocument(this.revisionDetail);
-  }
 
   getRevisionsToRemove(revision) {
     let revisionsToRemove = [];

--- a/app/controllers/agendapoints/show.js
+++ b/app/controllers/agendapoints/show.js
@@ -1,17 +1,10 @@
 import Controller from '@ember/controller';
 import { service } from '@ember/service';
 import { task } from 'ember-concurrency';
-import generateExportFromEditorDocument from 'frontend-gelinkt-notuleren/utils/generate-export-from-editor-document';
-import { action } from '@ember/object';
 
 export default class AgendapointsShowController extends Controller {
   @service currentSession;
   @service router;
-
-  @action
-  download() {
-    generateExportFromEditorDocument(this.model.editorDocument);
-  }
 
   copyAgendapunt = task(async () => {
     const response = await fetch(

--- a/app/controllers/regulatory-statements/edit.js
+++ b/app/controllers/regulatory-statements/edit.js
@@ -99,7 +99,6 @@ import {
   snippet,
   snippetView,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/nodes/snippet';
-import generateExportFromEditorDocument from 'frontend-gelinkt-notuleren/utils/generate-export-from-editor-document';
 import ENV from 'frontend-gelinkt-notuleren/config/environment';
 import {
   GEMEENTE,
@@ -333,12 +332,6 @@ export default class RegulatoryStatementsRoute extends Controller {
       // Return empty object instead of null so can be used safely in template
       return {};
     }
-  }
-
-  @action
-  download() {
-    this.editorDocument.content = this.controller.htmlContent;
-    generateExportFromEditorDocument(this.editorDocument);
   }
 
   saveTask = task(async () => {

--- a/app/controllers/regulatory-statements/revisions.js
+++ b/app/controllers/regulatory-statements/revisions.js
@@ -1,7 +1,5 @@
 import Controller from '@ember/controller';
 import { service } from '@ember/service';
-import generateExportFromEditorDocument from 'frontend-gelinkt-notuleren/utils/generate-export-from-editor-document';
-import { action } from '@ember/object';
 import { task } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
 import { replaceUris } from '../../utils/replace-uris';
@@ -22,11 +20,6 @@ export default class RegulatoryAttachmentsShowController extends Controller {
       5,
     );
   });
-
-  @action
-  download() {
-    generateExportFromEditorDocument(this.model.editorDocument);
-  }
 
   restoreTask = task(async () => {
     const currentVersion = this.model.currentVersion;

--- a/app/controllers/regulatory-statements/show.js
+++ b/app/controllers/regulatory-statements/show.js
@@ -1,7 +1,5 @@
 import Controller from '@ember/controller';
 import { service } from '@ember/service';
-import generateExportFromEditorDocument from 'frontend-gelinkt-notuleren/utils/generate-export-from-editor-document';
-import { action } from '@ember/object';
 import { task } from 'ember-concurrency';
 import { replaceUris } from '../../utils/replace-uris';
 import { tracked } from '@glimmer/tracking';
@@ -12,11 +10,6 @@ export default class RegulatoryAttachmentsShowController extends Controller {
   @service router;
   @service intl;
   @tracked revisions;
-
-  @action
-  download() {
-    generateExportFromEditorDocument(this.model.editorDocument);
-  }
 
   fetchRevisions = task(async () => {
     const revisionsToSkip = [this.model.editorDocument.id];

--- a/app/templates/agendapoints/edit.hbs
+++ b/app/templates/agendapoints/edit.hbs
@@ -27,10 +27,15 @@
         <AuIcon @icon='copy' @alignment='left' />
         {{t 'app-chrome.copy-agendapoint'}}
       </AuButton>
-      <AuButton {{on 'click' this.download}} @skin='link' role='menuitem'>
-        <AuIcon @icon='export' @alignment='left' />
-        {{t 'utils.html-export'}}
-      </AuButton>
+      <DownloadDocument
+        @content={{this.controller.htmlContent}}
+        @document={{this.editorDocument}}
+      />
+      <DownloadDocument
+        @content={{this.controller.htmlContent}}
+        @document={{this.editorDocument}}
+        @forPublish={{true}}
+      />
       <AuButton
         {{on 'click' this.toggleDeleteModal}}
         @skin='link'

--- a/app/templates/agendapoints/revisions.hbs
+++ b/app/templates/agendapoints/revisions.hbs
@@ -13,11 +13,11 @@
       @buttonLabel={{t 'utils.file-options'}}
       @alignment='right'
     >
-      {{! template-lint-disable require-context-role }}
-      <AuButton {{on 'click' this.download}} @skin='link' role='menuitem'>
-        <AuIcon @icon='export' @alignment='left' />
-        {{t 'utils.html-export'}}
-      </AuButton>
+      <DownloadDocument @document={{this.revisionDetail}} />
+      <DownloadDocument
+        @document={{this.revisionDetail}}
+        @forPublish={{true}}
+      />
     </AuDropdown>
     <AuButton
       @icon='redo'

--- a/app/templates/agendapoints/show.hbs
+++ b/app/templates/agendapoints/show.hbs
@@ -22,10 +22,11 @@
           {{t 'app-chrome.copy-agendapoint'}}
         </AuButton>
       {{/unless}}
-      <AuButton {{on 'click' this.download}} @skin='link' role='menuitem'>
-        <AuIcon @icon='export' @alignment='left' />
-        {{t 'utils.html-export'}}
-      </AuButton>
+      <DownloadDocument @document={{this.model.editorDocument}} />
+      <DownloadDocument
+        @document={{this.model.editorDocument}}
+        @forPublish={{true}}
+      />
     </AuDropdown>
   </:actions>
 </AppChrome>

--- a/app/templates/regulatory-statements/edit.hbs
+++ b/app/templates/regulatory-statements/edit.hbs
@@ -80,11 +80,15 @@
       @buttonLabel={{t 'utils.file-options'}}
       @alignment='right'
     >
-      {{! template-lint-disable require-context-role }}
-      <AuButton {{on 'click' this.download}} @skin='link' role='menuitem'>
-        <AuIcon @icon='export' @alignment='left' />
-        {{t 'utils.html-export'}}
-      </AuButton>
+      <DownloadDocument
+        @content={{this.controller.htmlContent}}
+        @document={{this.editorDocument}}
+      />
+      <DownloadDocument
+        @content={{this.controller.htmlContent}}
+        @document={{this.editorDocument}}
+        @forPublish={{true}}
+      />
     </AuDropdown>
     <AuButton
       {{on 'click' (perform this.saveTask)}}

--- a/app/templates/regulatory-statements/revisions.hbs
+++ b/app/templates/regulatory-statements/revisions.hbs
@@ -87,11 +87,11 @@
       @buttonLabel={{t 'utils.file-options'}}
       @alignment='right'
     >
-      {{! template-lint-disable require-context-role }}
-      <AuButton {{on 'click' this.download}} @skin='link' role='menuitem'>
-        <AuIcon @icon='export' @alignment='left' />
-        {{t 'utils.html-export'}}
-      </AuButton>
+      <DownloadDocument @document={{this.model.editorDocument}} />
+      <DownloadDocument
+        @document={{this.model.editorDocument}}
+        @forPublish={{true}}
+      />
     </AuDropdown>
     {{#if this.currentSession.canWrite}}
       <AuButton

--- a/app/templates/regulatory-statements/show.hbs
+++ b/app/templates/regulatory-statements/show.hbs
@@ -65,11 +65,11 @@
       @buttonLabel={{t 'utils.file-options'}}
       @alignment='right'
     >
-      {{! template-lint-disable require-context-role }}
-      <AuButton {{on 'click' this.download}} @skin='link' role='menuitem'>
-        <AuIcon @icon='export' @alignment='left' />
-        {{t 'utils.html-export'}}
-      </AuButton>
+      <DownloadDocument @document={{this.model.editorDocument}} />
+      <DownloadDocument
+        @document={{this.model.editorDocument}}
+        @forPublish={{true}}
+      />
     </AuDropdown>
     {{#if this.currentSession.canWrite}}
       <AuButton

--- a/app/utils/generate-export-from-editor-document.js
+++ b/app/utils/generate-export-from-editor-document.js
@@ -1,15 +1,23 @@
 import generateExportFromHtmlBody from './generate-export-from-html-body';
+import { stripHtmlForPublish } from '@lblod/ember-rdfa-editor/utils/strip-html-for-publish';
 
-export default function generateExportFromEditorDocument(editorDocument) {
+export default function generateExportFromEditorDocument(
+  editorDocument,
+  forPublication,
+) {
   const context = JSON.parse(editorDocument.context);
   let prefixes = Object.entries(context.prefix)
     .map(([key, value]) => {
       return `${key}: ${value}`;
     })
     .join(' ');
+  let content = editorDocument.content;
+  if (forPublication) {
+    content = stripHtmlForPublish(content);
+  }
   const body = `
       <div vocab="${context.vocab}" prefix="${prefixes}" typeof="foaf:Document" resource="#">
-        ${editorDocument.content}
+        ${content}
       </div>
   `;
   generateExportFromHtmlBody(editorDocument.title, body);

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,8 +29,8 @@
         "@lblod/ember-acmidm-login": "^2.1.0",
         "@lblod/ember-environment-banner": "^0.5.0",
         "@lblod/ember-mock-login": "^0.10.0",
-        "@lblod/ember-rdfa-editor": "^10.5.0",
-        "@lblod/ember-rdfa-editor-lblod-plugins": "23.0.0",
+        "@lblod/ember-rdfa-editor": "10.5.0-dev.7f01e7e07f7de4b7cef5870bbcffeed2b7589674",
+        "@lblod/ember-rdfa-editor-lblod-plugins": "23.0.0-dev.89791b510500f9ad47d040dcb2101632a740cc92",
         "@release-it-plugins/lerna-changelog": "^6.0.0",
         "broccoli-asset-rev": "^3.0.0",
         "broccoli-plugin": "^4.0.7",
@@ -7340,9 +7340,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-10.5.0.tgz",
-      "integrity": "sha512-XzF08ePGY16Y0ge68owaDSxjdHVcm+he3QObkme54dziQrzbgQ3x+kjuGJvL35+8Vdf4Jieoo41DCsGhOaSJOQ==",
+      "version": "10.5.0-dev.7f01e7e07f7de4b7cef5870bbcffeed2b7589674",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-10.5.0-dev.7f01e7e07f7de4b7cef5870bbcffeed2b7589674.tgz",
+      "integrity": "sha512-zYkpm/7D9OqXzZzcshxdfAjUekE0f2F9MDWEI9gbe3SkXbYUVtQ8rn/LXBDkU6RvhOyszhhN4wBMwSdg4lTC3w==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.24.7",
@@ -7428,16 +7428,16 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor-lblod-plugins": {
-      "version": "23.0.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-23.0.0.tgz",
-      "integrity": "sha512-VTL4SUvCWOzs0gwqpSXVagZm+ZSMA1av9dTWqmnyM4eKAnOgXRrLoyPVbupI1sKPxndmG7DL8xP4Swhh9yVRxA==",
+      "version": "23.0.0-dev.89791b510500f9ad47d040dcb2101632a740cc92",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-23.0.0-dev.89791b510500f9ad47d040dcb2101632a740cc92.tgz",
+      "integrity": "sha512-r0soE1BAH0nts8ToyR3Fdg5+ZYmxO9+pgJKCxaP9+BloGAP2Yz39xVj4NszOsnlkhZI4kheGw/sQpcBfc/cVVw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@codemirror/lang-html": "^6.4.9",
         "@codemirror/state": "^6.4.1",
         "@codemirror/view": "^6.28.3",
         "@curvenote/prosemirror-utils": "^1.0.5",
+        "@embroider/macros": "^1.16.5",
         "@lblod/marawa": "0.8.0-beta.6",
         "@rdfjs/data-model": "^2.0.2",
         "@rdfjs/dataset": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "@lblod/ember-acmidm-login": "^2.1.0",
     "@lblod/ember-environment-banner": "^0.5.0",
     "@lblod/ember-mock-login": "^0.10.0",
-    "@lblod/ember-rdfa-editor": "^10.5.0",
-    "@lblod/ember-rdfa-editor-lblod-plugins": "23.0.0",
+    "@lblod/ember-rdfa-editor": "10.5.0-dev.7f01e7e07f7de4b7cef5870bbcffeed2b7589674",
+    "@lblod/ember-rdfa-editor-lblod-plugins": "23.0.0-dev.89791b510500f9ad47d040dcb2101632a740cc92",
     "@release-it-plugins/lerna-changelog": "^6.0.0",
     "broccoli-asset-rev": "^3.0.0",
     "broccoli-plugin": "^4.0.7",
@@ -121,6 +121,9 @@
     "@appuniversum/ember-appuniversum": {
       "@floating-ui/dom": "^1.6.5",
       "tracked-toolbox": "^2.0.0"
+    },
+    "@lblod/ember-rdfa-editor-lblod-plugins": {
+      "@lblod/ember-rdfa-editor": "10.5.0-dev.7f01e7e07f7de4b7cef5870bbcffeed2b7589674"
     },
     "babel-plugin-ember-template-compilation": "^2.2.5",
     "ember-data-table": {

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -687,6 +687,7 @@ utils:
   insert: Insert
   file-options: File options
   html-export: Export as HTML
+  html-export-publish: Export as HTML (for publishing)
   delete: Delete
   restore: Restore
   current-version: Current Version

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -691,6 +691,7 @@ utils:
   insert: Invoegen
   file-options: Bestand acties
   html-export: Exporteer als HTML
+  html-export-publish: Exporteer als HTML (voor publicatie)
   delete: Naar prullenmand
   restore: Herstellen
   current-version: Actuele versie

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,5 +3,5 @@
     "experimentalDecorators": true
   },
   "exclude": ["node_modules", "dist"],
-  allowJs: true
+  "allowJs": true
 }


### PR DESCRIPTION
### Overview
Uses the util added to the editor repo to remove template comments when exporting (leaving the option to export as before).

##### connected issues and PRs:
Editor PR: https://github.com/lblod/ember-rdfa-editor/pull/1219
Plugins PR: https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/483
Jira ticket: [binnenland.atlassian.net/browse/GN-4999](https://binnenland.atlassian.net/browse/GN-4999)

### Setup
N/A

### How to test/reproduce
Find an agendapoint or regulatory statement with template comments, save a new version.
*Saving again is important* as we need to save the template comments with the necessary data attribute to be removed.
Go to any screen with a 'file options' menu and check that the two export options work as expected (for publish means without comments). You might need to go in as a 'lezer' to get some of the screens.

### Challenges/uncertainties
I don't know if these are the correct places for these functions as it was not specified in the ticket.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
