### PR TITLE
GN-5088: add LMB table configs for the RMW IV

### DIFF
--- a/.changeset/clean-kings-turn.md
+++ b/.changeset/clean-kings-turn.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Implement a more extendable way to determine the correct bestuursorgaan-classificatie for a new inauguration meeting

--- a/.changeset/fair-boxes-sleep.md
+++ b/.changeset/fair-boxes-sleep.md
@@ -1,0 +1,6 @@
+---
+'frontend-gelinkt-notuleren': minor
+---
+
+**LMB IV RMW tables**
+Add configs for the necessary LMB tables for the RMW IV

--- a/.changeset/slow-seals-bathe.md
+++ b/.changeset/slow-seals-bathe.md
@@ -1,0 +1,7 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+**IVGR LMB tables: adjust fractie-splitsing query**
+- Adjustment in how verkiezing and kieslijsten are determined
+- Fix variable name

--- a/app/components/inauguration-meeting/synchronization.js
+++ b/app/components/inauguration-meeting/synchronization.js
@@ -11,7 +11,10 @@ import ENV from 'frontend-gelinkt-notuleren/config/environment';
 import InaugurationMeetingSynchronizationToast from './synchronization-toast';
 import { syncDocument } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/mandatee-table-plugin';
 import SaySerializer from '@lblod/ember-rdfa-editor/core/say-serializer';
