### PR TITLE
IV LMB queries: ensure the correct bestuursorgaan-in-tijd is selected

### DIFF
--- a/.changeset/little-ravens-eat.md
+++ b/.changeset/little-ravens-eat.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': minor
+---
+
+Ensure the correct 'bestuursorgaan-in-tijd' is selected when syncing an IV

--- a/.changeset/loud-tomatoes-add.md
+++ b/.changeset/loud-tomatoes-add.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Change endpoints from LMB plugin and mandatee table to use the backend

--- a/app/components/inauguration-meeting/synchronization.js
+++ b/app/components/inauguration-meeting/synchronization.js
@@ -45,7 +45,7 @@ export default class InaugurationMeetingSynchronizationComponent extends Compone
     `;
     const response = await executeQuery({
       query,
-      endpoint: '/vendor-proxy/query',
+      endpoint: '/raw-sparql',
     });
     const bindings = response.results.bindings;
     if (bindings.length) {

--- a/app/components/inauguration-meeting/synchronization.js
+++ b/app/components/inauguration-meeting/synchronization.js
@@ -34,13 +34,13 @@ export default class InaugurationMeetingSynchronizationComponent extends Compone
   }
 
   lastModification = trackedFunction(this, async () => {
+    const bestuursorgaanIT = await this.meeting.bestuursorgaan;
+    const bestuursorgaanMain = await bestuursorgaanIT.isTijdsspecialisatieVan;
+    const bestuurseenheid = await bestuursorgaanMain.bestuurseenheid;
     const query = /* sparql */ `
