### PR TITLE
Fix model config for publishing-log to correctly work with IVs

### DIFF
--- a/.changeset/nine-files-know.md
+++ b/.changeset/nine-files-know.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Fix model configuration for publishing logs of IV meetings

--- a/app/models/publishing-log.js
+++ b/app/models/publishing-log.js
@@ -8,5 +8,5 @@ export default class PublishingLogs extends Model {
   @belongsTo('published-resource', { async: true }) publishedResource;
 
   @belongsTo('gebruiker', { async: true }) user;
-  @belongsTo('zitting', { async: true }, { polymorphic: true }) zitting;
+  @belongsTo('zitting', { async: true, polymorphic: true }) zitting;
 }


### PR DESCRIPTION
### Overview
The config to make the link between publishing-log and zitting polymorphic was done incorrectly, so ember-data gave an error. I didn't see any issues from this yet other than the console error.

##### connected issues and PRs:
N/A

### Setup
N/A

### How to test/reproduce
Publish an IV meeting and notice that there is no longer a console error.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
