### PR TITLE
IV LMB queries: add support for 'district' bestuurseenheden

### DIFF
--- a/.changeset/wet-chairs-drive.md
+++ b/.changeset/wet-chairs-drive.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': minor
+---
+
+IV LMB queries: adjust IVGR queries to also work for 'District' bestuurseenheden

--- a/app/config/constants.js
+++ b/app/config/constants.js
@@ -44,6 +44,14 @@ export const BESTUURSFUNCTIE_CODES = {
     'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000011',
   VOORZITTER_GEMEENTERAAD:
     'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000012',
+  DISTRICTSSCHEPEN:
+    'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e00001e',
+  DISTRICTSBURGEMEESTER:
+    'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e00001d',
+  DISTRICTSRAADLID:
+    'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e00001b',
+  VOORZITTER_DISTRICTSRAAD:
+    'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e00001c',
   LID_BCSD:
     'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000019',
   VOORZITTER_BCSD:
@@ -91,6 +99,8 @@ export const BESTUURSORGAAN_CLASSIFICATIE_CODES = {
     'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000c',
   DISTRICTSRAAD:
     'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000a',
+  DISTRICTSCOLLEGE:
+    'https://data.vlaanderen.be/doc/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000b',
   OCMW_RAAD:
     'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000007',
   COLLEGE_VAN_BURGEMEESTER_EN_SCHEPENEN:


### PR DESCRIPTION
### Overview
This PR adds support to the LMB queries for 'district' bestuurseenheden.
Specifically, the 'gemeenteraads' queries are adjusted to also work for 'districten'.

##### connected issues and PRs:
None

### Setup
- Set-up the backend
- Ensure the `ldes-client` service has run

### How to test/reproduce
- Quite difficult as the 'Opstart nieuwe legislatuur' feature is not yet enabled for 'district' bestuurseenheden on LMB
- Start the frontend
- Log in as a 'district' (e.g. 'Berchem')
- Create an IV
- The sync should run without errors

### Challenges/uncertainties
The implementation is a bit hacky, as we just use a simple object to look up the correct 'classificatie-codes' for 'districten'/'gemeentes'.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
