### PR TITLE
fix(intl): fix incorrect translations used on meeting page

### DIFF
--- a/.changeset/young-ligers-tickle.md
+++ b/.changeset/young-ligers-tickle.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Fix incorrect zitting intro/outro/custom-voting translations

--- a/app/templates/meetings/edit/intro.hbs
+++ b/app/templates/meetings/edit/intro.hbs
@@ -20,7 +20,7 @@
         @disabled={{this.saveTextTask.isRunning}}
         {{on 'click' this.closeModal}}
       >
-        {{t 'meetings.edit.intro.cancel'}}
+        {{t 'meetings.edit.cancel'}}
       </AuButton>
     </AuButtonGroup>
     <AuButtonGroup>
@@ -29,18 +29,18 @@
         {{on 'click' (perform this.saveTextTask)}}
         @disabled={{this.saveTextTask.isRunning}}
       >
-        {{t 'meetings.edit.intro.save'}}
+        {{t 'meetings.edit.save'}}
       </AuButton>
       <AuButton
         @disabled={{this.saveTextTask.isRunning}}
         {{on 'click' this.saveAndQuit}}
       >
-        {{t 'meetings.edit.intro.save-and-quit'}}
+        {{t 'meetings.edit.save-and-quit'}}
       </AuButton>
     </AuButtonGroup>
   </Modal.Footer>
 </AuModal>
 <ConfirmRouteLeave
   @enabled={{this.dirty}}
-  @message={{t 'meetings.edit.intro.confirm-quit-without-saving'}}
+  @message={{t 'meetings.edit.confirm-quit-without-saving'}}
 />

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -468,11 +468,10 @@ meetings:
     confirm-button: Ja, deze zitting verwijderen
     back: Terug
   edit:
-    edit:
-    save: Save
-    confirm-quit-without-saving: Are you sure you want to leave the page without saving your changes?
-    save-and-quit: Save and Quit
-    cancel: Cancel
+    save: Opslaan
+    confirm-quit-without-saving: Bent u zeker dat u deze pagina wilt verlaten zonder uw wijzigingen op te slaan?
+    save-and-quit: Opslaan en afsluiten
+    cancel: Annuleren
 
 mock-login:
   administrative-unit-selection: Kies een bestuurseenheid om mee in te loggen.


### PR DESCRIPTION
### Overview
This PR fixes some translations used in the intro/outro/custom-voting sections of a meeting:
- Fix the translation keys on the intro section
- Replace english by dutch in dutch translation file

##### connected issues and PRs:
None

### How to test/reproduce
- Start the app
- Open a meeting
- Open an intro/outro/custom-voting editor
- Ensure the button translations follow the configured browser language + no missing translations

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
