### PR TITLE
Do not autofill variables in a headless editor

### DIFF
--- a/.changeset/hip-dogs-call.md
+++ b/.changeset/hip-dogs-call.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Fix bug with LMB synchronisation by not autofilling variables in headless editors

--- a/app/controllers/agendapoints/edit.js
+++ b/app/controllers/agendapoints/edit.js
@@ -31,15 +31,19 @@ export default class AgendapointsEditController extends Controller {
 
   SnippetInsert = SnippetInsertRdfaComponent;
 
-  schema = this.agendapointEditor.schema;
-
   config = this.agendapointEditor.config;
 
   nodeViews = this.agendapointEditor.nodeViews;
 
-  plugins = this.agendapointEditor.plugins;
-
   citationPlugin = this.agendapointEditor.citationPlugin;
+
+  constructor(...args) {
+    super(...args);
+    const { schema, plugins } =
+      this.agendapointEditor.getSchemaAndPlugins(false);
+    this.schema = schema;
+    this.plugins = plugins;
+  }
 
   get dirty() {
     // Since we clear the undo history when saving, this works. If we want to maintain undo history


### PR DESCRIPTION
### Overview
Fixes the bug with LMB syncing, as the table replacements were being calculated on the pre-autofilled state but run on the post-autofilled state.

##### connected issues and PRs:
Jira ticket: https://binnenland.atlassian.net/browse/GN-5256

### Setup
Easiest to see when pointing to QA and either QA RB or prod RB.

### How to test/reproduce
This should take place in any template with an autofill variable in the document at some point before a mandatee table. An example of this is the IV for an OCMW, so logging in as one of these should work (see Jira comments for a list of exact municipalities).
1. Create an IV
2. Look at the preview of the APs to confirm that there is indeed an autofill variable, with a mandatee table somewhere later in the document. If you open an editor, do not save it.
3. Click the 'synchronize with LMB' button. This should work correctly.
4. Check the AP preview to verify that the mandatee tables have been replaced but the autofill variables have not.
5. Open the editor for the AP and verify that the autofill variables have now been filled.

### Challenges/uncertainties
These kinds of prosemirror issues are hard to debug. The use of transaction monads make it harder still.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
