### PR TITLE
Disable creation of IV if not applicable

### DIFF
--- a/.changeset/real-buses-invite.md
+++ b/.changeset/real-buses-invite.md
@@ -1,0 +1,10 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Disable creation of inauguration meeting if not applicable.
+To be able to create an inauguration meeting, you should be logged in as a:
+- Gemeente
+- District
+- OCMW
+The logged-in administrative unit should be relevant for the next legislation (e.g. no old, no longer existing muncipalities)

--- a/app/controllers/inbox/meetings.js
+++ b/app/controllers/inbox/meetings.js
@@ -2,6 +2,13 @@ import { service } from '@ember/service';
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import InstallatieVergaderingModel from 'frontend-gelinkt-notuleren/models/installatievergadering';
+import { trackedFunction } from 'reactiveweb/function';
+import {
+  BESTUURSEENHEID_CLASSIFICATIE_CODES,
+  BESTUURSPERIODES,
+  IV_CLASSIFICATIE_MAP,
+} from '../../config/constants';
+
 export default class InboxMeetingsController extends Controller {
   @service store;
   @service currentSession;
@@ -19,4 +26,42 @@ export default class InboxMeetingsController extends Controller {
   isInaugurationMeeting = (meeting) => {
     return meeting instanceof InstallatieVergaderingModel;
   };
+
+  mayCreateInaugurationMeeting = trackedFunction(this, async () => {
+    if (this.readOnly) {
+      return false;
+    }
+    const unitClass = await this.currentSession.group.classificatie;
+
+    // We only support IVs for gemeentes, districten and OCMWs
+    if (
+      ![
+        BESTUURSEENHEID_CLASSIFICATIE_CODES.GEMEENTE,
+        BESTUURSEENHEID_CLASSIFICATIE_CODES.DISTRICT,
+        BESTUURSEENHEID_CLASSIFICATIE_CODES.OCMW,
+      ].includes(unitClass.uri)
+    ) {
+      return false;
+    }
+
+    // We check if the logged-in 'bestuurseenheid' has a 'bestuursorgaan' in the new legislation
+    const isRelevant = Boolean(
+      await this.store.count('bestuursorgaan', {
+        filter: {
+          bestuursperiode: {
+            ':uri:': BESTUURSPERIODES['2024-heden'],
+          },
+          'is-tijdsspecialisatie-van': {
+            bestuurseenheid: {
+              id: this.currentSession.group.id,
+            },
+            classificatie: {
+              ':uri:': IV_CLASSIFICATIE_MAP[unitClass.uri],
+            },
+          },
+        },
+      }),
+    );
+    return isRelevant;
+  });
 }

--- a/app/templates/inbox/meetings.hbs
+++ b/app/templates/inbox/meetings.hbs
@@ -17,7 +17,7 @@
           </AuHeading>
         </Group>
         <Group class='au-c-toolbar__group--center au-u-hide-on-print'>
-          {{#unless this.readOnly}}
+          {{#unless (or this.readOnly this.mayCreateInaugurationMeeting.isLoading)}}
             <AuDropdown
               @skin='primary'
               @title={{t 'inbox.meetings.new.title'}}
@@ -28,9 +28,11 @@
               <AuLink @route='inbox.meetings.new' role='menuitem'>
                 {{t 'inbox.meetings.new.common-meeting.title'}}
               </AuLink>
-              <AuLink @route='inbox.meetings.new-inauguration' role='menuitem'>
-                {{t 'inbox.meetings.new.inauguration-meeting.title'}}
-              </AuLink>
+              {{#if this.mayCreateInaugurationMeeting.value}}
+                <AuLink @route='inbox.meetings.new-inauguration' role='menuitem'>
+                  {{t 'inbox.meetings.new.inauguration-meeting.title'}}
+                </AuLink>
+              {{/if}}
             </AuDropdown>
           {{/unless}}
         </Group>

--- a/app/templates/inbox/meetings.hbs
+++ b/app/templates/inbox/meetings.hbs
@@ -17,7 +17,9 @@
           </AuHeading>
         </Group>
         <Group class='au-c-toolbar__group--center au-u-hide-on-print'>
-          {{#unless (or this.readOnly this.mayCreateInaugurationMeeting.isLoading)}}
+          {{#unless
+            (or this.readOnly this.mayCreateInaugurationMeeting.isLoading)
+          }}
             <AuDropdown
               @skin='primary'
               @title={{t 'inbox.meetings.new.title'}}
@@ -29,7 +31,10 @@
                 {{t 'inbox.meetings.new.common-meeting.title'}}
               </AuLink>
               {{#if this.mayCreateInaugurationMeeting.value}}
-                <AuLink @route='inbox.meetings.new-inauguration' role='menuitem'>
+                <AuLink
+                  @route='inbox.meetings.new-inauguration'
+                  role='menuitem'
+                >
                   {{t 'inbox.meetings.new.inauguration-meeting.title'}}
                 </AuLink>
               {{/if}}


### PR DESCRIPTION
### Overview
This PR ensures that the creation of inauguration meetings is only available to:
- Gemeentes
- Districten
- OCMWs
The logged-in administrative unit should be relevant for the next legislation (e.g. no old, no longer existing muncipalities)

##### connected issues and PRs:
None

### Setup
None

### How to test/reproduce
- Start the app
- Log in as a (still-existing) gemeente, OCMW or district
- Ensure the option to create an IV is available
- Log in as a province or as a no-longer-existing administrative unit (e.g. a pre-fusion muncipality)
- Ensure the IV creation option is not available

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
