### PR TITLE
update editor to latest dev commit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@lblod/ember-acmidm-login": "^2.1.0",
         "@lblod/ember-environment-banner": "^0.5.0",
         "@lblod/ember-mock-login": "^0.10.0",
-        "@lblod/ember-rdfa-editor": "10.7.0",
+        "@lblod/ember-rdfa-editor": "10.7.0-dev.4a5ee3605e2f6f564e265dcc4cbd349ece3cfd41",
         "@lblod/ember-rdfa-editor-lblod-plugins": "24.3.2",
         "@lblod/template-uuid-instantiator": "^1.0.2",
         "@release-it-plugins/lerna-changelog": "^6.0.0",
@@ -7483,9 +7483,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-10.7.0.tgz",
-      "integrity": "sha512-vYhRYZk25qI06DOR6Va3cgjhl7MmpVXNh2UGwc0g7c7bzHCHW7T7RNyILdmpgvTkGBB405biJ5DSZF+8dtFTBQ==",
+      "version": "10.7.0-dev.4a5ee3605e2f6f564e265dcc4cbd349ece3cfd41",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-10.7.0-dev.4a5ee3605e2f6f564e265dcc4cbd349ece3cfd41.tgz",
+      "integrity": "sha512-Z/9g18tmhwkzBwv++ppHmtYxbHr/KAz3LPuDm64Mzxqoxi0IZ0h6gwcWfRDknascP8VUWyew7Ri9nf/+6fg2XQ==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.24.7",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@lblod/ember-acmidm-login": "^2.1.0",
     "@lblod/ember-environment-banner": "^0.5.0",
     "@lblod/ember-mock-login": "^0.10.0",
-    "@lblod/ember-rdfa-editor": "10.7.0",
+    "@lblod/ember-rdfa-editor": "10.7.0-dev.4a5ee3605e2f6f564e265dcc4cbd349ece3cfd41",
     "@lblod/ember-rdfa-editor-lblod-plugins": "24.3.2",
     "@lblod/template-uuid-instantiator": "^1.0.2",
     "@release-it-plugins/lerna-changelog": "^6.0.0",


### PR DESCRIPTION
### Overview
This PR updates the editor to the dev commit corresponding with https://github.com/lblod/ember-rdfa-editor/pull/1226.
It fixes a regression regarding the specificity of the general editor margin css rule.

##### connected issues and PRs:
https://github.com/lblod/ember-rdfa-editor/pull/1226


### Setup
None

### How to test/reproduce
- Start the app
- Open an agendapoint containing a template comment
**Without this PR**
- The margins inside the template commented are not as expected:
![image](https://github.com/user-attachments/assets/e461f73a-1cde-476c-ab9f-0a8631dcef64)

**With this PR**
- The margins of the template comment are correct again:
![image](https://github.com/user-attachments/assets/79eef134-61da-4b27-86b5-20dcb7cb231e)


### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
