### PR TITLE
Split out and copy parts of a decision

### DIFF
--- a/.changeset/bright-dingos-watch.md
+++ b/.changeset/bright-dingos-watch.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': minor
+---
+
+Add functionality to copy parts of a decision from the meeting copy-parts page

--- a/app/components/decision-copy-parts.gjs
+++ b/app/components/decision-copy-parts.gjs
@@ -9,11 +9,16 @@ import { trackedReset } from 'tracked-toolbox';
 import AuButton from '@appuniversum/ember-appuniversum/components/au-button';
 
 class DownloadButton extends Component {
+  @service intl;
+
   get isSuccess() {
     return this.copyToClipboard.last?.isSuccessful;
   }
   get icon() {
     return this.isSuccess ? 'circle-check' : undefined;
+  }
+  get label() {
+    return this.args.translatedLabel ?? this.intl.t(this.args.section.label);
   }
 
   copyToClipboard = task(async () => {
@@ -31,9 +36,9 @@ class DownloadButton extends Component {
       ...attributes
     >
       {{#if this.isSuccess}}
-        {{t 'copy-options.part-copied' part=(t @section.label)}}
+        {{t 'copy-options.part-copied' part=this.label}}
       {{else}}
-        {{t 'copy-options.copy-part' part=(t @section.label)}}
+        {{t 'copy-options.copy-part' part=this.label}}
       {{/if}}
     </AuButton>
   </template>
@@ -55,8 +60,14 @@ const SECTIONS = [
   {
     label: 'copy-options.section.ruling',
     selector:
-      '[property="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"][resource="http://data.vlaanderen.be/ns/besluit#Artikel"]',
-    callback: (selected) => selected.parentElement?.parentElement,
+      ':scope [about^="http://data.lblod.info/id/besluiten/"][property="http://www.w3.org/ns/prov#value"]',
+    parts: {
+      selector:
+        '[property="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"][resource="http://data.vlaanderen.be/ns/besluit#Artikel"]',
+      callback: (selected) => selected.parentElement?.parentElement,
+      labelSelector: ':scope h5',
+      contentSelector: ':scope [data-say-structure-content=true]',
+    },
   },
 ];
 
@@ -75,18 +86,36 @@ function update(component) {
     component.args.decision.content,
     'text/html',
   );
-  return SECTIONS.flatMap(({ label, selector, callback = (a) => a }) => {
+  return SECTIONS.flatMap(({ label, selector, parts, callback = (a) => a }) => {
     const elements = Array.from(parsed.querySelectorAll(selector));
-    return elements.map((element) => ({
-      label,
-      content: callback(element).outerHTML,
-    }));
+    return elements.map((element) => {
+      const contentElement = callback(element);
+      let foundParts = [];
+      if (parts) {
+        const partCb = parts.callback || ((a) => a);
+        const partElements = contentElement.querySelectorAll(parts.selector);
+        partElements.forEach((part) => {
+          const partElement = partCb(part);
+          const partLabel = partElement.querySelector(parts.labelSelector);
+          const partContent = partElement.querySelector(
+            parts.contentSelector,
+          ).outerHTML;
+          foundParts.push({
+            translatedLabel: partLabel.textContent,
+            content: partContent,
+          });
+        });
+      }
+      return {
+        label,
+        content: contentElement.outerHTML,
+        parts: foundParts,
+      };
+    });
   });
 }
 
 export default class DecisionCopyParts extends Component {
-  @service intl;
-
   @trackedReset({
     memo: 'decision.content',
     update,
@@ -94,18 +123,38 @@ export default class DecisionCopyParts extends Component {
   sections = update(this);
 
   <template>
-    <div class='au-o-flow--small'>
+    <div class='au-o-flow--small au-u-3-5'>
       {{#each this.sections as |section|}}
-        <div class='au-u-flex'>
+        <div class='gn-meeting-copy-section--container'>
           <div class='say-structure'>
             <div class='say-structure__header'>
               {{t section.label}}
             </div>
-            <div class='say-structure__content'>
-              {{(htmlSafer section.content)}}
-            </div>
+            {{#each section.parts as |part|}}
+              <div class='say-structure__content'>
+                <div class='gn-meeting-copy-section--container'>
+                  <div class='say-structure'>
+                    <div class='say-structure__header'>
+                      {{part.translatedLabel}}
+                    </div>
+                    <div class='say-structure__content'>
+                      {{(htmlSafer part.content)}}
+                    </div>
+                  </div>
+                  <div class='gn-meeting-copy-section--button'>
+                    <DownloadButton @section={{part}} @translatedLabel={{part.translatedLabel}} />
+                  </div>
+                </div>
+              </div>
+            {{else}}
+              <div class='say-structure__content'>
+                {{(htmlSafer section.content)}}
+              </div>
+            {{/each}}
           </div>
-          <DownloadButton @section={{section}} />
+          <div class='gn-meeting-copy-section--button'>
+            <DownloadButton @section={{section}} />
+          </div>
         </div>
       {{/each}}
     </div>

--- a/app/components/decision-copy-parts.gjs
+++ b/app/components/decision-copy-parts.gjs
@@ -22,7 +22,9 @@ class DownloadButton extends Component {
   }
 
   copyToClipboard = task(async () => {
-    await navigator.clipboard.writeText(this.args.section.content.trim());
+    await navigator.clipboard.write([
+      new ClipboardItem({ 'text/html': this.args.section.content.trim() }),
+    ]);
   });
 
   <template>

--- a/app/components/decision-copy-parts.gjs
+++ b/app/components/decision-copy-parts.gjs
@@ -56,6 +56,21 @@ const SECTIONS = [
   {
     label: 'copy-options.section.motivation',
     selector: '[property="http://data.vlaanderen.be/ns/besluit#motivering"]',
+    parts: {
+      selector: ':scope h5',
+      callback: (sectionHeading) => {
+        const wrapper = document.createElement('div');
+        const sectionContents = [];
+        let next = sectionHeading.nextElementSibling;
+        while (next && next.tagName !== 'H5') {
+          sectionContents.push(next);
+          next = next.nextElementSibling;
+        }
+        wrapper.append(...sectionContents);
+        return wrapper;
+      },
+      labelCallback: (sectionHeading) => sectionHeading,
+    },
   },
   {
     label: 'copy-options.section.ruling',
@@ -92,13 +107,16 @@ function update(component) {
       let foundParts = [];
       if (parts) {
         const partCb = parts.callback || ((a) => a);
-        const partElements = contentElement.querySelectorAll(parts.selector);
+        const partElements =
+          contentElement.querySelectorAll(parts.selector) ?? [];
         partElements.forEach((part) => {
           const partElement = partCb(part);
-          const partLabel = partElement.querySelector(parts.labelSelector);
-          const partContent = partElement.querySelector(
-            parts.contentSelector,
-          ).outerHTML;
+          const partLabel = parts.labelCallback
+            ? parts.labelCallback(part)
+            : partElement.querySelector(parts.labelSelector);
+          const partContent = parts.contentSelector
+            ? partElement.querySelector(parts.contentSelector).outerHTML
+            : partElement.outerHTML;
           foundParts.push({
             translatedLabel: partLabel.textContent,
             content: partContent,

--- a/app/components/decision-copy-parts.gjs
+++ b/app/components/decision-copy-parts.gjs
@@ -1,0 +1,113 @@
+import Component from '@glimmer/component';
+import { service } from '@ember/service';
+import { htmlSafe } from '@ember/template';
+import { on } from '@ember/modifier';
+import { task } from 'ember-concurrency';
+import perform from 'ember-concurrency/helpers/perform';
+import t from 'ember-intl/helpers/t';
+import { trackedReset } from 'tracked-toolbox';
+import AuButton from '@appuniversum/ember-appuniversum/components/au-button';
+
+class DownloadButton extends Component {
+  get isSuccess() {
+    return this.copyToClipboard.last?.isSuccessful;
+  }
+  get icon() {
+    return this.isSuccess ? 'circle-check' : undefined;
+  }
+
+  copyToClipboard = task(async () => {
+    await navigator.clipboard.writeText(this.args.section.content.trim());
+  });
+
+  <template>
+    <AuButton
+      @skin='link'
+      @icon={{this.icon}}
+      @loading={{this.copyToClipboard.isRunning}}
+      @loadingMessage={{t 'copy-options.copying'}}
+      class={{if this.isSuccess 'download-meeting-part-downloaded'}}
+      {{on 'click' (perform this.copyToClipboard)}}
+      ...attributes
+    >
+      {{#if this.isSuccess}}
+        {{t 'copy-options.part-copied' part=(t @section.label)}}
+      {{else}}
+        {{t 'copy-options.copy-part' part=(t @section.label)}}
+      {{/if}}
+    </AuButton>
+  </template>
+}
+
+const SECTIONS = [
+  {
+    label: 'copy-options.section.title',
+    selector: '[property="http://data.europa.eu/eli/ontology#title"]',
+  },
+  {
+    label: 'copy-options.section.description',
+    selector: '[property="http://data.europa.eu/eli/ontology#description"]',
+  },
+  {
+    label: 'copy-options.section.motivation',
+    selector: '[property="http://data.vlaanderen.be/ns/besluit#motivering"]',
+  },
+  {
+    label: 'copy-options.section.ruling',
+    selector:
+      '[property="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"][resource="http://data.vlaanderen.be/ns/besluit#Artikel"]',
+    callback: (selected) => selected.parentElement?.parentElement,
+  },
+];
+
+function htmlSafer(text) {
+  return htmlSafe(text);
+}
+
+// This method of looking for query selectors is error-prone as it assumes that the document follows
+// the current DOM output specs. This is not necessarily true of historic or future documents. It
+// would be better to either use an RDFa parser that can also return the elements associated with
+// relations or a headless prosemirror instance.
+function update(component) {
+  console.warn('content processing!');
+  const parser = new DOMParser();
+  const parsed = parser.parseFromString(
+    component.args.decision.content,
+    'text/html',
+  );
+  return SECTIONS.flatMap(({ label, selector, callback = (a) => a }) => {
+    const elements = Array.from(parsed.querySelectorAll(selector));
+    return elements.map((element) => ({
+      label,
+      content: callback(element).outerHTML,
+    }));
+  });
+}
+
+export default class DecisionCopyParts extends Component {
+  @service intl;
+
+  @trackedReset({
+    memo: 'decision.content',
+    update,
+  })
+  sections = update(this);
+
+  <template>
+    <div class='au-o-flow--small'>
+      {{#each this.sections as |section|}}
+        <div class='au-u-flex'>
+          <div class='say-structure'>
+            <div class='say-structure__header'>
+              {{t section.label}}
+            </div>
+            <div class='say-structure__content'>
+              {{(htmlSafer section.content)}}
+            </div>
+          </div>
+          <DownloadButton @section={{section}} />
+        </div>
+      {{/each}}
+    </div>
+  </template>
+}

--- a/app/components/decision-copy-parts.gjs
+++ b/app/components/decision-copy-parts.gjs
@@ -80,7 +80,6 @@ function htmlSafer(text) {
 // would be better to either use an RDFa parser that can also return the elements associated with
 // relations or a headless prosemirror instance.
 function update(component) {
-  console.warn('content processing!');
   const parser = new DOMParser();
   const parsed = parser.parseFromString(
     component.args.decision.content,
@@ -125,34 +124,34 @@ export default class DecisionCopyParts extends Component {
   <template>
     <div class='au-o-flow--small au-u-3-5'>
       {{#each this.sections as |section|}}
-        <div class='gn-meeting-copy-section--container'>
-          <div class='say-structure'>
-            <div class='say-structure__header'>
+        <div class='gn-meeting-copy--section-container'>
+          <div class='gn-meeting-copy--structure'>
+            <div class='gn-meeting-copy--structure-header'>
               {{t section.label}}
             </div>
             {{#each section.parts as |part|}}
-              <div class='say-structure__content'>
-                <div class='gn-meeting-copy-section--container'>
-                  <div class='say-structure'>
-                    <div class='say-structure__header'>
+              <div class='gn-meeting-copy--structure-content'>
+                <div class='gn-meeting-copy--section-container'>
+                  <div class='gn-meeting-copy--structure'>
+                    <div class='gn-meeting-copy--structure-header'>
                       {{part.translatedLabel}}
                     </div>
-                    <div class='say-structure__content'>
+                    <div class='gn-meeting-copy--structure-content'>
                       {{(htmlSafer part.content)}}
                     </div>
                   </div>
-                  <div class='gn-meeting-copy-section--button'>
+                  <div class='gn-meeting-copy--section-button'>
                     <DownloadButton @section={{part}} @translatedLabel={{part.translatedLabel}} />
                   </div>
                 </div>
               </div>
             {{else}}
-              <div class='say-structure__content'>
+              <div class='gn-meeting-copy--structure-content'>
                 {{(htmlSafer section.content)}}
               </div>
             {{/each}}
           </div>
-          <div class='gn-meeting-copy-section--button'>
+          <div class='gn-meeting-copy--section-button'>
             <DownloadButton @section={{section}} />
           </div>
         </div>

--- a/app/components/decision-copy-parts.gjs
+++ b/app/components/decision-copy-parts.gjs
@@ -47,15 +47,18 @@ class DownloadButton extends Component {
 const SECTIONS = [
   {
     label: 'copy-options.section.title',
-    selector: '[property="http://data.europa.eu/eli/ontology#title"]',
+    selector:
+      '[property="http://data.europa.eu/eli/ontology#title"]>[data-content-container="true"]',
   },
   {
     label: 'copy-options.section.description',
-    selector: '[property="http://data.europa.eu/eli/ontology#description"]',
+    selector:
+      '[property="http://data.europa.eu/eli/ontology#description"]>[data-content-container="true"]',
   },
   {
     label: 'copy-options.section.motivation',
-    selector: '[property="http://data.vlaanderen.be/ns/besluit#motivering"]',
+    selector:
+      '[property="http://data.vlaanderen.be/ns/besluit#motivering"]>[data-content-container="true"]',
     parts: {
       selector: ':scope h5',
       callback: (sectionHeading) => {
@@ -75,7 +78,7 @@ const SECTIONS = [
   {
     label: 'copy-options.section.ruling',
     selector:
-      ':scope [about^="http://data.lblod.info/id/besluiten/"][property="http://www.w3.org/ns/prov#value"]',
+      ':scope [about^="http://data.lblod.info/id/besluiten/"][property="http://www.w3.org/ns/prov#value"]>[data-content-container="true"]',
     parts: {
       selector:
         '[property="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"][resource="http://data.vlaanderen.be/ns/besluit#Artikel"]',

--- a/app/components/meeting-form.hbs
+++ b/app/components/meeting-form.hbs
@@ -80,8 +80,12 @@
           <DeleteMeeting @meeting={{@zitting}} />
         {{/unless}}
       </AuDropdown>
-      {{#if this.isComplete}}
-        <AuButton @skin='secondary' {{on 'click' this.goToPublish}}>
+      {{#if (or this.isComplete this.isLoading)}}
+        <AuButton
+          @skin='secondary'
+          @loading={{this.isLoading}}
+          {{on 'click' this.goToPublish}}
+        >
           {{t 'meeting-form.publish-button'}}
         </AuButton>
       {{else}}

--- a/app/components/meeting-form.js
+++ b/app/components/meeting-form.js
@@ -75,6 +75,9 @@ export default class MeetingForm extends Component {
     return this.zitting instanceof InstallatieVergaderingModel;
   }
 
+  get isLoading() {
+    return this.fetchTreatments.isRunning;
+  }
   get isComplete() {
     return !this.zitting?.isNew && this.behandelingen?.length > 0;
   }

--- a/app/controllers/meetings/download/copy.js
+++ b/app/controllers/meetings/download/copy.js
@@ -7,7 +7,7 @@ export default class MeetingsDownloadCopyController extends Controller {
   @action
   async copyToClipboard(text) {
     // TODO error handling, e.g. not secure...
-    await navigator.clipboard.writeText(text.trim());
+    await navigator.clipboard.write([new ClipboardItem({ 'text/html': text })]);
   }
 
   get previewDocument() {

--- a/app/controllers/meetings/download/index.js
+++ b/app/controllers/meetings/download/index.js
@@ -11,7 +11,9 @@ export default class MeetingsDownloadController extends Controller {
     return this.model;
   }
   get agendapoints() {
-    return this.zitting.agendapunten;
+    return this.zitting.agendapunten
+      .slice()
+      .sort((a, b) => a.position - b.position);
   }
   get meetingDateForTitle() {
     if (this.zitting?.gestartOpTijdstip) {

--- a/app/routes/meetings/download.js
+++ b/app/routes/meetings/download.js
@@ -6,9 +6,8 @@ export default class MeetingsDownloadRoute extends Route {
   async model(params) {
     const zitting = await this.store.findRecord('zitting', params.id, {
       include:
-        'bestuursorgaan,agendapunten.behandeling,agendapunten.behandeling.document-container',
+        'bestuursorgaan,agendapunten,agendapunten.behandeling,agendapunten.behandeling.document-container',
     });
-    zitting.agendapunten = [...(await zitting.agendapunten)].sortBy('position');
     return zitting;
   }
 }

--- a/app/routes/meetings/publish.js
+++ b/app/routes/meetings/publish.js
@@ -8,7 +8,6 @@ export default class MeetingsPublishRoute extends Route {
     const zitting = await this.store.findRecord('zitting', params.id, {
       include: 'aanwezigen-bij-start,agendapunten,secretaris,voorzitter',
     });
-    zitting.agendapunten = [...(await zitting.agendapunten)].sortBy('position');
     return zitting;
   }
 }

--- a/app/styles/project/_c-meeting-chrome.scss
+++ b/app/styles/project/_c-meeting-chrome.scss
@@ -402,3 +402,17 @@
     border-radius: $au-unit;
   }
 }
+
+.gn-meeting-copy-section--container {
+  // We don't actually do any positioning, just need this to be 'positioned' to allow children to be
+  // positioned relative to it
+  position: relative;
+}
+
+.gn-meeting-copy-section--button {
+  position: absolute;
+  right: 0;
+  top: 0;
+  // Width 0 container div for the button to allow for positioning independent of text length
+  width: 0;
+}

--- a/app/styles/project/_c-meeting-chrome.scss
+++ b/app/styles/project/_c-meeting-chrome.scss
@@ -403,16 +403,33 @@
   }
 }
 
-.gn-meeting-copy-section--container {
+.gn-meeting-copy--section-container {
   // We don't actually do any positioning, just need this to be 'positioned' to allow children to be
   // positioned relative to it
   position: relative;
 }
-
-.gn-meeting-copy-section--button {
+.gn-meeting-copy--section-button {
   position: absolute;
   right: 0;
   top: 0;
   // Width 0 container div for the button to allow for positioning independent of text length
   width: 0;
+}
+.gn-meeting-copy--section-container
+  .gn-meeting-copy--section-container
+  .gn-meeting-copy--section-button {
+  right: -1rem;
+}
+.gn-meeting-copy--structure {
+  border: 0.1rem solid var(--au-gray-300);
+  border-radius: var(--au-radius);
+}
+.gn-meeting-copy--structure-header {
+  background-color: var(--au-gray-100);
+  border-bottom: 0.1rem solid var(--au-gray-300);
+  padding-left: 0.7rem;
+  font-weight: var(--au-medium);
+}
+.gn-meeting-copy--structure-content {
+  margin: 1rem;
 }

--- a/app/templates/meetings/download/copy.hbs
+++ b/app/templates/meetings/download/copy.hbs
@@ -51,7 +51,9 @@
         />
       </Group>
     </AuToolbar>
-    <p class='au-u-padding'>{{t 'copy-options.disclaimer'}}</p>
+    <p class='au-u-margin-left au-u-margin-bottom'>{{t
+        'copy-options.disclaimer'
+      }}</p>
     <div
       class='au-u-flex au-u-flex--column au-u-flex--vertical-center au-u-margin-bottom-large'
     >

--- a/app/templates/meetings/download/copy.hbs
+++ b/app/templates/meetings/download/copy.hbs
@@ -55,17 +55,7 @@
     <div
       class='au-u-flex au-u-flex--column au-u-flex--vertical-center au-u-margin-bottom-large'
     >
-      <AuPanel @active={{true}} class='au-u-3-5' as |Panel|>
-        <Panel>
-          <AuHeading
-            @level={{4}}
-            @skin={{4}}
-          >{{@model.document.title}}</AuHeading>
-        </Panel>
-        <Panel>
-          {{this.previewDocument}}
-        </Panel>
-      </AuPanel>
+      <DecisionCopyParts @decision={{@model.document}} />
     </div>
   </m.content>
 </AuMainContainer>

--- a/app/templates/meetings/download/index.hbs
+++ b/app/templates/meetings/download/index.hbs
@@ -7,7 +7,7 @@
     <Group>
       <AuLink
         @route='meetings.edit'
-        @model={{@model.id}}
+        @model={{this.zitting.id}}
         @skin='secondary'
         @icon='arrow-left'
         @iconAlignment='left'
@@ -150,7 +150,7 @@
             <td><AuLink
                 @route='meetings.download.copy'
                 @models={{(array
-                  @model agendapoint.behandeling.documentContainer.id
+                  this.zitting agendapoint.behandeling.documentContainer.id
                 )}}
               >
                 {{t 'download.table.copy-options'}}

--- a/app/templates/meetings/download/index.hbs
+++ b/app/templates/meetings/download/index.hbs
@@ -149,7 +149,9 @@
               /></td>
             <td><AuLink
                 @route='meetings.download.copy'
-                @model={{agendapoint.behandeling.documentContainer.id}}
+                @models={{(array
+                  @model agendapoint.behandeling.documentContainer.id
+                )}}
               >
                 {{t 'download.table.copy-options'}}
               </AuLink></td>

--- a/app/templates/mock-login.hbs
+++ b/app/templates/mock-login.hbs
@@ -34,7 +34,7 @@
 
         <MockLogin as |login|>
           {{#if this.queryStore.isRunning}}
-            <AuLoader @padding='small' />
+            <AuLoader @padding='small'>{{t 'application.loading'}}</AuLoader>
           {{else}}
             {{#if this.login.errorMessage}}
               <AuAlert

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -807,3 +807,10 @@ copy-options:
   copy-all: Copy full decision
   copying: copying
   completed: copied
+  copy-part: 'Copy {part}'
+  part-copied: '{part} copied'
+  section:
+    title: Title
+    description: Description
+    motivation: Motivation
+    ruling: Ruling

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -811,3 +811,10 @@ copy-options:
   copy-all: Volledig besluit kopieren
   copying: kopiëren
   completed: gekopieerd
+  copy-part: 'Kopieer {part}'
+  part-copied: '{part} gekopieerd'
+  section:
+    title: Titel
+    description: Beschrijving
+    motivation: Motivering
+    ruling: Beslissing


### PR DESCRIPTION
### Overview
Use query selectors to pull apart a decision document to pull out the individual parts, to allow for these to be pasted into an external editor. Should maintain all of the content of each section, without setting the URIs for the sections.

##### connected issues and PRs:
Builds on: https://github.com/lblod/frontend-gelinkt-notuleren/pull/728
Jira ticket: https://binnenland.atlassian.net/browse/GN-5067

### Setup
N/A

### How to test/reproduce
You should be able to copy just the parts now. It should handle incomplete documents by simply not showing the parts it cannot find.

### Challenges/uncertainties
This is very hacky and it's not entirely clear what should be included in the copied contents.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
