### PR TITLE
GN-5304: automatically connect articles to parent decision upon saving the agendapoint

### DIFF
--- a/.changeset/ninety-tomatoes-swim.md
+++ b/.changeset/ninety-tomatoes-swim.md
@@ -1,5 +1,0 @@
----
-'frontend-gelinkt-notuleren': patch
----
-
-Work around virtuoso optional-nested-select duplication bug by replacing `OPTIONAL` statements by `UNION` statements

--- a/.changeset/quiet-pants-greet.md
+++ b/.changeset/quiet-pants-greet.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Fix: automatically connect articles to parent decision upon opening an agendapoint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # frontend-gelinkt-notuleren
 
+## 5.43.3
+
+### Patch Changes
+
+- [#782](https://github.com/lblod/frontend-gelinkt-notuleren/pull/782) [`28f57ed`](https://github.com/lblod/frontend-gelinkt-notuleren/commit/28f57ed34462f6f48e91cdad0160ef4f817b1365) Thanks [@elpoelma](https://github.com/elpoelma)! - Work around virtuoso optional-nested-select duplication bug by replacing `OPTIONAL` statements by `UNION` statements
+
 ## 5.43.2
 
 ### Patch Changes

--- a/app/components/global-system-notification.gjs
+++ b/app/components/global-system-notification.gjs
@@ -1,0 +1,37 @@
+import AuAlert from '@appuniversum/ember-appuniversum/components/au-alert';
+import Component from '@glimmer/component';
+import config from 'frontend-gelinkt-notuleren/config/environment';
+
+export default class GlobalSystemNotification extends Component {
+  get notification() {
+    console.log('Not: ', config.globalSystemNotification);
+    return config.globalSystemNotification;
+  }
+
+  get show() {
+    if (!this.notification) {
+      return false;
+    }
+    if (this.notification.startsWith('{{')) {
+      return false;
+    }
+    return true;
+  }
+
+  <template>
+    {{#if this.show}}
+      <AuAlert
+        @skin='warning'
+        @size='tiny'
+        @closable={{true}}
+        class='au-u-margin-bottom-none'
+        ...attributes
+      >
+        <p class='au-u-text-center'>
+          {{!template-lint-disable no-triple-curlies}}
+          {{{this.notification}}}
+        </p>
+      </AuAlert>
+    {{/if}}
+  </template>
+}

--- a/app/components/global-system-notification.gjs
+++ b/app/components/global-system-notification.gjs
@@ -4,7 +4,6 @@ import config from 'frontend-gelinkt-notuleren/config/environment';
 
 export default class GlobalSystemNotification extends Component {
   get notification() {
-    console.log('Not: ', config.globalSystemNotification);
     return config.globalSystemNotification;
   }
 

--- a/app/components/inauguration-meeting/synchronization.js
+++ b/app/components/inauguration-meeting/synchronization.js
@@ -15,6 +15,7 @@ import {
   mandateeTableConfigIVGR,
   mandateeTableConfigRMW,
 } from '../../config/mandatee-table-config';
+import { fixArticleConnections } from '../../utils/fix-article-connections';
 
 export default class InaugurationMeetingSynchronizationComponent extends Component {
   @service toaster;
@@ -197,10 +198,15 @@ export default class InaugurationMeetingSynchronizationComponent extends Compone
     const currentVersion = await container.currentVersion;
     const html = currentVersion.content ?? '';
     const initialState = this.agendapointEditor.getState(html);
-    const syncedState = await syncDocument(initialState, {
+    let syncedState = await syncDocument(initialState, {
       ...mandateeTableConfigIVGR(this.meeting),
       ...mandateeTableConfigRMW(this.meeting),
     });
+    const fixArticleConnectionsTr = fixArticleConnections(syncedState);
+    if (fixArticleConnectionsTr) {
+      syncedState = syncedState.applyTransaction(fixArticleConnectionsTr).state;
+    }
+
     const serializer = SaySerializer.fromSchema(
       syncedState.schema,
       () => syncedState,

--- a/app/controllers/agendapoints/edit.js
+++ b/app/controllers/agendapoints/edit.js
@@ -73,7 +73,6 @@ export default class AgendapointsEditController extends Controller {
   async handleRdfaEditorInit(editor) {
     this.controller = editor;
     editor.initialize(this.editorDocument.content || '', { doNotClean: true });
-    fixArticleConnections(editor);
   }
 
   copyAgendapunt = task(async () => {
@@ -135,6 +134,7 @@ export default class AgendapointsEditController extends Controller {
   });
 
   saveTask = task(async () => {
+    fixArticleConnections(this.controller);
     if (!this.editorDocument.title) {
       this.hasDocumentValidationErrors = true;
     } else {

--- a/app/controllers/agendapoints/edit.js
+++ b/app/controllers/agendapoints/edit.js
@@ -134,7 +134,12 @@ export default class AgendapointsEditController extends Controller {
   });
 
   saveTask = task(async () => {
-    fixArticleConnections(this.controller);
+    const fixArticleConnectionsTr = fixArticleConnections(
+      this.controller.mainEditorState,
+    );
+    if (fixArticleConnectionsTr) {
+      this.controller.mainEditorView.dispatch(fixArticleConnectionsTr);
+    }
     if (!this.editorDocument.title) {
       this.hasDocumentValidationErrors = true;
     } else {

--- a/app/controllers/agendapoints/edit.js
+++ b/app/controllers/agendapoints/edit.js
@@ -12,6 +12,7 @@ import InsertArticleComponent from '@lblod/ember-rdfa-editor-lblod-plugins/compo
 import { getActiveEditableNode } from '@lblod/ember-rdfa-editor/plugins/_private/editable-node';
 
 import SnippetInsertRdfaComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/snippet-plugin/snippet-insert-rdfa';
+import { fixArticleConnections } from '../../utils/fix-article-connections';
 
 export default class AgendapointsEditController extends Controller {
   @service store;
@@ -69,9 +70,10 @@ export default class AgendapointsEditController extends Controller {
   }
 
   @action
-  handleRdfaEditorInit(editor) {
+  async handleRdfaEditorInit(editor) {
     this.controller = editor;
     editor.initialize(this.editorDocument.content || '', { doNotClean: true });
+    fixArticleConnections(editor);
   }
 
   copyAgendapunt = task(async () => {

--- a/app/templates/agendapoints/edit.hbs
+++ b/app/templates/agendapoints/edit.hbs
@@ -98,7 +98,7 @@
     @widgets={{this.widgets}}
     @nodeViews={{this.nodeViews}}
     @plugins={{this.plugins}}
-    @shouldEditRdfa={{false}}
+    @shouldEditRdfa={{true}}
     @shouldShowRdfa={{true}}
   >
     <:toolbar>

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -6,6 +6,7 @@
 }}
 <AuModalContainer />
 <AuApp class='{{if this.showEnvironment "au-c-app--environment"}}'>
+  <GlobalSystemNotification/>
   {{#if this.showEnvironment}}
     <div class='au-u-hide-on-print'>
       <EnvironmentBanner

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -6,7 +6,7 @@
 }}
 <AuModalContainer />
 <AuApp class='{{if this.showEnvironment "au-c-app--environment"}}'>
-  <GlobalSystemNotification/>
+  <GlobalSystemNotification />
   {{#if this.showEnvironment}}
     <div class='au-u-hide-on-print'>
       <EnvironmentBanner

--- a/app/utils/fix-article-connections.js
+++ b/app/utils/fix-article-connections.js
@@ -1,0 +1,80 @@
+import { SayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
+import { transactionCombinator } from '@lblod/ember-rdfa-editor/utils/transaction-utils';
+import { addPropertyToNode } from '@lblod/ember-rdfa-editor/utils/rdfa-utils';
+import { hasOutgoingNamedNodeTriple } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
+import {
+  RDF,
+  BESLUIT,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
+import { findChildren } from '@curvenote/prosemirror-utils';
+
+export function fixArticleConnections(editorController) {
+  const state = editorController.mainEditorState;
+  const decisions = findDecisions(state.doc, editorController.schema);
+  if (!decisions.length) {
+    return false;
+  }
+  const transactionMonads = [];
+  const factory = new SayDataFactory();
+  for (const decision of decisions) {
+    const unconnectedArticles = findUnconnectedArticles(
+      decision.node,
+      editorController.schema,
+    );
+    for (const article of unconnectedArticles) {
+      transactionMonads.push(
+        addPropertyToNode({
+          resource: decision.node.attrs.subject,
+          property: {
+            predicate: 'http://data.europa.eu/eli/ontology#has_part',
+            object: factory.resourceNode(article.node.attrs.subject),
+          },
+        }),
+      );
+    }
+  }
+  if (!transactionMonads.length) {
+    return false;
+  }
+  editorController.withTransaction((tr) => {
+    const result = transactionCombinator(
+      editorController.mainEditorState,
+      tr,
+    )(transactionMonads);
+    result.transaction.setMeta('addToHistory', false);
+    return result.transaction;
+  });
+  return true;
+}
+
+function findDecisions(doc, schema) {
+  const decisions = findChildren(doc, (child) => {
+    return (
+      child.type === schema.nodes.block_rdfa &&
+      hasOutgoingNamedNodeTriple(child.attrs, RDF('type'), BESLUIT('Besluit'))
+    );
+  });
+  return decisions;
+}
+
+function findUnconnectedArticles(decisionNode, schema) {
+  const decisionURI = decisionNode.subject;
+  const articles = findChildren(decisionNode, (child) => {
+    return (
+      child.type === schema.nodes.structure &&
+      child.attrs.structureType === 'article' &&
+      !isConnectedTo(child, decisionURI)
+    );
+  });
+  return articles;
+}
+
+function isConnectedTo(articleNode, decisionURI) {
+  return Boolean(
+    (articleNode.attrs.backlinks ?? []).some(
+      (backlink) =>
+        backlink.subject === decisionURI &&
+        backlink.predicate == 'http://data.europa.eu/eli/ontology#has_part',
+    ),
+  );
+}

--- a/app/utils/fix-article-connections.js
+++ b/app/utils/fix-article-connections.js
@@ -58,7 +58,7 @@ function findDecisions(doc, schema) {
 }
 
 function findUnconnectedArticles(decisionNode, schema) {
-  const decisionURI = decisionNode.subject;
+  const decisionURI = decisionNode.attrs.subject;
   const articles = findChildren(decisionNode, (child) => {
     return (
       child.type === schema.nodes.structure &&
@@ -70,11 +70,12 @@ function findUnconnectedArticles(decisionNode, schema) {
 }
 
 function isConnectedTo(articleNode, decisionURI) {
-  return Boolean(
+  const result = Boolean(
     (articleNode.attrs.backlinks ?? []).some(
       (backlink) =>
-        backlink.subject === decisionURI &&
-        backlink.predicate == 'http://data.europa.eu/eli/ontology#has_part',
+        backlink.subject.value === decisionURI &&
+        backlink.predicate === 'http://data.europa.eu/eli/ontology#has_part',
     ),
   );
+  return result;
 }

--- a/config/environment.js
+++ b/config/environment.js
@@ -14,6 +14,7 @@ module.exports = function (environment) {
     zonalLocationCodelistUri: '{{ZONAL_LOCATION_CODELIST_URI}}',
     nonZonalLocationCodelistUri: '{{NON_ZONAL_LOCATION_CODELIST_URI}}',
     lmbEndpoint: '{{LMB_ENDPOINT}}',
+    globalSystemNotification: '{{GLOBAL_SYSTEM_NOTIFICATION}}',
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend-gelinkt-notuleren",
-  "version": "5.43.2",
+  "version": "5.43.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend-gelinkt-notuleren",
-      "version": "5.43.2",
+      "version": "5.43.3",
       "license": "MIT",
       "dependencies": {
         "@curvenote/prosemirror-utils": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-gelinkt-notuleren",
-  "version": "5.43.2",
+  "version": "5.43.3",
   "private": true,
   "description": "Ember frontend of the Gelinkt Notuleren application",
   "repository": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@tsconfig/ember/tsconfig.json",
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "esnext",
     "experimentalDecorators": true,
     "allowJs": true,
     "checkJs": false


### PR DESCRIPTION
### Overview
This PR includes a way for users to (unknowingly) easily fix the article-decision connections.
Specifically this PR includes the following:
- A utility function `fixArticleConnections` which, given a document, connects the articles in that document to their parent decision (if they were not already connected).
- A `global-system-notification` component which can be configured to show (closable) system notifications to the user
   * It may be configured through the `EMBER_GLOBAL_SYSTEM_NOTIFICATION` environment variable

##### connected issues and PRs:
Provides tooling to partially fix [GN-5304](https://binnenland.atlassian.net/browse/GN-5304)

### Setup
You should connect to a backend containing agendapoints with unconnected/incorrectly connected articles

### How to test/reproduce
- Start the app
- Login as any user
- Open an agendapoint with unconnected/incorrectly connected articles
- Ensure the connections are automatically fixed after saving the AP
- The user should not be aware anything has happened:
  * No undo possible

### Challenges/uncertainties
- This requires the user to open the affected APs and save them. We can add a global notification with a little explanation.
- Based on modification timestamps, we can determine the APs which were not fixed.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
