### PR TITLE
Set start date to planned start for new IVs

### DIFF
--- a/.changeset/proud-wombats-give.md
+++ b/.changeset/proud-wombats-give.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Set meeting start date to planned start for new IVs

--- a/app/api/installatievergadering.js
+++ b/app/api/installatievergadering.js
@@ -24,11 +24,9 @@ export async function createInstallatievergadering(
   store,
   { bestuursorgaan, templateFetcher, location, plannedStart },
 ) {
-  const now = new Date();
-
   const meeting = store.createRecord('installatievergadering', {
     geplandeStart: plannedStart,
-    gestartOpTijdstip: now,
+    gestartOpTijdstip: plannedStart,
     opLocatie: location,
     bestuursorgaan,
   });


### PR DESCRIPTION
### Overview
<!-- high level overview of changes (not just \"implement ticket\") + *why* + design document, special notes like ticket partially implemented etc. -->
meeting start dates should default to the planned start rather than `now()`

##### connected issues and PRs:
<!-- links to connected jira tickets -->
<!-- Link to PRs that are related (and in what way) -->
[GN-5185](https://binnenland.atlassian.net/browse/GN-5185)


### Setup
<!-- PR dependencies -->
<!-- override snippets -->

### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->



### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [ ] npm lint
- [ ] no new deprecations