### PR TITLE
Show agendapoint numbers in meeting publish flow

### DIFF
--- a/.changeset/tall-moles-flash.md
+++ b/.changeset/tall-moles-flash.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': minor
+---
+
+Add styling for agendapoint numbers next to titles in prepublish flow

--- a/app/components/agenda-manager/agenda-table/row.hbs
+++ b/app/components/agenda-manager/agenda-table/row.hbs
@@ -24,12 +24,9 @@
 {{else}}
   <DraggableObject @tagName='tr' @content={{@item}} @isSortable={{true}}>
     <td>
-      <AuButton
-        @icon='drag'
-        @skin='link'
-        @hideText={{true}}
-        class='au-c-button--drag'
-      />
+      <AuButton @icon='drag' @skin='link' class='au-c-button--drag'>
+        {{add @item.position 1}}
+      </AuButton>
     </td>
     <td>
       <AuButton

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -43,6 +43,7 @@ body {
 // Drag button
 .au-c-button--drag {
   cursor: grab;
+  text-decoration: none;
 
   .au-c-icon {
     width: 1.75rem;

--- a/app/styles/project/_c-editor-preview.scss
+++ b/app/styles/project/_c-editor-preview.scss
@@ -136,6 +136,19 @@
       border-right: 4px solid $au-blue-700;
     }
   }
+
+  // Subject is different as it sits next to a number, so override some of the previous rules
+  [property='dc:subject'] {
+    width: auto;
+    flex-grow: 1;
+    margin-top: 0;
+  }
+
+  [typeof='besluit:BehandelingVanAgendapunt'] > h3 {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
 }
 
 .au-c-editor-preview-treatment-toggle-box {

--- a/app/styles/project/_c-template.scss
+++ b/app/styles/project/_c-template.scss
@@ -298,6 +298,7 @@
     }
   }
 
+  .au-c-template--treatment>h3,
   [property='dc:subject'],
   [property='http://purl.org/dc/elements/1.1/subject']
   {


### PR DESCRIPTION
### Overview
Mostly styling changes to support changed prepublisher output. Also include the numbers when allowing to drag the agenda points into different positions. There were no designs, so hopefully this fits the desired outcome.

##### connected issues and PRs:
Expects a modified version of the prepublisher: https://github.com/lblod/notulen-prepublish-service/pull/116
Jira ticket: https://binnenland.atlassian.net/browse/GN-5043

### Setup
Run the app-gn stack locally, with the PR version of the prepublisher

### How to test/reproduce
All steps of the meeting publish flow should consistently show the numbers next to the agenda point titles (not the decision titles).

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
