### PR TITLE
Correct URI generated when inserting decision articles

### DIFF
--- a/.changeset/heavy-apricots-jump.md
+++ b/.changeset/heavy-apricots-jump.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Update to ember-rdfa-editor-lblod-plugins v24.3.2 to get snippet URI fix

--- a/.changeset/orange-kids-hug.md
+++ b/.changeset/orange-kids-hug.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Correct generated URI for inserted articles in decisions

--- a/app/services/editor/agendapoint.js
+++ b/app/services/editor/agendapoint.js
@@ -1,4 +1,5 @@
 import Service, { service } from '@ember/service';
+import { v4 as uuidv4 } from 'uuid';
 
 import { Schema } from '@lblod/ember-rdfa-editor';
 import {
@@ -248,6 +249,9 @@ export default class AgendapointEditorService extends Service {
         autofilledValues: {
           administrativeUnit: `${municipality.naam}`,
         },
+      },
+      insertArticle: {
+        uriGenerator: () => `http://data.lblod.info/artikels/${uuidv4()}`,
       },
     };
   }

--- a/app/templates/agendapoints/edit.hbs
+++ b/app/templates/agendapoints/edit.hbs
@@ -114,7 +114,10 @@
       <Plugins::Formatting::FormattingToggle @controller={{this.controller}} />
     </:toolbar>
     <:sidebarCollapsible>
-      <this.InsertArticle @controller={{this.controller}} />
+      <this.InsertArticle
+        @controller={{this.controller}}
+        @options={{this.config.insertArticle}}
+      />
       <CitationPlugin::CitationInsert
         @controller={{this.controller}}
         @plugin={{this.citationPlugin}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@lblod/ember-environment-banner": "^0.5.0",
         "@lblod/ember-mock-login": "^0.10.0",
         "@lblod/ember-rdfa-editor": "10.7.0",
-        "@lblod/ember-rdfa-editor-lblod-plugins": "24.3.1",
+        "@lblod/ember-rdfa-editor-lblod-plugins": "24.3.2",
         "@lblod/template-uuid-instantiator": "^1.0.2",
         "@release-it-plugins/lerna-changelog": "^6.0.0",
         "@tsconfig/ember": "^3.0.8",
@@ -7571,9 +7571,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor-lblod-plugins": {
-      "version": "24.3.1",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-24.3.1.tgz",
-      "integrity": "sha512-c2eptsianacHqKdfGYpF2NeH1hhghTsh0LCuAtiBOSJ0GjqzUR9ymPVLwtALw7toJHtPpgxxZvcqvJ6y40fDCQ==",
+      "version": "24.3.2",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-24.3.2.tgz",
+      "integrity": "sha512-PUxPPGXCXlG/NuXD5b4AGV2ThOr38hJp/7Nm1OJYEU3MkP35vm6vnldwNlJ03oVNtyu1vWW6qLAldqClqv3Wyw==",
       "dev": true,
       "dependencies": {
         "@codemirror/lang-html": "^6.4.9",
@@ -7582,6 +7582,7 @@
         "@curvenote/prosemirror-utils": "^1.0.5",
         "@embroider/macros": "^1.16.5",
         "@lblod/marawa": "0.8.0-beta.6",
+        "@lblod/template-uuid-instantiator": "^1.0.2",
         "@rdfjs/data-model": "^2.0.2",
         "@rdfjs/dataset": "^2.0.2",
         "@rdfjs/parser-n3": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@lblod/ember-environment-banner": "^0.5.0",
     "@lblod/ember-mock-login": "^0.10.0",
     "@lblod/ember-rdfa-editor": "10.7.0",
-    "@lblod/ember-rdfa-editor-lblod-plugins": "24.3.1",
+    "@lblod/ember-rdfa-editor-lblod-plugins": "24.3.2",
     "@lblod/template-uuid-instantiator": "^1.0.2",
     "@release-it-plugins/lerna-changelog": "^6.0.0",
     "@tsconfig/ember": "^3.0.8",


### PR DESCRIPTION
### Overview
Remove the '--ref-uuid4-' part used for templates and just use a uuidv4.

Most importantly, includes a version of the plugins that uses the uuid instantiator for snippet insertion, see [plugins PR](https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/498)

##### connected issues and PRs:
Includes: https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/498
Jira ticket: [binnenland.atlassian.net/browse/GN-5206](https://binnenland.atlassian.net/browse/GN-5206)

### Setup
N/A

### How to test/reproduce
Insert a snippet which includes an article and also use the 'insert article' button and confirm that all articles have well-formed URIs. Easiest is to enable RDFa editing mode to verify this.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
