### PR TITLE
feat(meeting-creation): only allow bestuursorganen active at planned start date

### DIFF
--- a/.changeset/chatty-lemons-return.md
+++ b/.changeset/chatty-lemons-return.md
@@ -1,0 +1,8 @@
+---
+'frontend-gelinkt-notuleren': minor
+---
+
+- Adjust logic of meeting creation modal:
+  * Only allow the selection of 'bestuursorganen' which are active on the selected 'planned start' date
+  * When modifying the 'planned start' date, clear the 'bestuursorgaan' if necessary.
+- Modernize `administrative-body-select` component

--- a/app/components/administrative-body-select.hbs
+++ b/app/components/administrative-body-select.hbs
@@ -2,7 +2,7 @@
   <PowerSelect
     @placeholder={{t 'manage-zittings-data.select-placeholder'}}
     @selected={{@selected}}
-    @options={{this.administrativeBodyOptions}}
+    @options={{this.administrativeBodyOptions.value}}
     @onChange={{@onChange}}
     @triggerId={{@id}}
     as |administrativeBody|

--- a/app/controllers/inbox/meetings/new.js
+++ b/app/controllers/inbox/meetings/new.js
@@ -20,6 +20,15 @@ export default class InboxMeetingsNewController extends Controller {
     this.meeting.opLocatie = event.target.value;
   }
 
+  @action
+  async updatePlannedStart(date) {
+    this.meeting.geplandeStart = new Date(date.getTime());
+    const bestuursorgaan = await this.meeting.bestuursorgaan;
+    if (!bestuursorgaan?.isActive(date)) {
+      this.meeting.bestuursorgaan = null;
+    }
+  }
+
   get title() {
     return this.intl.t('inbox.meetings.new.common-meeting.title');
   }

--- a/app/models/bestuursorgaan.js
+++ b/app/models/bestuursorgaan.js
@@ -1,4 +1,6 @@
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
+import isAfter from 'date-fns/isAfter';
+import isBefore from 'date-fns/isBefore';
 
 export default class BestuursorgaanModel extends Model {
   @attr uri;
@@ -47,4 +49,15 @@ export default class BestuursorgaanModel extends Model {
       'http://data.vlaanderen.be/ns/mandaat#isTijdspecialisatieVan',
     bevat: 'http://www.w3.org/ns/org#hasPost',
   };
+
+  /**
+   * @param {Date} referenceDate
+   */
+  isActive(referenceDate) {
+    const startDateIsValid =
+      !this.bindingStart || isBefore(this.bindingStart, referenceDate);
+    const endDateIsValid =
+      !this.bindingEinde || isAfter(this.bindingEinde, referenceDate);
+    return startDateIsValid && endDateIsValid;
+  }
 }

--- a/app/templates/inbox/meetings/new.hbs
+++ b/app/templates/inbox/meetings/new.hbs
@@ -22,6 +22,7 @@
             @id={{id}}
             @selected={{this.meeting.bestuursorgaan}}
             @onChange={{this.updateAdministrativeBody}}
+            @referenceDate={{this.meeting.geplandeStart}}
             @error={{if errors true false}}
           />
           {{#each errors as |error|}}
@@ -52,7 +53,7 @@
           }}</AuLabel>
         <DateTimePicker
           @alignment='top'
-          @onChange={{fn (mut this.meeting.geplandeStart)}}
+          @onChange={{this.updatePlannedStart}}
           @value={{this.meeting.geplandeStart}}
         />
       </div>


### PR DESCRIPTION
### Overview
This PR adjusts the logic of the meeting creation dialog:
- Only allow the selection of 'bestuursorganen' which are active on the selected 'planned start' date
- When modifying the 'planned start' date, clear the 'bestuursorgaan' if necessary.

Additionally, this PR also modernizes the `administrative-body-select` component a bit (usage of `trackedFunction` and ensuring reactivity)

##### connected issues and PRs:
Should reduce issues like these: https://binnenland.atlassian.net/browse/GN-5216

### How to test/reproduce
- Start the app
- Log in as a municipality
- Open the meeting creation dialog
- Ensure that the list of 'bestuursorgaan' options changes based on the 'planned start` that is selected
- Ensure that the 'bestuursorgaan' field is cleared when you select a 'planned start' date on which the 'bestuursorgaan' is not active
- Meeting creation itself should still work as before

### Challenges/uncertainties
- This PR _only_ applies this logic on the meeting creation flow. It doesn't allow for editing the 'bestuursorgaan' after creation.
- I created a seperate Jira ticket to track the feature to be able to edit the bestuursorgaan after the meeting creation: https://binnenland.atlassian.net/browse/GN-5218 . This is, however, not trivial to implement.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