-import { mandateeTableConfigIVGR } from '../../config/mandatee-table-config';
+import {
+  mandateeTableConfigIVGR,
+  mandateeTableConfigRMW,
+} from '../../config/mandatee-table-config';
 
 export default class InaugurationMeetingSynchronizationComponent extends Component {
   @service toaster;
@@ -194,10 +197,10 @@ export default class InaugurationMeetingSynchronizationComponent extends Compone
     const currentVersion = await container.currentVersion;
     const html = currentVersion.content ?? '';
     const initialState = this.agendapointEditor.getState(html);
-    const syncedState = await syncDocument(
-      initialState,
-      mandateeTableConfigIVGR(this.meeting),
-    );
+    const syncedState = await syncDocument(initialState, {
+      ...mandateeTableConfigIVGR(this.meeting),
+      ...mandateeTableConfigRMW(this.meeting),
+    });
     const serializer = SaySerializer.fromSchema(
       syncedState.schema,
       () => syncedState,

--- a/app/config/constants.js
+++ b/app/config/constants.js
@@ -63,10 +63,6 @@ export const BESTUURSPERIODES = {
     'http://data.lblod.info/id/concept/Bestuursperiode/96efb929-5d83-48fa-bfbb-b98dfb1180c7',
 };
 
-export const LOKALE_VERKIEZINGEN = {
-  2024: 'http://data.lblod.info/id/rechtstreekse-verkiezingen/612a57de-7fc2-40af-a7dc-17d544e5de20',
-};
-
 export const MANDATARIS_STATUS_CODES = {
   EFFECTIEF:
     'http://data.vlaanderen.be/id/concept/MandatarisStatusCode/21063a5b-912c-4241-841c-cc7fb3c73e75',
@@ -76,4 +72,36 @@ export const MANDATARIS_STATUS_CODES = {
     'http://data.vlaanderen.be/id/concept/MandatarisStatusCode/c301248f-0199-45ca-b3e5-4c596731d5fe',
   WAARNEMEND:
     'http://data.vlaanderen.be/id/concept/MandatarisStatusCode/e1ca6edd-55e1-4288-92a5-53f4cf71946a',
+};
+
+export const BESTUURSEENHEID_CLASSIFICATIE_CODES = {
+  GEMEENTE:
+    'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001',
+  PROVINCIE:
+    'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000',
+  OCMW: 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000002',
+  DISTRICT:
+    'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000003',
+};
+
+export const BESTUURSORGAAN_CLASSIFICATIE_CODES = {
+  GEMEENTERAAD:
+    'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000005',
+  PROVINCIERAAD:
+    'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000c',
+  DISTRICTSRAAD:
+    'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000a',
+  OCMW_RAAD:
+    'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000007',
+};
+
+export const IV_CLASSIFICATIE_MAP = {
+  [BESTUURSEENHEID_CLASSIFICATIE_CODES.GEMEENTE]:
+    BESTUURSORGAAN_CLASSIFICATIE_CODES.GEMEENTERAAD,
+  [BESTUURSEENHEID_CLASSIFICATIE_CODES.PROVINCIE]:
+    BESTUURSORGAAN_CLASSIFICATIE_CODES.PROVINCIERAAD,
+  [BESTUURSEENHEID_CLASSIFICATIE_CODES.DISTRICT]:
+    BESTUURSORGAAN_CLASSIFICATIE_CODES.DISTRICTSRAAD,
+  [BESTUURSEENHEID_CLASSIFICATIE_CODES.OCMW]:
+    BESTUURSORGAAN_CLASSIFICATIE_CODES.OCMW_RAAD,
 };

--- a/app/config/mandatee-table-config.js
+++ b/app/config/mandatee-table-config.js
@@ -976,7 +976,7 @@ export const mandateeTableConfigRMW = (meeting) => {
           # TODO: http or https?
           PREFIX regorg: <https://www.w3.org/ns/regorg#>
           SELECT DISTINCT ?fractie ?fractie_naam (COUNT(DISTINCT ?persoon) as ?fractie_aantal_zetels) WHERE {
-            ?bestuursorgaan lmb:heeftBestuursperiode <${BESTUURSPERIODES['2019-2024']}>.
+            ?bestuursorgaan lmb:heeftBestuursperiode <${BESTUURSPERIODES['2024-heden']}>.
 
             ?fractie org:memberOf ?bestuursorgaan.
             ?fractie regorg:legalName ?fractie_naam.
@@ -1060,7 +1060,7 @@ export const mandateeTableConfigRMW = (meeting) => {
             ?mandaat org:role <${BESTUURSFUNCTIE_CODES.LID_BCSD}>.
 
             ?bestuursorgaan org:hasPost ?mandaat.
-            ?bestuursorgaan lmb:heeftBestuursperiode <${BESTUURSPERIODES['2019-2024']}>.
+            ?bestuursorgaan lmb:heeftBestuursperiode <${BESTUURSPERIODES['2024-heden']}>.
           }
         `;
         return executeQuery({
@@ -1138,7 +1138,7 @@ export const mandateeTableConfigRMW = (meeting) => {
             ?mandaat org:role <${BESTUURSFUNCTIE_CODES.LID_BCSD}>.
 
             ?bestuursorgaan org:hasPost ?mandaat.
-            ?bestuursorgaan lmb:heeftBestuursperiode <${BESTUURSPERIODES['2019-2024']}>.
+            ?bestuursorgaan lmb:heeftBestuursperiode <${BESTUURSPERIODES['2024-heden']}>.
           }
         `;
         return executeQuery({
@@ -1243,7 +1243,7 @@ export const mandateeTableConfigRMW = (meeting) => {
             ?mandaat org:role <${BESTUURSFUNCTIE_CODES.LID_BCSD}>.
 
             ?bestuursorgaan org:hasPost ?mandaat.
-            ?bestuursorgaan lmb:heeftBestuursperiode <${BESTUURSPERIODES['2019-2024']}>.
+            ?bestuursorgaan lmb:heeftBestuursperiode <${BESTUURSPERIODES['2024-heden']}>.
           }
         `;
         return executeQuery({
@@ -1312,7 +1312,7 @@ export const mandateeTableConfigRMW = (meeting) => {
             ?mandaat org:role <${BESTUURSFUNCTIE_CODES.LID_BCSD}>.
 
             ?bestuursorgaan org:hasPost ?mandaat.
-            ?bestuursorgaan lmb:heeftBestuursperiode <${BESTUURSPERIODES['2019-2024']}>.
+            ?bestuursorgaan lmb:heeftBestuursperiode <${BESTUURSPERIODES['2024-heden']}>.
           }
         `;
         return executeQuery({

--- a/app/routes/inbox/meetings/new-inauguration.js
+++ b/app/routes/inbox/meetings/new-inauguration.js
@@ -1,12 +1,7 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 import { format } from 'date-fns/fp';
-
-import { GEMEENTE } from '../../../utils/bestuurseenheid-classificatie-codes';
-import {
-  GEMEENTERAAD,
-  RAAD_VOOR_MAATSCHAPPELIJK_WELZIJN,
-} from '../../../utils/classification-utils';
+import { IV_CLASSIFICATIE_MAP } from '../../../config/constants';
 
 export default class InboxMeetingsNewInaugurationRoute extends Route {
   @service currentSession;
@@ -41,10 +36,7 @@ export default class InboxMeetingsNewInaugurationRoute extends Route {
               id: this.currentSession.group.id,
             },
             classificatie: {
-              ':uri:':
-                unitClass.uri === GEMEENTE
-                  ? GEMEENTERAAD
-                  : RAAD_VOOR_MAATSCHAPPELIJK_WELZIJN,
+              ':uri:': IV_CLASSIFICATIE_MAP[unitClass.uri],
             },
           },
         },

--- a/app/services/editor/agendapoint.js
+++ b/app/services/editor/agendapoint.js
@@ -106,7 +106,7 @@ import {
   snippetView,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/nodes/snippet';
 
-import { IVGR_TAGS } from '../../config/mandatee-table-config';
+import { IVGR_TAGS, RMW_TAGS } from '../../config/mandatee-table-config';
 import { variableAutofillerPlugin } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/plugins/autofiller';
 import { emberApplication } from '@lblod/ember-rdfa-editor/plugins/ember-application';
 import { getOwner } from '@ember/application';
@@ -237,7 +237,7 @@ export default class AgendapointEditorService extends Service {
         endpoint: '/lpdc-service',
       },
       mandateeTable: {
-        tags: IVGR_TAGS,
+        tags: [...IVGR_TAGS, ...RMW_TAGS],
         defaultTag: IVGR_TAGS[0],
       },
       lmb: {

--- a/app/utils/editor-utils.js
+++ b/app/utils/editor-utils.js
@@ -5,6 +5,7 @@ import {
   XSD,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 import { unwrap } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
+import { isSome } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
 import { sayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -67,11 +68,11 @@ export function dateNode(schema, value) {
         predicate: DCT('type').full,
         object: sayDataFactory.literal('date', XSD('date').namedNode),
       },
-      {
+      value && {
         predicate: EXT('content').full,
         object: sayDataFactory.literal(value, XSD('date')),
       },
-    ],
+    ].filter(isSome),
     backlinks: [],
   });
 }


### PR DESCRIPTION
### Overview
This PR adds LMB-table configs for the 'Installatievergadering' of the 'Raad van maatschappelijk welzijn'.
Specifically, it adds configs for the following dynamic tables:
- 'Zetelverdeling van de BSCD (Bijzonder comite voor de sociale dienst)'
- 'Kandidaat-leden BSCD'
- 'Verkiezing leden BCSD' (this one contains the `mandaat:bekrachtigdAanstellingVan` annotations)
- 'Geloofsbrieven leden BSCD'
- 'Eedaflegging leden BCSD'

As you'll notice while testing this PR, some of these tables have empty cells which we can't derive/automatically fill-in based on LMB.

##### connected issues and PRs:
[GN-5088](https://binnenland.atlassian.net/browse/GN-5088)

### Setup
None

### How to test/reproduce
- You'll need to test this PR logged in as an OCMW
- Create a new IV
- Add the necessary (configured with the new RMW tags) LMB tables in any AP (the second is the legally correct one)
- Test the sync flow
- Ensure the tables are filled in with sensible data on the previous legislation

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
