### PR TITLE
Update editor to version 10.9.0

### DIFF
--- a/.changeset/nice-pumas-fix.md
+++ b/.changeset/nice-pumas-fix.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Update `@lblod/ember-rdfa-editor` to version [10.9.0](https://github.com/lblod/ember-rdfa-editor/releases/tag/v10.9.0)

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@lblod/ember-acmidm-login": "^2.1.0",
         "@lblod/ember-environment-banner": "^0.5.0",
         "@lblod/ember-mock-login": "^0.10.0",
-        "@lblod/ember-rdfa-editor": "10.8.0",
+        "@lblod/ember-rdfa-editor": "10.9.0",
         "@lblod/ember-rdfa-editor-lblod-plugins": "26.0.2",
         "@lblod/template-uuid-instantiator": "^1.0.3",
         "@release-it-plugins/lerna-changelog": "^6.0.0",
@@ -7483,9 +7483,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor": {
-      "version": "10.8.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-10.8.0.tgz",
-      "integrity": "sha512-Xmcs8+e5sC9aDKz6hB5PslIePKizvh294O9A1JpKx00TzZhIFVBZeyW2baKiBpKpMjR/SyXj4WyryUKLYDldWw==",
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-10.9.0.tgz",
+      "integrity": "sha512-FHCV9/yYosA9c/dU1zQkHhscsysv5MuUQEZCZ3mayrVFN7EQyerJutC/apej0pqHx+dBL6HHtV+nTv3O3q8FSQ==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.24.7",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@lblod/ember-acmidm-login": "^2.1.0",
     "@lblod/ember-environment-banner": "^0.5.0",
     "@lblod/ember-mock-login": "^0.10.0",
-    "@lblod/ember-rdfa-editor": "10.8.0",
+    "@lblod/ember-rdfa-editor": "10.9.0",
     "@lblod/ember-rdfa-editor-lblod-plugins": "26.0.2",
     "@lblod/template-uuid-instantiator": "^1.0.3",
     "@release-it-plugins/lerna-changelog": "^6.0.0",


### PR DESCRIPTION
### Overview
Update `@lblod/ember-rdfa-editor` to version [10.9.0](https://github.com/lblod/ember-rdfa-editor/releases/tag/v10.9.0)
