### PR TITLE
Add hack for handling single articles in copy-parts component

### DIFF
--- a/.changeset/silver-humans-smash.md
+++ b/.changeset/silver-humans-smash.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Update copy-decision-parts screen to better handle single articles


### PR DESCRIPTION
### Overview
Render the 'label' of decision parts to copy to the DOM temporarily, so we can use `innerText` and ignore any parts that are hidden from the user, such as the article number for single articles.

##### connected issues and PRs:
Jira bug: https://binnenland.atlassian.net/browse/GN-5161

### Setup
N/A

### How to test/reproduce
Create a meeting with an agenda point, which has only one article. Then go to actions / download or copy / more copy options. The label for the article should now be `Enig artikel .` (without the number that used to be there).

### Challenges/uncertainties
It's not clear if the number should be there at all, but rather than change the HTML, just hack around it.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
