### PR TITLE
GN-5089: add config for fraction splitting

### DIFF
--- a/app/config/constants.js
+++ b/app/config/constants.js
@@ -62,3 +62,7 @@ export const BESTUURSPERIODES = {
   '2025-heden':
     'http://data.lblod.info/id/concept/Bestuursperiode/96efb929-5d83-48fa-bfbb-b98dfb1180c7',
 };
+
+export const LOKALE_VERKIEZINGEN = {
+  2024: 'http://data.lblod.info/id/rechtstreekse-verkiezingen/612a57de-7fc2-40af-a7dc-17d544e5de20',
+};

--- a/app/utils/promises.js
+++ b/app/utils/promises.js
@@ -1,0 +1,24 @@
+/**
+ *
+ * A more generic version of `Promise.all`.
+ *
+ * Works with all kind of objects (and lists).
+ * Has an optional `recursive` flag
+ * @param {Record<string | number, unknown>} obj
+ * @param {boolean} recursive
+ */
+export async function promiseProperties(obj, recursive = false) {
+  const inputIsList = Array.isArray(obj);
+  const entries = Object.entries(obj);
+  const awaitedEntries = await Promise.all(
+    entries.map(async ([k, v]) => {
+      let awaited = await v;
+      if (recursive && typeof awaited === 'object' && awaited !== null) {
+        awaited = await promiseProperties(awaited, true);
+      }
+      return [k, awaited];
+    }),
+  );
+  const awaitedObject = Object.fromEntries(awaitedEntries);
+  return inputIsList ? Object.values(awaitedObject) : awaitedObject;
+}


### PR DESCRIPTION
### Overview
This PR adds a mandatee-table config for the `IVGR5-LMB-1` section: splitsing van 'fracties' (fraction splitting).
It queries all 'kandidatenlijsten' (candidate lists) which result in two 'fracties'.
It then queries information about both fractions.

##### connected issues and PRs:
[GN-5089](https://binnenland.atlassian.net/browse/GN-5089?atlOrigin=eyJpIjoiYjcyNTQ0ZmFjNjNjNGM4OTkyM2ExZjZlZmNiNzg3NmMiLCJwIjoiaiJ9)

### How to test/reproduce
- Start the application
- Open an IV meeting and insert a 'IVGR5-LMB-1-splitsing-fracties' table into one of the agendapoints
- Press the sync button
- If using 'Aalst' as a municipality, you should see an example. Currently none of the two fractions will have any members shown. 
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

### Challenges/uncertainties
- Maybe we should show a message to the users if there are no candidate lists which splitted?
- Weird mix of english and dutch. Tried to keep it consistent.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
