### PR TITLE
Always open insert menu and move insert snippet button to the bottom

### DIFF
--- a/.changeset/nervous-chefs-pretend.md
+++ b/.changeset/nervous-chefs-pretend.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Insert menu is open by default now and moved insert snippet button to the bottom of the list

--- a/app/components/rdfa-editor-container.hbs
+++ b/app/components/rdfa-editor-container.hbs
@@ -120,7 +120,7 @@
           {{#if this.controller}}
             <Sidebar as |Sidebar|>
               {{#if (has-block 'sidebarCollapsible')}}
-                <Sidebar.Collapsible @title={{t 'utils.insert'}}>
+                <Sidebar.Collapsible @title={{t 'utils.insert'}} @expandedInitially="true">
                   {{yield to='sidebarCollapsible'}}
                 </Sidebar.Collapsible>
               {{/if}}

--- a/app/components/rdfa-editor-container.hbs
+++ b/app/components/rdfa-editor-container.hbs
@@ -120,7 +120,10 @@
           {{#if this.controller}}
             <Sidebar as |Sidebar|>
               {{#if (has-block 'sidebarCollapsible')}}
-                <Sidebar.Collapsible @title={{t 'utils.insert'}} @expandedInitially="true">
+                <Sidebar.Collapsible
+                  @title={{t 'utils.insert'}}
+                  @expandedInitially='true'
+                >
                   {{yield to='sidebarCollapsible'}}
                 </Sidebar.Collapsible>
               {{/if}}

--- a/app/templates/agendapoints/edit.hbs
+++ b/app/templates/agendapoints/edit.hbs
@@ -137,14 +137,6 @@
           @controller={{this.controller}}
         />
       {{/if}}
-
-      {{#if this.activeNode}}
-        <this.SnippetInsert
-          @controller={{this.controller}}
-          @config={{this.config.snippet}}
-          @node={{this.activeNode}}
-        />
-      {{/if}}
       <TemplateCommentsPlugin::Insert @controller={{this.controller}} />
       <LocationPlugin::Insert
         @controller={{this.controller}}
@@ -167,6 +159,13 @@
         @controller={{this.controller}}
         @config={{this.config.lmb}}
       />
+      {{#if this.activeNode}}
+        <this.SnippetInsert
+          @controller={{this.controller}}
+          @config={{this.config.snippet}}
+          @node={{this.activeNode}}
+        />
+      {{/if}}
     </:sidebarCollapsible>
     <:sidebar>
       <this.StructureControlCard @controller={{this.controller}} />

--- a/app/templates/regulatory-statements/edit.hbs
+++ b/app/templates/regulatory-statements/edit.hbs
@@ -131,13 +131,6 @@
         @plugin={{this.citationPlugin}}
         @config={{this.config.citation}}
       />
-      {{#if this.activeNode}}
-        <this.SnippetInsert
-          @controller={{this.controller}}
-          @config={{this.config.snippet}}
-          @node={{this.activeNode}}
-        />
-      {{/if}}
       <VariablePlugin::Date::Insert
         @controller={{this.controller}}
         @options={{this.config.date}}
@@ -160,6 +153,13 @@
         @controller={{this.controller}}
         @config={{this.config.lmb}}
       />
+      {{#if this.activeNode}}
+        <this.SnippetInsert
+          @controller={{this.controller}}
+          @config={{this.config.snippet}}
+          @node={{this.activeNode}}
+        />
+      {{/if}}
     </:sidebarCollapsible>
     <:sidebar>
       <ArticleStructurePlugin::StructureCard


### PR DESCRIPTION
### Overview
Always open insert menu and move insert snippet button to the bottom of the list

##### connected issues and PRs:
GN-5092


### Setup
None

### How to test/reproduce
Go to agendapoints edit and RB edit and check that the insert menu is open by default and the insert snippet button is at the bottom

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
