### PR TITLE
Sort IV mandatee tables by fractie votes when having equal seat numbers

### DIFF
--- a/.changeset/twenty-goats-end.md
+++ b/.changeset/twenty-goats-end.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Update mandatee table queries for IVs to sort fracties with the same number of seats by number of votes

--- a/app/config/mandatee-table-query-fragments.js
+++ b/app/config/mandatee-table-query-fragments.js
@@ -1,0 +1,21 @@
+export const fractieOrderingSubquery = (role, period) => `{
+  SELECT ?fractie (COUNT(DISTINCT ?_persoon) AS ?fractie_grootte) (SUM(?_aantal_stemmen) AS ?fractie_stemmen)
+  WHERE {
+    ?_mandataris a mandaat:Mandataris.
+    ?_mandataris org:hasMembership/org:organisation ?fractie.
+
+    ?_mandataris org:holds ?_mandaat.
+    ?_mandaat org:role <${role}>.
+
+    ?_bestuursorgaanIT org:hasPost ?_mandaat.
+    ?_bestuursorgaanIT lmb:heeftBestuursperiode <${period}>.
+
+    ?_persoon a person:Person.
+    ?_mandataris mandaat:isBestuurlijkeAliasVan ?_persoon.
+
+    ?_verkiezing mandaat:steltSamen ?_bestuursorgaanIT.
+    ?_verkiezingsresultaat mandaat:isResultaatVoor/mandaat:behoortTot ?_verkiezing.
+    ?_verkiezingsresultaat mandaat:isResultaatVan ?_persoon.
+    ?_verkiezingsresultaat mandaat:aantalNaamstemmen ?_aantal_stemmen.
+  }
+}`;


### PR DESCRIPTION
### Overview
Add sorting based on the sum of the votes for the candidates within a fractie to any mandatee table query where the fracties are sorted by number of seats. I think I haven't missed any that should be sorted this way, but it's possible that I missed some.

Notes:
- Some of the queries are significantly slower now. If we think this is a problem, we'll need to look to optimise the queries. Alternatively, it doesn't make sense to me to overload the queries in this way, it would make sense to do one query for the sorting of the fracties and then handle sorting based on this in code.
- There was one RMW query which was using the gemeenteraadslid functie code. I assumed this was a mistake, but I'll flag it in the review so it can be sanity checked.

##### connected issues and PRs:
Jira ticket: https://binnenland.atlassian.net/browse/GN-5308

### Setup
N/A

### How to test/reproduce
Sync mandatee tables for an IV and see that the new sorting is applied. For example, for Mechelen GR the previous sorting put PVDA above cd&v, but the new sorting puts cd&v first as they got more total votes.

### Challenges/uncertainties
It's hard to know if the numbers I'm seeing for votes are correct as I have no way to verify them. So, it's possible that I'm including results that I shouldn't or excluding ones that I should. I used similar logic to where we are getting vote numbers elsewhere, so I think it's unlikely, but it's hard for me to exclude it.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
