### PR TITLE
GN-5239: headless-editor - add necessary RDFa plugins

### DIFF
--- a/.changeset/eight-forks-live.md
+++ b/.changeset/eight-forks-live.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Agendapoint headless editor: ensure the necessary RDFa plugins are configured for the headless editor to work as expected

--- a/app/services/editor/agendapoint.js
+++ b/app/services/editor/agendapoint.js
@@ -1,5 +1,8 @@
 import Service, { service } from '@ember/service';
 import { v4 as uuidv4 } from 'uuid';
+import { removePropertiesOfDeletedNodes } from '@lblod/ember-rdfa-editor/plugins/remove-properties-of-deleted-nodes';
+import { defaultAttributeValueGeneration } from '@lblod/ember-rdfa-editor/plugins/default-attribute-value-generation';
+import { rdfaInfoPlugin } from '@lblod/ember-rdfa-editor/plugins/rdfa-info';
 
 import { Schema } from '@lblod/ember-rdfa-editor';
 import {
@@ -347,7 +350,27 @@ export default class AgendapointEditorService extends Service {
 
     const state = EditorState.create({
       doc,
-      plugins: this.plugins,
+      // We need to configure some additional (default) plugins for the headless editor
+      // (they are already configured by default on the headful one)
+      plugins: [
+        defaultAttributeValueGeneration([
+          {
+            attribute: '__guid',
+            generator() {
+              return uuidv4();
+            },
+          },
+          {
+            attribute: '__rdfaId',
+            generator() {
+              return uuidv4();
+            },
+          },
+        ]),
+        removePropertiesOfDeletedNodes(),
+        rdfaInfoPlugin(),
+        ...this.plugins,
+      ],
     });
     return state;
   };


### PR DESCRIPTION
### Overview
While moving to the seperate `agendapoint` service, I forgot to configure the necessary RDFa plugins for the headless editor (this are plugins that are configured by default on a headful editor).

##### connected issues and PRs:
[GN-5239](https://binnenland.atlassian.net/browse/GN-5239)


### How to test/reproduce
- Start the app
- Login as a municipality/OCMW
- Open/create an IV
- Ensure at least one of the following mandatee tables is configured
  * IVGR3-LMB-1-eedafleggingen
  * IVGR7-LMB-2-ontvankelijkheid-schepenen
  * IVRMW2-LBM-3-verkiezing-leden
- Sync the meeting
- Open the AP containing one of the 3 tables
- Ensure the RDFa is correct (the mandatees should be connected to the decision using the `mandaat:bekrachtigtAanstellingVan` predicate)

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
