### PR TITLE
Fixes to copy parts functionality

### DIFF
--- a/.changeset/fast-jokes-tie.md
+++ b/.changeset/fast-jokes-tie.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Fix handling of motivation section when copying parts of decisions to clipboard

--- a/app/components/decision-copy-parts.gjs
+++ b/app/components/decision-copy-parts.gjs
@@ -109,6 +109,10 @@ function update(component) {
     const elements = Array.from(parsed.querySelectorAll(selector));
     return elements.map((element) => {
       const contentElement = callback(element);
+      // Note, it's important to generate the content here as with the use of DOM apis in the
+      // callbacks, it's easy to accidentally mutate `contentElement`. For example when appending
+      // parts of the content to a 'container' element.
+      const contentHtml = contentElement.outerHTML;
       let foundParts = [];
       if (parts) {
         const partCb = parts.callback || ((a) => a);
@@ -132,7 +136,7 @@ function update(component) {
       }
       return {
         label,
-        content: contentElement.outerHTML,
+        content: contentHtml,
         parts: foundParts,
       };
     });

--- a/app/components/decision-copy-parts.gjs
+++ b/app/components/decision-copy-parts.gjs
@@ -120,12 +120,14 @@ function update(component) {
             ? parts.labelCallback(part)
             : partElement.querySelector(parts.labelSelector);
           const partContent = parts.contentSelector
-            ? partElement.querySelector(parts.contentSelector).outerHTML
+            ? partElement.querySelector(parts.contentSelector)?.outerHTML
             : partElement.outerHTML;
-          foundParts.push({
-            translatedLabel: partLabel.textContent,
-            content: partContent,
-          });
+          if (partLabel && partContent) {
+            foundParts.push({
+              translatedLabel: partLabel.textContent,
+              content: partContent,
+            });
+          }
         });
       }
       return {

--- a/app/controllers/meetings/download/copy.js
+++ b/app/controllers/meetings/download/copy.js
@@ -7,7 +7,7 @@ import { copyStringToClipboard } from '../../../utils/copy-string-to-clipboard';
 export default class MeetingsDownloadCopyController extends Controller {
   @action
   async copyToClipboard(text) {
-    await copyStringToClipboard({ html: text }, true);
+    await copyStringToClipboard({ html: text });
   }
 
   get previewDocument() {

--- a/app/controllers/meetings/download/copy.js
+++ b/app/controllers/meetings/download/copy.js
@@ -7,7 +7,7 @@ import { copyStringToClipboard } from '../../../utils/copy-string-to-clipboard';
 export default class MeetingsDownloadCopyController extends Controller {
   @action
   async copyToClipboard(text) {
-    await copyStringToClipboard({ html: text });
+    await copyStringToClipboard({ html: text }, true);
   }
 
   get previewDocument() {

--- a/app/styles/project/_c-inauguration-meeting-synchronization.scss
+++ b/app/styles/project/_c-inauguration-meeting-synchronization.scss
@@ -80,8 +80,8 @@
   }
 }
 .meeting__sync-mocal__treatments__entry__header {
-  width: 60%
+  width: 60%;
 }
 .meeting__sync-mocal__treatments__entry__pill {
-  width: 40%
+  width: 40%;
 }


### PR DESCRIPTION
### Overview
There are 3 fixes here of increasing subtlety:
1. ~~Set the copy-all button on the copy screen to set the plaintext mime type as well as text/html.~~
2. Prevent articles from before the `data-say-structure-content` attribute was added to article nodes from crashing the component.
3. Extract the `outerHTML` of the section before extracting parts, as `append()`ing of content elements to a `div` element in the callback function removes them from the element, and so from the `outerHTML` if we generate it after doing this.
4. Working around Firefox stripping many RDFa attributes when using the clipboard API.

##### connected issues and PRs:
Fixes the result of https://github.com/lblod/frontend-gelinkt-notuleren/pull/731
Fixes: https://binnenland.atlassian.net/browse/GN-5127

### Setup
N/A

### How to test/reproduce
For any meeting, go to the 'copy parts' screen for an agendapoint with a correct motivation section. How to test the two relevant fixes:
1. ~~Click the 'copy full decision' button and look at the `text/plain` clipboard contents~~
3. copy the whole motivation section (not the individual parts). Previously this was only extracting the headings, now it is the whole content.
4. Verify that on Firefox attributes such as `property` are maintained in the output.
To test 2. open the same screen for an agendapoint created more than 4 months ago, and note that the screen works. Previously the content was blank and there was an error in the console.

### Challenges/uncertainties
It's really unclear from the docs why 3. is actually happening, as it's not clear that appending a node to an element removes it from its previous parent.
The clipboard API on Firefox strips attributes in a way that doesn't seem to be documented anywhere, or at least, not anywhere that I could find.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
