### PR TITLE
fix(lmb-tables): adjust fractie-splitsing query

### DIFF
--- a/.changeset/clean-kings-turn.md
+++ b/.changeset/clean-kings-turn.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Implement a more extendable way to determine the correct bestuursorgaan-classificatie for a new inauguration meeting

--- a/.changeset/slow-seals-bathe.md
+++ b/.changeset/slow-seals-bathe.md
@@ -1,0 +1,7 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+**IVGR LMB tables: adjust fractie-splitsing query**
+- Adjustment in how verkiezing and kieslijsten are determined
+- Fix variable name

--- a/app/config/constants.js
+++ b/app/config/constants.js
@@ -63,10 +63,6 @@ export const BESTUURSPERIODES = {
     'http://data.lblod.info/id/concept/Bestuursperiode/96efb929-5d83-48fa-bfbb-b98dfb1180c7',
 };
 
-export const LOKALE_VERKIEZINGEN = {
-  2024: 'http://data.lblod.info/id/rechtstreekse-verkiezingen/612a57de-7fc2-40af-a7dc-17d544e5de20',
-};
-
 export const MANDATARIS_STATUS_CODES = {
   EFFECTIEF:
     'http://data.vlaanderen.be/id/concept/MandatarisStatusCode/21063a5b-912c-4241-841c-cc7fb3c73e75',

--- a/app/config/constants.js
+++ b/app/config/constants.js
@@ -73,3 +73,35 @@ export const MANDATARIS_STATUS_CODES = {
   WAARNEMEND:
     'http://data.vlaanderen.be/id/concept/MandatarisStatusCode/e1ca6edd-55e1-4288-92a5-53f4cf71946a',
 };
+
+export const BESTUURSEENHEID_CLASSIFICATIE_CODES = {
+  GEMEENTE:
+    'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001',
+  PROVINCIE:
+    'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000',
+  OCMW: 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000002',
+  DISTRICT:
+    'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000003',
+};
+
+export const BESTUURSORGAAN_CLASSIFICATIE_CODES = {
+  GEMEENTERAAD:
+    'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000005',
+  PROVINCIERAAD:
+    'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000c',
+  DISTRICTSRAAD:
+    'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000a',
+  OCMW_RAAD:
+    'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000007',
+};
+
+export const IV_CLASSIFICATIE_MAP = {
+  [BESTUURSEENHEID_CLASSIFICATIE_CODES.GEMEENTE]:
+    BESTUURSORGAAN_CLASSIFICATIE_CODES.GEMEENTERAAD,
+  [BESTUURSEENHEID_CLASSIFICATIE_CODES.PROVINCIE]:
+    BESTUURSORGAAN_CLASSIFICATIE_CODES.PROVINCIERAAD,
+  [BESTUURSEENHEID_CLASSIFICATIE_CODES.DISTRICT]:
+    BESTUURSORGAAN_CLASSIFICATIE_CODES.DISTRICTSRAAD,
+  [BESTUURSEENHEID_CLASSIFICATIE_CODES.OCMW]:
+    BESTUURSORGAAN_CLASSIFICATIE_CODES.OCMW_RAAD,
+};

--- a/app/routes/inbox/meetings/new-inauguration.js
+++ b/app/routes/inbox/meetings/new-inauguration.js
@@ -1,12 +1,7 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 import { format } from 'date-fns/fp';
-
-import { GEMEENTE } from '../../../utils/bestuurseenheid-classificatie-codes';
-import {
-  GEMEENTERAAD,
-  RAAD_VOOR_MAATSCHAPPELIJK_WELZIJN,
-} from '../../../utils/classification-utils';
+import { IV_CLASSIFICATIE_MAP } from '../../../config/constants';
 
 export default class InboxMeetingsNewInaugurationRoute extends Route {
   @service currentSession;
@@ -41,10 +36,7 @@ export default class InboxMeetingsNewInaugurationRoute extends Route {
               id: this.currentSession.group.id,
             },
             classificatie: {
-              ':uri:':
-                unitClass.uri === GEMEENTE
-                  ? GEMEENTERAAD
-                  : RAAD_VOOR_MAATSCHAPPELIJK_WELZIJN,
+              ':uri:': IV_CLASSIFICATIE_MAP[unitClass.uri],
             },
           },
         },


### PR DESCRIPTION
### Overview
This PR introduces some bugfixes for the 'fractie-splitsing' LMB table query:
- Adjustment in how verkiezing and kieslijsten are determined (previous approach was erroneous)
- Fix an incorrect variable name

##### connected issues and PRs:
None

### How to test/reproduce
- Start the GN application
- Create/open an inauguration meeting
- Insert an LMB table with the `IVGR5-LMB-1-splitsing-fracties` tag
- When syncing, ensure the following
  * The correct election resource is used to determine the kieslijsten + fracties
  * It runs without error

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
