### PR TITLE
Disable `rdfaAware` setting on `heading` nodes

### DIFF
--- a/.changeset/mighty-chairs-pull.md
+++ b/.changeset/mighty-chairs-pull.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Disable `rdfa-aware` setting for `heading` nodes

--- a/app/components/zitting-text-document-container.js
+++ b/app/components/zitting-text-document-container.js
@@ -80,7 +80,7 @@ export default class ZittingTextDocumentContainerComponent extends Component {
       placeholder,
       ...tableNodes({ tableGroup: 'block', cellContent: 'block+' }),
       date: date(this.config.date),
-      heading: headingWithConfig({ rdfaAware: true }),
+      heading: headingWithConfig({ rdfaAware: false }),
       blockquote,
       horizontal_rule,
       code_block,

--- a/app/controllers/regulatory-statements/edit.js
+++ b/app/controllers/regulatory-statements/edit.js
@@ -146,7 +146,7 @@ export default class RegulatoryStatementsRoute extends Controller {
       number,
       text_variable,
       ...STRUCTURE_NODES,
-      heading: headingWithConfig({ rdfaAware: true }),
+      heading: headingWithConfig({ rdfaAware: false }),
       blockquote,
       snippet_placeholder: snippetPlaceholder,
       snippet: snippet(this.config.snippet),

--- a/app/services/editor/agendapoint.js
+++ b/app/services/editor/agendapoint.js
@@ -141,7 +141,7 @@ export default class AgendapointEditorService extends Service {
       codelist,
       roadsign_regulation,
       mandatee_table,
-      heading: headingWithConfig({ rdfaAware: true }),
+      heading: headingWithConfig({ rdfaAware: false }),
       blockquote,
       snippet_placeholder: snippetPlaceholder,
       snippet: snippet(this.config.snippet),


### PR DESCRIPTION
### Overview
This PR disables the `rdfaAware` setting on `heading` nodes for two main reasons:
- To ensure consistency with https://github.com/lblod/frontend-reglementaire-bijlage
- The `rdfaAware` setting never really worked very well in combination with `heading` nodes. Typically (IMO) it's not a good idea to mix markup/styled nodes (e.g. headings, paragraphs) with data nodes (block_rdfa, inline_rdfa...)


##### connected issues and PRs:
https://github.com/lblod/frontend-reglementaire-bijlage/pull/291

### How to test/reproduce
- Start the frontend
- Open any agendapoint/regulatory statement/intro,outro
- Notice that the heading nodes are no longer rdfa-aware: you can easily enter inside of them for example, no border around them...
- Check if the copy function still works as expected

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
