### PR TITLE
Add agendapoint numbers to download table

### DIFF
--- a/.changeset/dirty-vans-boil.md
+++ b/.changeset/dirty-vans-boil.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Add agendapoint numbers to download table

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -777,6 +777,11 @@ div[typeof='besluitpublicatie:Documentonderdeel'] {
   border-left: 0.1rem solid var(--au-gray-300);
   border-right: 0.1rem solid var(--au-gray-300);
 }
+.au-c-data-table:has(.au-c-data-table-without-pagination) {
+  .au-c-data-table__actions {
+    display: none;
+  }
+}
 .download-meeting-part-downloaded {
   color: var(--au-green-700);
   border-color: var(--au-green-700);

--- a/app/templates/meetings/download/index.hbs
+++ b/app/templates/meetings/download/index.hbs
@@ -114,7 +114,7 @@
       <AuDataTable
         @content={{this.agendapoints}}
         @noDataMessage={{t 'download.table.no-data-message'}}
-        @tableClass='au-c-data-table-with-borders'
+        @tableClass='au-c-data-table-with-borders au-c-data-table-without-pagination'
         as |table|
       >
         <table.content as |c|>

--- a/app/templates/meetings/download/index.hbs
+++ b/app/templates/meetings/download/index.hbs
@@ -120,24 +120,24 @@
         <table.content as |c|>
           <c.header>
             <th>
-              <span
-                class='au-c-data-table__header-title'
-              >{{t 'download.table.agendapoint-position'}}</span>
+              <span class='au-c-data-table__header-title'>{{t
+                  'download.table.agendapoint-position'
+                }}</span>
             </th>
             <th>
-              <span
-                class='au-c-data-table__header-title'
-              >{{t 'download.table.agendapoint-title'}}</span>
+              <span class='au-c-data-table__header-title'>{{t
+                  'download.table.agendapoint-title'
+                }}</span>
             </th>
             <th>
-              <span
-                class='au-c-data-table__header-title'
-              >{{t 'download.table.download-html'}}</span>
+              <span class='au-c-data-table__header-title'>{{t
+                  'download.table.download-html'
+                }}</span>
             </th>
             <th>
-              <span
-                class='au-c-data-table__header-title'
-              >{{t 'download.table.copy-options-header'}}</span>
+              <span class='au-c-data-table__header-title'>{{t
+                  'download.table.copy-options-header'
+                }}</span>
             </th>
           </c.header>
           <c.body as |agendapoint|>

--- a/app/templates/meetings/download/index.hbs
+++ b/app/templates/meetings/download/index.hbs
@@ -121,21 +121,27 @@
           <c.header>
             <th>
               <span
-                class='au-c-data-table__header-title au-c-data-table__header-title--sortable'
+                class='au-c-data-table__header-title'
+              >{{t 'download.table.agendapoint-position'}}</span>
+            </th>
+            <th>
+              <span
+                class='au-c-data-table__header-title'
               >{{t 'download.table.agendapoint-title'}}</span>
             </th>
             <th>
               <span
-                class='au-c-data-table__header-title au-c-data-table__header-title--sortable'
+                class='au-c-data-table__header-title'
               >{{t 'download.table.download-html'}}</span>
             </th>
             <th>
               <span
-                class='au-c-data-table__header-title au-c-data-table__header-title--sortable'
+                class='au-c-data-table__header-title'
               >{{t 'download.table.copy-options-header'}}</span>
             </th>
           </c.header>
           <c.body as |agendapoint|>
+            <td>{{inc agendapoint.position}}</td>
             <td>{{agendapoint.titel}}</td>
             <td class='au-u-flex'><DownloadMeetingPart
                 @documentType='agendapunt'

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -794,6 +794,7 @@ download:
     notulen-downloading: Downloading meeting
     notulen-downloaded: Meeting downloaded
   table:
+    agendapoint-position: Position
     agendapoint-title: Agendapoint Title
     download-html: Download HTML
     no-data-message: No agendapoints found in meeting

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -798,6 +798,7 @@ download:
     notulen-downloading: Notulen aan het downloaden
     notulen-downloaded: Notulen gedownload
   table:
+    agendapoint-position: Positie
     agendapoint-title: Titel agendapunt
     download-html: Download HTML
     no-data-message: Geen agendapunten gevonden in zitting


### PR DESCRIPTION
### Overview
Add agendapoint numbers to download table
Also changed the way the headers looked, as they had the style of a sortable header without being sortable

##### connected issues and PRs:
GN-5177


### Setup
None

### How to test/reproduce
Go to the download table and see that the agendapoint number now appears on the left column 

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
