### PR TITLE
Hide mandatee-table editor behind feature-flag

### DIFF
--- a/.changeset/afraid-dodos-sparkle.md
+++ b/.changeset/afraid-dodos-sparkle.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Hide mandatee-table editor feature behind feature-flag `mandatee-table-editor`

--- a/app/templates/agendapoints/edit.hbs
+++ b/app/templates/agendapoints/edit.hbs
@@ -151,10 +151,12 @@
         @controller={{this.controller}}
         @config={{this.config.lpdc}}
       />
-      <MandateeTablePlugin::Insert
-        @controller={{this.controller}}
-        @defaultTag={{this.config.mandateeTable.defaultTag}}
-      />
+      {{#if (feature-flag 'mandateeTableEditor')}}
+        <MandateeTablePlugin::Insert
+          @controller={{this.controller}}
+          @defaultTag={{this.config.mandateeTable.defaultTag}}
+        />
+      {{/if}}
       <LmbPlugin::Insert
         @controller={{this.controller}}
         @config={{this.config.lmb}}
@@ -193,10 +195,12 @@
         @config={{this.config.lmb}}
       />
       <TemplateCommentsPlugin::EditCard @controller={{this.controller}} />
-      <MandateeTablePlugin::Configure
-        @controller={{this.controller}}
-        @supportedTags={{this.config.mandateeTable.tags}}
-      />
+      {{#if (feature-flag 'mandateeTableEditor')}}
+        <MandateeTablePlugin::Configure
+          @controller={{this.controller}}
+          @supportedTags={{this.config.mandateeTable.tags}}
+        />
+      {{/if}}
     </:sidebar>
   </RdfaEditorContainer>
 </div>

--- a/config/environment.js
+++ b/config/environment.js
@@ -50,6 +50,7 @@ module.exports = function (environment) {
       'editor-extended-html-paste': true,
       'prosemirror-dev-tools': false,
       'regulatory-statements': '{{GN_FEATURE_REGULATORY_STATEMENTS}}',
+      'mandatee-table-editor': '{{GN_FEATURE_MANDATEE_TABLE_EDITOR}}',
     },
     browserUpdate: {
       vs: { f: -3, c: -3 },
@@ -85,6 +86,7 @@ module.exports = function (environment) {
     ENV.manual.print = '';
     ENV.featureFlags['regulatory-statements'] = true;
     ENV.featureFlags['prosemirror-dev-tools'] = true;
+    ENV.featureFlags['mandatee-table-editor'] = true;
     ENV.mowRegistryEndpoint =
       process.env.MOW_REGISTRY_SPARQL_ENDPOINT ??
       'https://dev.roadsigns.lblod.info/sparql';


### PR DESCRIPTION
### Overview
This PR hides the mandatee-table editor behind a feature-flag `mandatee-table-editor`.
By default, this flag is set to `false`. In development mode, it is set to `true`.

In a prod environment, you can control the feature-flag through the `EMBER_GN_FEATURE_MANDATEE_TABLE_EDITOR` environment variable.
##### connected issues and PRs:
None


### Setup
None

### How to test/reproduce
- Start the app
- Open an agendapoint
- Notice that it is possible to insert a table/edit it
- Update the feature-flag to `false` in the `environment.js` file
- Restart the dev server
- Notice that the mandatee-table insert/edit features are now disabled



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
