### PR TITLE
LMB GR config: ensure bestuursfunctie is filtered on 'gemeenteraadslid' where necessary

### DIFF
--- a/.changeset/two-bottles-raise.md
+++ b/.changeset/two-bottles-raise.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+LMB IV GR config: ensure queries filter on bestuursfunctie 'gemeenteraadslid' where necessary

--- a/app/config/mandatee-table-config.js
+++ b/app/config/mandatee-table-config.js
@@ -61,6 +61,7 @@ export const mandateeTableConfigIVGR = (meeting) => {
 
           ?mandataris mandaat:isBestuurlijkeAliasVan ?persoon.
           ?mandataris org:holds ?mandaat.
+          ?mandaat org:role <${BESTUURSFUNCTIE_CODES.GEMEENTERAADSLID}>.
 
           ?bestuursorgaan org:hasPost ?mandaat.
           ?bestuursorgaan lmb:heeftBestuursperiode <${BESTUURSPERIODES['2019-2025']}>.
@@ -365,6 +366,9 @@ export const mandateeTableConfigIVGR = (meeting) => {
           OPTIONAL {
             ?mandataris org:hasMembership/org:organisation ?fractie.
             ?mandataris mandaat:isBestuurlijkeAliasVan ?lid.
+            ?mandataris org:holds ?mandaat.
+
+            ?mandaat org:role <${BESTUURSFUNCTIE_CODES.GEMEENTERAADSLID}>.
           }
         }
       `;
@@ -432,6 +436,7 @@ export const mandateeTableConfigIVGR = (meeting) => {
           ?fractie regorg:legalName ?fractie_naam.
 
           ?mandataris org:holds ?mandaat.
+          ?mandaat org:role <${BESTUURSFUNCTIE_CODES.GEMEENTERAADSLID}>.
 
           ?bestuursorgaan org:hasPost ?mandaat.
           ?bestuursorgaan lmb:heeftBestuursperiode <${BESTUURSPERIODES['2019-2025']}>.
@@ -877,6 +882,9 @@ async function fetchFractieLeden(fractieUri) {
 
       ?mandataris mandaat:isBestuurlijkeAliasVan ?persoon.
       ?mandataris org:hasMembership/org:organisation <${fractieUri}>.
+      ?mandataris org:holds ?mandaat.
+
+      ?mandaat org:role <${BESTUURSFUNCTIE_CODES.GEMEENTERAADSLID}>.
     }
   `;
   const result = await executeQuery({


### PR DESCRIPTION
### Overview
This PR ensures that all GR LMB queries filter on the necessary 'bestuursfunctie-code':
- `IVGR2-LMB-1-geloofsbrieven`: filters on 'gemeenteraadslid'
- `IVGR3-LMB-1-eedafleggingen`: filters on 'gemeenteraadslid'
- `IVGR4-LMB-1-rangorde-gemeenteraadsleden`: filters on 'gemeenteraadslid'
- `IVGR5-LMB-1-splitsing-fracties`: filters on 'gemeenteraadslid'
- `IVGR5-LMB-2-grootte-fracties`: filters on 'gemeenteraadslid'
- `IVGR5-LMB-3-samenstelling-fracties`: filters on 'gemeenteraadslid'
- `IVGR7-LMB-1-kandidaat-schepenen`: filters on 'schepen'
- `IVGR7-LMB-2-ontvankelijkheid-schepenen`: filters on 'schepen'
- `IVGR8-LMB-1-verkozen-schepenen`: filters on 'schepen'
- `IVGR8-LMB-2-coalitie`: filters on 'schepen' and 'voorzitter bijzonder comite sociale dienst (BCSD)`

Most of the queries already filtered correctly on the necessary  'bestuursfunctie-code', some filters where still missing.
