### PR TITLE
bugfix: ensure decision templates get correctly instantiated upon IV creation

### DIFF
--- a/.changeset/sweet-boxes-rush.md
+++ b/.changeset/sweet-boxes-rush.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+IV creation: ensure decision templates are correctly instantiated upon meeting creation

--- a/app/api/installatievergadering.js
+++ b/app/api/installatievergadering.js
@@ -5,6 +5,7 @@
  */
 
 import { RAAD_VOOR_MAATSCHAPPELIJK_WELZIJN } from '../utils/classification-utils';
+import templateUuidInstantiator from '@lblod/template-uuid-instantiator';
 
 /**
  * @typedef {Object} CreateInstallatievergaderingOptions
@@ -55,7 +56,7 @@ export async function createInstallatievergadering(
     promises.push(
       agendapoint.save(),
       treatment
-        .initializeDocument(template.body)
+        .initializeDocument(templateUuidInstantiator(template.body))
         .then(() => treatment.saveAndPersistDocument()),
     );
     previousAgendapoint = agendapoint;


### PR DESCRIPTION
### Overview
This PR ensures that the relevant decision templates get correctly instantiated upon an IV creation.

##### connected issues and PRs:
None

### Setup
None

### How to test/reproduce
- Start the app
- Creation an IV
- Ensure that the (decision) URIs are correctly instantiated (no `--ref` etc.)

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