-      PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-      PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
-      PREFIX dct: <http://purl.org/dc/terms/>
-      SELECT (max(?m) as ?modified) WHERE {
-        ?sub dct:modified ?m.
+      PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+      SELECT ?modified WHERE {
+        <${bestuurseenheid.uri}> ext:lastLMBUpdate ?modified.
       }
     `;
     const response = await executeQuery({

--- a/app/config/constants.js
+++ b/app/config/constants.js
@@ -93,6 +93,11 @@ export const BESTUURSORGAAN_CLASSIFICATIE_CODES = {
     'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000a',
   OCMW_RAAD:
     'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000007',
+  COLLEGE_VAN_BURGEMEESTER_EN_SCHEPENEN:
+    'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000006',
+  VOORZITTER_BSCD:
+    'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/53c0d8cd-f3a2-411d-bece-4bd83ae2bbc9',
+  BCSD: 'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000009',
 };
 
 export const IV_CLASSIFICATIE_MAP = {

--- a/app/config/mandatee-table-config.js
+++ b/app/config/mandatee-table-config.js
@@ -22,6 +22,7 @@ import {
   MANDATARIS_STATUS_CODES,
   BESTUURSPERIODES,
   BESTUURSORGAAN_CLASSIFICATIE_CODES,
+  BESTUURSEENHEID_CLASSIFICATIE_CODES,
 } from './constants';
 import { promiseProperties } from '../utils/promises';
 
@@ -49,6 +50,10 @@ export const mandateeTableConfigIVGR = (meeting) => {
     'IVGR2-LMB-1-geloofsbrieven': {
       query: async () => {
         const bestuurseenheid = await getBestuurseenheid(meeting);
+        await assertClassificatie(bestuurseenheid, [
+          BESTUURSEENHEID_CLASSIFICATIE_CODES.GEMEENTE,
+          BESTUURSEENHEID_CLASSIFICATIE_CODES.DISTRICT,
+        ]);
         const sparqlQuery = /* sparql */ `
         PREFIX persoon: <http://data.vlaanderen.be/ns/persoon#>
         PREFIX person: <http://www.w3.org/ns/person#>
@@ -118,6 +123,10 @@ export const mandateeTableConfigIVGR = (meeting) => {
     'IVGR3-LMB-1-eedafleggingen': {
       query: async () => {
         const bestuurseenheid = await getBestuurseenheid(meeting);
+        await assertClassificatie(bestuurseenheid, [
+          BESTUURSEENHEID_CLASSIFICATIE_CODES.GEMEENTE,
+          BESTUURSEENHEID_CLASSIFICATIE_CODES.DISTRICT,
+        ]);
         const sparqlQuery = /* sparql */ `
         PREFIX org: <http://www.w3.org/ns/org#>
         PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
@@ -216,6 +225,10 @@ export const mandateeTableConfigIVGR = (meeting) => {
     'IVGR4-LMB-1-rangorde-gemeenteraadsleden': {
       query: async () => {
         const bestuurseenheid = await getBestuurseenheid(meeting);
+        await assertClassificatie(bestuurseenheid, [
+          BESTUURSEENHEID_CLASSIFICATIE_CODES.GEMEENTE,
+          BESTUURSEENHEID_CLASSIFICATIE_CODES.DISTRICT,
+        ]);
         const sparqlQuery = /* sparql */ `
         PREFIX org: <http://www.w3.org/ns/org#>
         PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
@@ -303,6 +316,10 @@ export const mandateeTableConfigIVGR = (meeting) => {
     'IVGR5-LMB-1-splitsing-fracties': {
       query: async () => {
         const bestuurseenheid = await getBestuurseenheid(meeting);
+        await assertClassificatie(bestuurseenheid, [
+          BESTUURSEENHEID_CLASSIFICATIE_CODES.GEMEENTE,
+          BESTUURSEENHEID_CLASSIFICATIE_CODES.DISTRICT,
+        ]);
         const splitKandidatenlijstQuery = /* sparql */ `
         PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -411,6 +428,10 @@ export const mandateeTableConfigIVGR = (meeting) => {
     'IVGR5-LMB-2-grootte-fracties': {
       query: async () => {
         const bestuurseenheid = await getBestuurseenheid(meeting);
+        await assertClassificatie(bestuurseenheid, [
+          BESTUURSEENHEID_CLASSIFICATIE_CODES.GEMEENTE,
+          BESTUURSEENHEID_CLASSIFICATIE_CODES.DISTRICT,
+        ]);
         const sparqlQuery = /* sparql */ `
         PREFIX org: <http://www.w3.org/ns/org#>
         PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
@@ -487,6 +508,10 @@ export const mandateeTableConfigIVGR = (meeting) => {
     'IVGR5-LMB-3-samenstelling-fracties': {
       query: async () => {
         const bestuurseenheid = await getBestuurseenheid(meeting);
+        await assertClassificatie(bestuurseenheid, [
+          BESTUURSEENHEID_CLASSIFICATIE_CODES.GEMEENTE,
+          BESTUURSEENHEID_CLASSIFICATIE_CODES.DISTRICT,
+        ]);
         const sparqlQuery = /* sparql */ `
         PREFIX org: <http://www.w3.org/ns/org#>
         PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
@@ -565,6 +590,10 @@ export const mandateeTableConfigIVGR = (meeting) => {
     'IVGR7-LMB-1-kandidaat-schepenen': {
       query: async () => {
         const bestuurseenheid = await getBestuurseenheid(meeting);
+        await assertClassificatie(bestuurseenheid, [
+          BESTUURSEENHEID_CLASSIFICATIE_CODES.GEMEENTE,
+          BESTUURSEENHEID_CLASSIFICATIE_CODES.DISTRICT,
+        ]);
         const sparqlQuery = /* sparql */ `
         PREFIX org: <http://www.w3.org/ns/org#>
         PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
@@ -651,6 +680,10 @@ export const mandateeTableConfigIVGR = (meeting) => {
     'IVGR7-LMB-2-ontvankelijkheid-schepenen': {
       query: async () => {
         const bestuurseenheid = await getBestuurseenheid(meeting);
+        await assertClassificatie(bestuurseenheid, [
+          BESTUURSEENHEID_CLASSIFICATIE_CODES.GEMEENTE,
+          BESTUURSEENHEID_CLASSIFICATIE_CODES.DISTRICT,
+        ]);
         const sparqlQuery = /* sparql */ `
         PREFIX org: <http://www.w3.org/ns/org#>
         PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
@@ -786,6 +819,10 @@ export const mandateeTableConfigIVGR = (meeting) => {
     'IVGR7-LMB-3-verhindering-schepenen': {
       query: async () => {
         const bestuurseenheid = await getBestuurseenheid(meeting);
+        await assertClassificatie(bestuurseenheid, [
+          BESTUURSEENHEID_CLASSIFICATIE_CODES.GEMEENTE,
+          BESTUURSEENHEID_CLASSIFICATIE_CODES.DISTRICT,
+        ]);
         const sparqlQuery = /* sparql */ `
         PREFIX org: <http://www.w3.org/ns/org#>
         PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
@@ -863,6 +900,10 @@ export const mandateeTableConfigIVGR = (meeting) => {
     'IVGR8-LMB-1-verkozen-schepenen': {
       query: async () => {
         const bestuurseenheid = await getBestuurseenheid(meeting);
+        await assertClassificatie(bestuurseenheid, [
+          BESTUURSEENHEID_CLASSIFICATIE_CODES.GEMEENTE,
+          BESTUURSEENHEID_CLASSIFICATIE_CODES.DISTRICT,
+        ]);
         const sparqlQuery = /* sparql */ `
         PREFIX org: <http://www.w3.org/ns/org#>
         PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
@@ -941,6 +982,10 @@ export const mandateeTableConfigIVGR = (meeting) => {
     'IVGR8-LMB-2-coalitie': {
       query: async () => {
         const bestuurseenheid = await getBestuurseenheid(meeting);
+        await assertClassificatie(bestuurseenheid, [
+          BESTUURSEENHEID_CLASSIFICATIE_CODES.GEMEENTE,
+          BESTUURSEENHEID_CLASSIFICATIE_CODES.DISTRICT,
+        ]);
         const sparqlQuery = /* sparql */ `
         PREFIX org: <http://www.w3.org/ns/org#>
         PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
@@ -1069,6 +1114,9 @@ export const mandateeTableConfigRMW = (meeting) => {
     'IVRMW2-LMB-1-zetelverdeling': {
       query: async () => {
         const bestuurseenheid = await getBestuurseenheid(meeting);
+        await assertClassificatie(bestuurseenheid, [
+          BESTUURSEENHEID_CLASSIFICATIE_CODES.OCMW,
+        ]);
         const sparqlQuery = /* sparql */ `
           PREFIX org: <http://www.w3.org/ns/org#>
           PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
@@ -1147,6 +1195,9 @@ export const mandateeTableConfigRMW = (meeting) => {
     'IVRMW2-LMB-2-kandidaat-leden': {
       query: async () => {
         const bestuurseenheid = await getBestuurseenheid(meeting);
+        await assertClassificatie(bestuurseenheid, [
+          BESTUURSEENHEID_CLASSIFICATIE_CODES.OCMW,
+        ]);
         const sparqlQuery = /* sparql */ `
           PREFIX org: <http://www.w3.org/ns/org#>
           PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
@@ -1233,6 +1284,9 @@ export const mandateeTableConfigRMW = (meeting) => {
     'IVRMW2-LBM-3-verkiezing-leden': {
       query: async () => {
         const bestuurseenheid = await getBestuurseenheid(meeting);
+        await assertClassificatie(bestuurseenheid, [
+          BESTUURSEENHEID_CLASSIFICATIE_CODES.OCMW,
+        ]);
         const sparqlQuery = /* sparql */ `
           PREFIX org: <http://www.w3.org/ns/org#>
           PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
@@ -1351,6 +1405,9 @@ export const mandateeTableConfigRMW = (meeting) => {
     'IVRMW2-LBM-4-geloofsbrieven-leden': {
       query: async () => {
         const bestuurseenheid = await getBestuurseenheid(meeting);
+        await assertClassificatie(bestuurseenheid, [
+          BESTUURSEENHEID_CLASSIFICATIE_CODES.OCMW,
+        ]);
         const sparqlQuery = /* sparql */ `
           PREFIX org: <http://www.w3.org/ns/org#>
           PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
@@ -1429,6 +1486,9 @@ export const mandateeTableConfigRMW = (meeting) => {
     'IVRMW2-LBM-5-eed-leden': {
       query: async () => {
         const bestuurseenheid = await getBestuurseenheid(meeting);
+        await assertClassificatie(bestuurseenheid, [
+          BESTUURSEENHEID_CLASSIFICATIE_CODES.OCMW,
+        ]);
         const sparqlQuery = /* sparql */ `
           PREFIX org: <http://www.w3.org/ns/org#>
           PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
@@ -1509,4 +1569,16 @@ async function getBestuurseenheid(meeting) {
   const bestuursorgaanIT = await meeting.bestuursorgaan;
   const bestuursorgaanMain = await bestuursorgaanIT.isTijdsspecialisatieVan;
   return bestuursorgaanMain.bestuurseenheid;
+}
+
+async function assertClassificatie(bestuurseenheid, classificatiecodes) {
+  const classificatie = await bestuurseenheid.classificatie;
+  const match = classificatiecodes.some((code) => code === classificatie.uri);
+  if (match) {
+    return classificatie.uri;
+  } else {
+    throw new Error(
+      `Bestuurseenheid holding the IV does not have the correct 'classificatie'. Received ${classificatie.uri}. Expected one of ${classificatiecodes.join(', ')}`,
+    );
+  }
 }

--- a/app/config/mandatee-table-config.js
+++ b/app/config/mandatee-table-config.js
@@ -453,7 +453,7 @@ export const mandateeTableConfigIVGR = (meeting) => {
             <${BESTUURSORGAAN_CLASSIFICATIE_CODES.GEMEENTERAAD}>
           }
           ?bestuursorgaan besluit:bestuurt <${bestuurseenheid.uri}>.
-          # We want this to be optional, as it is possible there are 'fracties' without any electees
+
           OPTIONAL {
             ?mandataris org:hasMembership/org:organisation ?fractie.
             ?mandataris mandaat:isBestuurlijkeAliasVan ?lid.
@@ -1122,7 +1122,6 @@ export const mandateeTableConfigRMW = (meeting) => {
           PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
           PREFIX persoon: <http://data.vlaanderen.be/ns/persoon#>
           PREFIX foaf: <http://xmlns.com/foaf/0.1/>
-          # TODO: http or https?
           PREFIX regorg: <https://www.w3.org/ns/regorg#>
           PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
 
@@ -1137,7 +1136,7 @@ export const mandateeTableConfigRMW = (meeting) => {
               <${BESTUURSORGAAN_CLASSIFICATIE_CODES.BCSD}>
             }
             ?bestuursorgaan besluit:bestuurt <${bestuurseenheid.uri}>.
-            # We want this to be optional, as it is possible there are 'fracties' without any electees
+
             OPTIONAL {
               ?mandataris org:hasMembership/org:organisation ?fractie.
               ?mandataris mandaat:isBestuurlijkeAliasVan ?persoon.

--- a/app/config/mandatee-table-config.js
+++ b/app/config/mandatee-table-config.js
@@ -915,7 +915,7 @@ export const mandateeTableConfigIVGR = (meeting) => {
             const { mandataris_naam, fractie_naam } = bindingToObject(binding);
             return row(schema, [
               schema.text(mandataris_naam),
-              schema.text(fractie_naam ?? ''),
+              fractie_naam ? schema.text(fractie_naam) : undefined,
             ]);
           });
           const content = schema.nodes.table.create(null, [

--- a/app/config/mandatee-table-config.js
+++ b/app/config/mandatee-table-config.js
@@ -693,7 +693,7 @@ export const mandateeTableConfigIVGR = (meeting) => {
         PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
         PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
 
-        SELECT DISTINCT ?mandataris ?mandataris_rang ?mandataris_naam ?mandataris_status ?mandaat_start ?mandaat_einde ?mandataris_opvolger WHERE {
+        SELECT DISTINCT ?mandataris ?mandataris_rang ?mandataris_naam ?mandataris_status ?mandaat_start ?mandaat_einde WHERE {
           ?mandaat org:role <${BESTUURSFUNCTIE_CODES.SCHEPEN}>.
 
           ?bestuursorgaanIT org:hasPost ?mandaat.
@@ -717,8 +717,6 @@ export const mandateeTableConfigIVGR = (meeting) => {
           ?persoon persoon:gebruikteVoornaam ?voornaam.
           ?persoon foaf:familyName ?achternaam.
           BIND(CONCAT(?voornaam, " ", ?achternaam) AS ?mandataris_naam)
-
-          VALUES ?mandataris_opvolger { undef }
         }
       `;
         return executeQuery({
@@ -773,7 +771,6 @@ export const mandateeTableConfigIVGR = (meeting) => {
               mandataris_status,
               mandaat_start,
               mandaat_einde,
-              mandataris_opvolger,
             } = bindingToObject(binding);
             return row(schema, [
               schema.text(mandataris_rang),
@@ -781,9 +778,7 @@ export const mandateeTableConfigIVGR = (meeting) => {
               schema.text(mandataris_status),
               dateNode(schema, mandaat_start),
               mandaat_einde ? dateNode(schema, mandaat_einde) : undefined,
-              mandataris_opvolger
-                ? schema.text(mandataris_opvolger)
-                : undefined,
+              undefined,
             ]);
           });
           const content = schema.nodes.table.create(null, [

--- a/app/config/mandatee-table-config.js
+++ b/app/config/mandatee-table-config.js
@@ -1148,7 +1148,7 @@ export const mandateeTableConfigRMW = (meeting) => {
         `;
         return executeQuery({
           query: sparqlQuery,
-          endpoint: '/vendor-proxy/query',
+          endpoint: '/raw-sparql',
         });
       },
       updateContent: (pos, queryResult) => {
@@ -1235,7 +1235,7 @@ export const mandateeTableConfigRMW = (meeting) => {
         `;
         return executeQuery({
           query: sparqlQuery,
-          endpoint: '/vendor-proxy/query',
+          endpoint: '/raw-sparql',
         });
       },
       updateContent: (pos, queryResult) => {
@@ -1325,7 +1325,7 @@ export const mandateeTableConfigRMW = (meeting) => {
         `;
         return executeQuery({
           query: sparqlQuery,
-          endpoint: '/vendor-proxy/query',
+          endpoint: '/raw-sparql',
         });
       },
       updateContent: (pos, queryResult) => {
@@ -1442,7 +1442,7 @@ export const mandateeTableConfigRMW = (meeting) => {
         `;
         return executeQuery({
           query: sparqlQuery,
-          endpoint: '/vendor-proxy/query',
+          endpoint: '/raw-sparql',
         });
       },
       updateContent: (pos, queryResult) => {
@@ -1523,7 +1523,7 @@ export const mandateeTableConfigRMW = (meeting) => {
         `;
         return executeQuery({
           query: sparqlQuery,
-          endpoint: '/vendor-proxy/query',
+          endpoint: '/raw-sparql',
         });
       },
       updateContent: (pos, queryResult) => {

--- a/app/config/mandatee-table-config.js
+++ b/app/config/mandatee-table-config.js
@@ -439,7 +439,6 @@ export const mandateeTableConfigIVGR = (meeting) => {
         PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
         PREFIX persoon: <http://data.vlaanderen.be/ns/persoon#>
         PREFIX foaf: <http://xmlns.com/foaf/0.1/>
-        # TODO: http or https?
         PREFIX regorg: <https://www.w3.org/ns/regorg#>
         PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
 
@@ -719,7 +718,6 @@ export const mandateeTableConfigIVGR = (meeting) => {
           ?persoon foaf:familyName ?achternaam.
           BIND(CONCAT(?voornaam, " ", ?achternaam) AS ?mandataris_naam)
 
-          # TODO: unsure how we will fetch the 'opvolger'
           VALUES ?mandataris_opvolger { undef }
         }
       `;

--- a/app/config/mandatee-table-config.js
+++ b/app/config/mandatee-table-config.js
@@ -85,7 +85,7 @@ export const mandateeTableConfigIVGR = (meeting) => {
       `;
         return executeQuery({
           query: sparqlQuery,
-          endpoint: '/vendor-proxy/query',
+          endpoint: '/raw-sparql',
         });
       },
       updateContent: (pos, queryResult) => {
@@ -157,7 +157,7 @@ export const mandateeTableConfigIVGR = (meeting) => {
       `;
         return executeQuery({
           query: sparqlQuery,
-          endpoint: '/vendor-proxy/query',
+          endpoint: '/raw-sparql',
         });
       },
       updateContent: (pos, queryResult) => {
@@ -263,7 +263,7 @@ export const mandateeTableConfigIVGR = (meeting) => {
       `;
         return executeQuery({
           query: sparqlQuery,
-          endpoint: '/vendor-proxy/query',
+          endpoint: '/raw-sparql',
         });
       },
       updateContent: (pos, queryResult) => {
@@ -354,7 +354,7 @@ export const mandateeTableConfigIVGR = (meeting) => {
       `;
         const kandidatenlijstQueryResult = await executeQuery({
           query: splitKandidatenlijstQuery,
-          endpoint: '/vendor-proxy/query',
+          endpoint: '/raw-sparql',
         });
         const bindings = kandidatenlijstQueryResult.results.bindings;
 
@@ -466,7 +466,7 @@ export const mandateeTableConfigIVGR = (meeting) => {
       `;
         return executeQuery({
           query: sparqlQuery,
-          endpoint: '/vendor-proxy/query',
+          endpoint: '/raw-sparql',
         });
       },
       updateContent: (pos, queryResult) => {
@@ -549,7 +549,7 @@ export const mandateeTableConfigIVGR = (meeting) => {
       `;
         return executeQuery({
           query: sparqlQuery,
-          endpoint: '/vendor-proxy/query',
+          endpoint: '/raw-sparql',
         });
       },
       updateContent: (pos, queryResult) => {
@@ -626,7 +626,7 @@ export const mandateeTableConfigIVGR = (meeting) => {
       `;
         return executeQuery({
           query: sparqlQuery,
-          endpoint: '/vendor-proxy/query',
+          endpoint: '/raw-sparql',
         });
       },
       updateContent: (pos, queryResult) => {
@@ -725,7 +725,7 @@ export const mandateeTableConfigIVGR = (meeting) => {
       `;
         return executeQuery({
           query: sparqlQuery,
-          endpoint: '/vendor-proxy/query',
+          endpoint: '/raw-sparql',
         });
       },
       updateContent: (pos, queryResult) => {
@@ -856,7 +856,7 @@ export const mandateeTableConfigIVGR = (meeting) => {
       `;
         return executeQuery({
           query: sparqlQuery,
-          endpoint: '/vendor-proxy/query',
+          endpoint: '/raw-sparql',
         });
       },
       updateContent: (pos, queryResult) => {
@@ -941,7 +941,7 @@ export const mandateeTableConfigIVGR = (meeting) => {
       `;
         return executeQuery({
           query: sparqlQuery,
-          endpoint: '/vendor-proxy/query',
+          endpoint: '/raw-sparql',
         });
       },
       updateContent: (pos, queryResult) => {
@@ -1022,7 +1022,7 @@ export const mandateeTableConfigIVGR = (meeting) => {
       `;
         return executeQuery({
           query: sparqlQuery,
-          endpoint: '/vendor-proxy/query',
+          endpoint: '/raw-sparql',
         });
       },
       updateContent: (pos, queryResult) => {
@@ -1074,7 +1074,7 @@ async function fetchFractieLeden(fractieUri) {
   `;
   const result = await executeQuery({
     query: sparqlQuery,
-    endpoint: '/vendor-proxy/query',
+    endpoint: '/raw-sparql',
   });
   return result.results.bindings.map(bindingToObject) ?? [];
 }

--- a/app/config/mandatee-table-config.js
+++ b/app/config/mandatee-table-config.js
@@ -223,6 +223,8 @@ export const mandateeTableConfigIVGR = (meeting) => {
         PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
         PREFIX persoon: <http://data.vlaanderen.be/ns/persoon#>
         PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+        PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+
         SELECT DISTINCT ?mandataris ?mandataris_naam ?mandataris_rang WHERE {
           ?mandaat org:role <${BESTUURSFUNCTIE_CODES.GEMEENTERAADSLID}>.
 
@@ -309,6 +311,7 @@ export const mandateeTableConfigIVGR = (meeting) => {
         PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
         PREFIX regorg: <https://www.w3.org/ns/regorg#>
         PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+        PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
 
         SELECT DISTINCT ?kandidatenlijst ?kandidatenlijst_naam ?fractie1 ?fractie2 ?fractie1_naam ?fractie2_naam WHERE {
           ?kandidatenlijst a <http://data.vlaanderen.be/ns/mandaat#Kandidatenlijst>.

--- a/app/config/mandatee-table-config.js
+++ b/app/config/mandatee-table-config.js
@@ -371,7 +371,6 @@ export const mandateeTableConfigIVGR = (meeting) => {
       },
       updateContent: (pos, kandidatenlijsten) => {
         return (state) => {
-          console.log('Kandidatenlijsten: ', kandidatenlijsten);
           const content = [];
           const { schema, doc } = state;
           const $pos = doc.resolve(pos);

--- a/app/controllers/regulatory-statements/edit.js
+++ b/app/controllers/regulatory-statements/edit.js
@@ -286,7 +286,7 @@ export default class RegulatoryStatementsRoute extends Controller {
           'https://publicatie.gelinkt-notuleren.vlaanderen.be/id/adres/',
       },
       lmb: {
-        endpoint: '/vendor-proxy/query',
+        endpoint: '/raw-sparql',
       },
       autofilledVariable: {
         autofilledValues: {

--- a/app/services/editor/agendapoint.js
+++ b/app/services/editor/agendapoint.js
@@ -241,7 +241,7 @@ export default class AgendapointEditorService extends Service {
         defaultTag: IVGR_TAGS[0],
       },
       lmb: {
-        endpoint: '/vendor-proxy/query',
+        endpoint: '/raw-sparql',
       },
       autofilledVariable: {
         autofilledValues: {


### PR DESCRIPTION
### Overview
This PR adjusts the IV LMB queries in the following way:
- The 'bestuursorgaan' who created the IV meeting is determined. This 'bestuursorgaan' will be either a:
   * Districtsraad
   * Gemeenteraad
   * Bijzonder comité voor de sociale dienst (BCSD)
- Based on this 'bestuursorgaan', we can determine the 'bestuurseenheid'
- We check if the classificatie of the 'bestuurseenheid' is correct/relevant
- Based on the 'bestuurseenheid' and the correct 'bestuursperiode', we can determine which (other) 'bestuursorgaan' we need to select to query the mandatees/fractions from. Depending on the query, this will be either:
  * Gemeenteraad
  * College van burgemeester en schepenen
  * Bijzonder comite voor de sociale dienst

### Setup
Ensure you are running the latest version of the backend or are proxying to dev.

### How to test/reproduce
- Start the frontend
- Open/create an IV
- Sync the IV
- Ensure that during the sync, the correct 'bestuurorganen-in-tijd' are used to fetch the data from.



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
