### PR TITLE
Bugfix/fix contact page

### DIFF
--- a/.changeset/tame-bulldogs-cheat.md
+++ b/.changeset/tame-bulldogs-cheat.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Fix contact page

--- a/app/components/contact-form.hbs
+++ b/app/components/contact-form.hbs
@@ -3,21 +3,19 @@
   <AuLabel for='select'>{{t 'contact.about'}}</AuLabel>
   <ul>
     <li>
-      <AuControlRadio
-        @label={{t 'contact.bug-message'}}
+      <AuRadio
         @value='GelinktNotuleren@vlaanderen.be?subject=Functionaliteit of bug of probleem'
         @name='type-vraag'
         @onChange={{this.setMailto}}
-      />
+      >{{t 'contact.bug-message'}}</AuRadio>
 
     </li>
     <li>
-      <AuControlRadio
-        @label={{t 'contact.question-message'}}
+      <AuRadio
         @name='type-vraag'
         @value='GelinktNotuleren@vlaanderen.be?subject=Inhoudelijke vraag'
         @onChange={{this.setMailto}}
-      />
+      >{{t 'contact.question-message'}}</AuRadio>
     </li>
   </ul>
   {{#if this.mailto}}


### PR DESCRIPTION
### Overview
Seems like the contact page was already done, but a bug with an appuniversum breaking change prevented it from displaying

##### connected issues and PRs:
GN-5234


### Setup
None

### How to test/reproduce
Go to the contact page and ,check that it displays correctly

### Challenges/uncertainties
Maybe we want to change the content of this contact page, but I think it looks good



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
