### PR TITLE
GN-5252: meeting-attendee-modal don't filter mandatees on status

### DIFF
--- a/.changeset/heavy-tips-hang.md
+++ b/.changeset/heavy-tips-hang.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Meeting attendee modal: don't filter on status when fetching mandatees

--- a/app/components/meeting-form.js
+++ b/app/components/meeting-form.js
@@ -7,10 +7,6 @@ import { articlesBasedOnClassifcationMap } from '../utils/classification-utils';
 import { trackedFunction } from 'reactiveweb/function';
 import { trackedTask } from 'reactiveweb/ember-concurrency';
 import InstallatieVergaderingModel from 'frontend-gelinkt-notuleren/models/installatievergadering';
-import {
-  MANDATARIS_STATUS_EFFECTIEF,
-  MANDATARIS_STATUS_WAARNEMEND,
-} from '../utils/constants';
 import { getIdentifier } from '../utils/rdf-utils';
 import { BESTUURSFUNCTIE_CODES } from '../config/constants';
 
@@ -213,12 +209,6 @@ export default class MeetingForm extends Component {
             ':id:': stringifiedDefaultTypeIds,
           },
         },
-        status: {
-          ':id:': [
-            MANDATARIS_STATUS_EFFECTIEF,
-            MANDATARIS_STATUS_WAARNEMEND,
-          ].join(','),
-        },
         ':lte:start': startOfMeeting.toISOString(),
         ':or:': {
           ':has-no:einde': true,
@@ -268,12 +258,6 @@ export default class MeetingForm extends Component {
                     ),
                   ].join(','),
                 },
-              },
-              status: {
-                ':id:': [
-                  MANDATARIS_STATUS_EFFECTIEF,
-                  MANDATARIS_STATUS_WAARNEMEND,
-                ].join(','),
               },
               ':or:': {
                 ':has-no:einde': true,

--- a/app/components/participation-list/mandataris-selector.js
+++ b/app/components/participation-list/mandataris-selector.js
@@ -2,10 +2,6 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { all, restartableTask, timeout } from 'ember-concurrency';
 import { service } from '@ember/service';
-import {
-  MANDATARIS_STATUS_EFFECTIEF,
-  MANDATARIS_STATUS_WAARNEMEND,
-} from '../../utils/constants';
 import { BESTUURSFUNCTIE_CODES } from '../../config/constants';
 import InstallatieVergaderingModel from 'frontend-gelinkt-notuleren/models/installatievergadering';
 import { getIdentifier } from '../../utils/rdf-utils';
@@ -60,12 +56,6 @@ export default class ParticipationListMandatarisSelectorComponent extends Compon
           },
         },
         'is-bestuurlijke-alias-van': searchData,
-        status: {
-          ':id:': [
-            MANDATARIS_STATUS_EFFECTIEF,
-            MANDATARIS_STATUS_WAARNEMEND,
-          ].join(','),
-        },
         ':lte:start': this.startOfMeeting.toISOString(),
         ':or:': {
           ':has-no:einde': true,
@@ -117,12 +107,6 @@ export default class ParticipationListMandatarisSelectorComponent extends Compon
                   ].join(','),
                 },
               },
-              status: {
-                ':id:': [
-                  MANDATARIS_STATUS_EFFECTIEF,
-                  MANDATARIS_STATUS_WAARNEMEND,
-                ].join(','),
-              },
               ':or:': {
                 ':has-no:einde': true,
                 ':gt:einde': this.startOfMeeting.toISOString(),
@@ -160,12 +144,6 @@ export default class ParticipationListMandatarisSelectorComponent extends Compon
           },
         },
         'is-bestuurlijke-alias-van': searchData,
-        status: {
-          ':id:': [
-            MANDATARIS_STATUS_EFFECTIEF,
-            MANDATARIS_STATUS_WAARNEMEND,
-          ].join(','),
-        },
         ':lte:start': this.startOfMeeting.toISOString(),
         ':or:': {
           ':has-no:einde': true,


### PR DESCRIPTION
### Overview
LMB contains several mandatees from previous legislations without a status (that should have one). This means we can't confidently filter on the 'status' property when fetching potential attendees for a meeting.

##### connected issues and PRs:
Fixes [GN-5252](https://binnenland.atlassian.net/browse/GN-5252)

### How to test/reproduce
- Start the app
- Login as a municipality which has a mandatee with a missing status (e.g. Avelgem)
- Ensure that in an IV meeting, you can correctly select the chairman of the previous legislation (who has no status)

### Challenges/uncertainties
This is not as bad as it seems, as we still filter on start- and end-date of the mandatee.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
