### PR TITLE
FIx bug when creating a IV with Ronse and Voeren

### DIFF
--- a/.changeset/angry-guests-poke.md
+++ b/.changeset/angry-guests-poke.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Fix agendapoint not generated bug when creating a IV with Ronse and Voeren

--- a/app/api/installatievergadering.js
+++ b/app/api/installatievergadering.js
@@ -204,7 +204,7 @@ const FACILITY_SPEC = DEFAULT_MUNICIPALITY_SPEC;
 /** @type { Record<string, MunicipalitySpec> } */
 const MUNICIPALITY_CONFIG = {
   // We won't have special templates for voeren
-  Voeren: { gemeenteraad: NO_POLITIERAAD_SPEC, rmw: IVRMW_MAP },
+  Voeren: NO_POLITIERAAD_SPEC,
   // faciliteitengemeentes (municipalities on the language border which have
   // special facilities for the french-speaking minorities)
   Bever: FACILITY_SPEC,
@@ -213,7 +213,7 @@ const MUNICIPALITY_CONFIG = {
   Kraainem: FACILITY_SPEC,
   Linkebeek: FACILITY_SPEC,
   Mesen: FACILITY_SPEC,
-  Ronse: { gemeenteraad: NO_POLITIERAAD_SPEC, rmw: IVRMW_MAP },
+  Ronse: NO_POLITIERAAD_SPEC,
   'Sint-Genesius-Rode': FACILITY_SPEC,
   'Spiere-Helkijn': FACILITY_SPEC,
   Wemmel: FACILITY_SPEC,

--- a/app/api/installatievergadering.js
+++ b/app/api/installatievergadering.js
@@ -198,26 +198,9 @@ const DEFAULT_MUNICIPALITY_SPEC = {
   gemeenteraad: IVGR_POLITIERAAD_MAP,
   rmw: IVRMW_MAP,
 };
-// we will not provide special templates for border municipalities
-const FACILITY_SPEC = DEFAULT_MUNICIPALITY_SPEC;
 
 /** @type { Record<string, MunicipalitySpec> } */
 const MUNICIPALITY_CONFIG = {
-  // We won't have special templates for voeren
-  Voeren: NO_POLITIERAAD_SPEC,
-  // faciliteitengemeentes (municipalities on the language border which have
-  // special facilities for the french-speaking minorities)
-  Bever: FACILITY_SPEC,
-  Drogenbos: FACILITY_SPEC,
-  Herstappe: FACILITY_SPEC,
-  Kraainem: FACILITY_SPEC,
-  Linkebeek: FACILITY_SPEC,
-  Mesen: FACILITY_SPEC,
-  Ronse: NO_POLITIERAAD_SPEC,
-  'Sint-Genesius-Rode': FACILITY_SPEC,
-  'Spiere-Helkijn': FACILITY_SPEC,
-  Wemmel: FACILITY_SPEC,
-  'Wezembeek-Oppem': FACILITY_SPEC,
   // fusions
   'Merelbeke-Melle': FUSION_SPEC,
   'Nazareth-De Pinte': FUSION_SPEC,
@@ -234,6 +217,8 @@ const MUNICIPALITY_CONFIG = {
   Lokeren: FUSION_SPEC,
 
   // municipalities without the 9th agenda item
+  Voeren: NO_POLITIERAAD_SPEC,
+  Ronse: NO_POLITIERAAD_SPEC,
   Antwerpen: NO_POLITIERAAD_SPEC,
   Brasschaat: NO_POLITIERAAD_SPEC,
   Schoten: NO_POLITIERAAD_SPEC,


### PR DESCRIPTION
### Overview
Ronse and Voeren where not getting agendapoints when creating a IV due to a configuration error

##### connected issues and PRs:
GN-5281


### Setup
None

### How to test/reproduce
Login with Voeren or Ronse, both Geemente and OCMW, verify that you can successfully create IV and the agendapoints appear 

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
