### PR TITLE
`zitting-text-document-container`: add `emberApplication` plugin

### DIFF
--- a/.changeset/six-crabs-think.md
+++ b/.changeset/six-crabs-think.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': minor
+---
+
+Add `emberApplication` prosemirror plugin to `zitting-text-document-container` component

--- a/app/components/zitting-text-document-container.js
+++ b/app/components/zitting-text-document-container.js
@@ -1,8 +1,9 @@
 import Component from '@glimmer/component';
 import { task } from 'ember-concurrency';
 import { action } from '@ember/object';
-import { Schema } from '@lblod/ember-rdfa-editor';
+import { getOwner } from '@ember/application';
 
+import { Schema } from '@lblod/ember-rdfa-editor';
 import {
   em,
   strikethrough,
@@ -53,6 +54,7 @@ import {
   inlineRdfaWithConfig,
   inlineRdfaWithConfigView,
 } from '@lblod/ember-rdfa-editor/nodes/inline-rdfa';
+import { emberApplication } from '@lblod/ember-rdfa-editor/plugins/ember-application';
 
 export default class ZittingTextDocumentContainerComponent extends Component {
   @service intl;
@@ -170,6 +172,7 @@ export default class ZittingTextDocumentContainerComponent extends Component {
       tableKeymap,
       linkPasteHandler(this.schema.nodes.link),
       listTrackingPlugin(),
+      emberApplication(getOwner(this)),
     ];
   }
 


### PR DESCRIPTION
### Overview
This PR adds the `emberApplication` plugin to the `zitting-text-document-container` component editor config.
This ensure that nodes who might require it, can access the ember application instance (e.g. for intl).

##### connected issues and PRs:
https://github.com/lblod/frontend-reglementaire-bijlage/pull/294


### Setup
None

### How to test/reproduce
- Ensure the intro/outro of the meeting has no prosemirror config issues (e.g. doesn't crash etc.)

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
