### PR TITLE
Ember application plugin was wrongly configured on custom voting and zitting text container

### DIFF
--- a/.changeset/rich-pandas-protect.md
+++ b/.changeset/rich-pandas-protect.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Fix ember application plugin configuration error

--- a/app/components/zitting-text-document-container.js
+++ b/app/components/zitting-text-document-container.js
@@ -153,7 +153,7 @@ export default class ZittingTextDocumentContainerComponent extends Component {
       tableKeymap,
       linkPasteHandler(this.schema.nodes.link),
       listTrackingPlugin(),
-      emberApplication(getOwner(this)),
+      emberApplication({ application: getOwner(this) }),
     ];
   }
 

--- a/app/controllers/meetings/edit/custom-voting.js
+++ b/app/controllers/meetings/edit/custom-voting.js
@@ -227,7 +227,7 @@ export default class MeetingsEditManualVotingController extends Controller {
       tableKeymap,
       linkPasteHandler(this.schema.nodes.link),
       listTrackingPlugin(),
-      emberApplication(getOwner(this)),
+      emberApplication({ application: getOwner(this) }),
     ];
   }
 


### PR DESCRIPTION
### Overview
The new ember application plugin was wrongly configured on Custom voting and zitting document text container

##### connected issues and PRs:
GN-5225

### Setup
None

### How to test/reproduce
Don't really know other ways of testing this than trying to reproduce the bug in the linked jira issue and check that it doesn't happen anymore

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
