### PR TITLE
Instantiate the templates coming from RB with the new library

### DIFF
--- a/.changeset/loud-schools-hang.md
+++ b/.changeset/loud-schools-hang.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': minor
+---
+
+Correctly instantiate templates coming from RB

--- a/app/components/document-creator.js
+++ b/app/components/document-creator.js
@@ -5,6 +5,7 @@ import { service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import { DRAFT_STATUS_ID } from 'frontend-gelinkt-notuleren/utils/constants';
 import { instantiateUuids } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/standard-template-plugin';
+import templateUuidInstantiator from '@lblod/template-uuid-instantiator';
 
 export default class DocumentCreatorComponent extends Component {
   @tracked title = '';
@@ -97,9 +98,13 @@ export default class DocumentCreatorComponent extends Component {
        */
       if (this.template.loadBody) {
         await this.template.loadBody();
+        const trimmedHtml = this.template.body.replace(/>\s+</g, '><');
+        //If the template comes from RB we instantiate it with the new library
+        return templateUuidInstantiator(trimmedHtml);
+      } else {
+        const trimmedHtml = this.template.body.replace(/>\s+</g, '><');
+        return instantiateUuids(trimmedHtml);
       }
-      const trimmedHtml = this.template.body.replace(/>\s+</g, '><');
-      return instantiateUuids(trimmedHtml);
     } else return '';
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@lblod/ember-mock-login": "^0.10.0",
         "@lblod/ember-rdfa-editor": "10.6.0",
         "@lblod/ember-rdfa-editor-lblod-plugins": "23.1.0",
+        "@lblod/template-uuid-instantiator": "^1.0.2",
         "@release-it-plugins/lerna-changelog": "^6.0.0",
         "broccoli-asset-rev": "^3.0.0",
         "broccoli-plugin": "^4.0.7",
@@ -7674,6 +7675,15 @@
       },
       "bin": {
         "rdfjs-dataset-test": "bin/test.js"
+      }
+    },
+    "node_modules/@lblod/template-uuid-instantiator": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@lblod/template-uuid-instantiator/-/template-uuid-instantiator-1.0.2.tgz",
+      "integrity": "sha512-gw6nJnWCcHZYOG/Z/5Br8Txjqi5qV4S95ApoBpxeJKFzFyXMpl1Gh6LOKeOtuJerLp4NtZ71uVTJ3LzrrS2bdQ==",
+      "dev": true,
+      "dependencies": {
+        "uuid": "^9.0.1"
       }
     },
     "node_modules/@lezer/common": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@lblod/ember-mock-login": "^0.10.0",
     "@lblod/ember-rdfa-editor": "10.6.0",
     "@lblod/ember-rdfa-editor-lblod-plugins": "23.1.0",
+    "@lblod/template-uuid-instantiator": "^1.0.2",
     "@release-it-plugins/lerna-changelog": "^6.0.0",
     "broccoli-asset-rev": "^3.0.0",
     "broccoli-plugin": "^4.0.7",
@@ -145,7 +146,7 @@
   "dependencies": {
     "@curvenote/prosemirror-utils": "^1.0.5",
     "ember-resources": "^7.0.2",
-    "tracked-toolbox": "^2.0.0",
-    "reactiveweb": "^1.3.0"
+    "reactiveweb": "^1.3.0",
+    "tracked-toolbox": "^2.0.0"
   }
 }


### PR DESCRIPTION
### Overview
Made the document instantiator differentiate  if the template comes from RB and use the new instantiator for those

### connected issues and PRs:
https://github.com/lblod/frontend-reglementaire-bijlage/pull/283


### How to test/reproduce
Create a template on RB using the new branch and check that it gets correctly instantiated on GN

### Challenges/uncertainties
None



### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
