### PR TITLE
fix duplicated SPARQL results

### DIFF
--- a/.changeset/ninety-tomatoes-swim.md
+++ b/.changeset/ninety-tomatoes-swim.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Work around virtuoso optional-nested-select duplication bug by replacing `OPTIONAL` statements by `UNION` statements

--- a/app/config/mandatee-table-config.js
+++ b/app/config/mandatee-table-config.js
@@ -1332,8 +1332,15 @@ export const mandateeTableConfigRMW = (meeting) => {
             ?mandataris a mandaat:Mandataris.
             ?mandataris mandaat:isBestuurlijkeAliasVan ?persoon.
             ?mandataris org:hasMembership/org:organisation ?fractie.
-            OPTIONAL {
+
+            {
               ?mandataris mandaat:einde ?persoon_mandaat_einde.
+            }
+            UNION
+            {
+              FILTER NOT EXISTS {
+                ?mandataris mandaat:einde ?persoon_mandaat_einde.
+              }
             }
 
             ?fractie a mandaat:Fractie.
@@ -1438,8 +1445,15 @@ export const mandateeTableConfigRMW = (meeting) => {
             ?mandataris mandaat:isBestuurlijkeAliasVan ?persoon.
             ?mandataris org:hasMembership/org:organisation ?fractie.
             ?mandataris mandaat:start ?mandaat_start.
-            OPTIONAL {
+
+            {
               ?mandataris mandaat:einde ?mandaat_einde.
+            }
+            UNION
+            {
+              FILTER NOT EXISTS {
+                ?mandataris mandaat:einde ?mandaat_einde.
+              }
             }
 
             ?fractie a mandaat:Fractie.


### PR DESCRIPTION
### Overview
This PR contains a workaround to what I call the 'virtuoso-optional-nested-select-duplication-bug'.
This (rare) bug only seems to appear when your SPARQL query contains both an `OPTIONAL` and nested `SELECT` statement.
It basically causes the individual results of your query (even when using `DISTINCT`) to be duplicated an undetermined amount of times (up to 8 times even).
 
To work around this bug, this PR adjusts the affect queries by replacing the `OPTIONAL` statements by equivalent `UNION` statements.

```
OPTIONAL {
  ?mandataris mandaat:einde ?persoon_mandaat_einde.
}
```
is replaced by the equivalent
```sparql
{
  ?mandataris mandaat:einde ?persoon_mandaat_einde.
}
UNION
{
  FILTER NOT EXISTS {
    ?mandataris mandaat:einde ?persoon_mandaat_einde.
  }
}
```

##### connected issues and PRs:
Related virtuoso issues:
https://github.com/openlink/virtuoso-opensource/issues/388
https://github.com/openlink/virtuoso-opensource/issues/568
https://github.com/openlink/virtuoso-opensource/issues/472

### How to test/reproduce
**Before this PR: **
- Start the frontend
- Login as an OCMW
- Open/create an IV
- Sync it
- (not consistent, might need a few tries): after some syncs/queries, the `IVRMW2-LMB-2-kandidaat-leden` will contain duplicate mandatees
**After this PR**
- Same steps as above, but not matter how many times you sync/send the query. There should be no duplicate mandatees in the result-set.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
