### PR TITLE
GN-5209: fix citation plugin issues

### DIFF
--- a/.changeset/early-pans-wink.md
+++ b/.changeset/early-pans-wink.md
@@ -1,0 +1,7 @@
+---
+'frontend-gelinkt-notuleren': minor
+---
+
+bump plugins to [v25.2.0](https://github.com/lblod/ember-rdfa-editor-lblod-plugins/releases/tag/v25.2.0)
+
+- set up config for new snippet placeholder UI

--- a/app/controllers/regulatory-statements/edit.js
+++ b/app/controllers/regulatory-statements/edit.js
@@ -257,8 +257,8 @@ export default class RegulatoryStatementsRoute extends Controller {
       },
       citation: {
         type: 'nodes',
-        activeInNodeTypes(schema) {
-          return new Set([schema.nodes.doc]);
+        activeInNode(node, state) {
+          return node.type === state.schema.nodes.doc;
         },
         endpoint: '/codex/sparql',
         decisionsEndpoint: ENV.publicatieEndpoint,

--- a/app/services/editor/agendapoint.js
+++ b/app/services/editor/agendapoint.js
@@ -147,7 +147,7 @@ export default class AgendapointEditorService extends Service {
       mandatee_table,
       heading: headingWithConfig({ rdfaAware: false }),
       blockquote,
-      snippet_placeholder: snippetPlaceholder,
+      snippet_placeholder: snippetPlaceholder(this.config.snippet),
       snippet: snippet(this.config.snippet),
       horizontal_rule,
       code_block,
@@ -307,7 +307,9 @@ export default class AgendapointEditorService extends Service {
         inline_rdfa: inlineRdfaWithConfigView({ rdfaAware: true })(controller),
         block_rdfa: (node) => new BlockRDFaView(node),
 
-        snippet_placeholder: snippetPlaceholderView(controller),
+        snippet_placeholder: snippetPlaceholderView(this.config.snippet)(
+          controller,
+        ),
         snippet: snippetView(this.config.snippet)(controller),
         structure: structureView(controller),
         mandatee_table: mandateeTableView(controller),

--- a/app/services/editor/agendapoint.js
+++ b/app/services/editor/agendapoint.js
@@ -115,6 +115,8 @@ import { getOwner } from '@ember/application';
 import { EditorState, ProseParser } from '@lblod/ember-rdfa-editor';
 import { htmlToDoc } from '@lblod/ember-rdfa-editor/utils/_private/html-utils';
 import { citationPlugin } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/citation-plugin';
+import { isRdfaAttrs } from '@lblod/ember-rdfa-editor/core/schema';
+import { BESLUIT } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 
 export default class AgendapointEditorService extends Service {
   @service intl;
@@ -194,8 +196,15 @@ export default class AgendapointEditorService extends Service {
       },
       citation: {
         type: 'nodes',
-        activeInNodeTypes(schema) {
-          return new Set([schema.nodes.motivering]);
+        activeInNode(node) {
+          const { attrs } = node;
+          if (!isRdfaAttrs(attrs)) {
+            return false;
+          }
+          const match = attrs.backlinks.find((bl) =>
+            BESLUIT('motivering').matches(bl.predicate),
+          );
+          return Boolean(match);
         },
         endpoint: '/codex/sparql',
         decisionsEndpoint: ENV.publicatieEndpoint,

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@lblod/ember-environment-banner": "^0.5.0",
         "@lblod/ember-mock-login": "^0.10.0",
         "@lblod/ember-rdfa-editor": "10.7.2",
-        "@lblod/ember-rdfa-editor-lblod-plugins": "25.1.0",
+        "@lblod/ember-rdfa-editor-lblod-plugins": "25.1.0-dev.ef6c3e41374417590a2b8aeab7a94d0438bd4912",
         "@lblod/template-uuid-instantiator": "^1.0.2",
         "@release-it-plugins/lerna-changelog": "^6.0.0",
         "@tsconfig/ember": "^3.0.8",
@@ -7571,9 +7571,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor-lblod-plugins": {
-      "version": "25.1.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-25.1.0.tgz",
-      "integrity": "sha512-toPgVOKM2nKFYZdJnTpHB0hEvpwFninF5DMIQtUOIR2dmW50jguavAEqspxWRyrh4f5NmMgdnUE/xIQvxO58JQ==",
+      "version": "25.1.0-dev.ef6c3e41374417590a2b8aeab7a94d0438bd4912",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-25.1.0-dev.ef6c3e41374417590a2b8aeab7a94d0438bd4912.tgz",
+      "integrity": "sha512-EXYNNZrIFmlEH4XjAhFQjig2p0ip449fOyQwt42olP/v2b/y5mgCvooTHlAoIrlbqqmGXNrvpDYdQhIcBMTGgg==",
       "dev": true,
       "dependencies": {
         "@codemirror/lang-html": "^6.4.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@lblod/ember-environment-banner": "^0.5.0",
         "@lblod/ember-mock-login": "^0.10.0",
         "@lblod/ember-rdfa-editor": "10.7.2",
-        "@lblod/ember-rdfa-editor-lblod-plugins": "25.1.0-dev.ef6c3e41374417590a2b8aeab7a94d0438bd4912",
+        "@lblod/ember-rdfa-editor-lblod-plugins": "25.2.0",
         "@lblod/template-uuid-instantiator": "^1.0.2",
         "@release-it-plugins/lerna-changelog": "^6.0.0",
         "@tsconfig/ember": "^3.0.8",
@@ -7571,9 +7571,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor-lblod-plugins": {
-      "version": "25.1.0-dev.ef6c3e41374417590a2b8aeab7a94d0438bd4912",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-25.1.0-dev.ef6c3e41374417590a2b8aeab7a94d0438bd4912.tgz",
-      "integrity": "sha512-EXYNNZrIFmlEH4XjAhFQjig2p0ip449fOyQwt42olP/v2b/y5mgCvooTHlAoIrlbqqmGXNrvpDYdQhIcBMTGgg==",
+      "version": "25.2.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-25.2.0.tgz",
+      "integrity": "sha512-Ns6GfQP8ye20yBg6Nj/8A/wB5ZQRzc2NcxDdDzxfbRlaWe1XSXBK5fUFhvloOIIMbY9gLfH9pUcXwC40dBfxpg==",
       "dev": true,
       "dependencies": {
         "@codemirror/lang-html": "^6.4.9",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@lblod/ember-environment-banner": "^0.5.0",
     "@lblod/ember-mock-login": "^0.10.0",
     "@lblod/ember-rdfa-editor": "10.7.2",
-    "@lblod/ember-rdfa-editor-lblod-plugins": "25.1.0-dev.ef6c3e41374417590a2b8aeab7a94d0438bd4912",
+    "@lblod/ember-rdfa-editor-lblod-plugins": "25.2.0",
     "@lblod/template-uuid-instantiator": "^1.0.2",
     "@release-it-plugins/lerna-changelog": "^6.0.0",
     "@tsconfig/ember": "^3.0.8",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@lblod/ember-environment-banner": "^0.5.0",
     "@lblod/ember-mock-login": "^0.10.0",
     "@lblod/ember-rdfa-editor": "10.7.2",
-    "@lblod/ember-rdfa-editor-lblod-plugins": "25.1.0",
+    "@lblod/ember-rdfa-editor-lblod-plugins": "25.1.0-dev.ef6c3e41374417590a2b8aeab7a94d0438bd4912",
     "@lblod/template-uuid-instantiator": "^1.0.2",
     "@release-it-plugins/lerna-changelog": "^6.0.0",
     "@tsconfig/ember": "^3.0.8",


### PR DESCRIPTION
### Overview
This PR includes two things:
- An update to the editor-plugins dev-commit created by https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/503
- Adjustments to the citation plugin configuration to ensure it follows the latest API and remains active in 'motivering' blocks.

##### connected issues and PRs:
[GN-5209](https://binnenland.atlassian.net/browse/GN-5209)
https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/503


### Setup
None

### How to test/reproduce
- Start the app
- Log in
- Open an agendapoint containing a decision
- Ensure that you can insert a citation in a 'motivering' block
- Open a regulatory statement
- The citation plugin should be active document-wide



### Checks PR readiness
- [ ] changelog
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] npm lint
- [x] no new deprecations
