### PR TITLE
Modernize meeting page css

### DIFF
--- a/.changeset/shy-dancers-joke.md
+++ b/.changeset/shy-dancers-joke.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Slightly modernize the meeting page styling by moving to a flex-based layout

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -583,11 +583,6 @@ body {
   .au-c-main-container {
     height: calc(100vh - 92px);
   }
-
-  // Fix sidebar offset
-  .au-c-meeting-sidebar {
-    top: 14.8rem;
-  }
 }
 
 // TOC temp styling

--- a/app/styles/project/_c-meeting-chrome.scss
+++ b/app/styles/project/_c-meeting-chrome.scss
@@ -10,36 +10,22 @@
 
 .au-c-meeting {
   background-color: $au-gray-100;
+  display: flex;
+  flex-direction: row;
 }
 
 .au-c-meeting-chrome {
   padding: $au-unit $au-unit * 0.5;
-  width: 100%;
   position: relative;
-  overflow: visible;
+  overflow: scroll;
+
   z-index: 2;
-
-  @include mq(small) {
-    padding: $au-unit;
-  }
-
-  @include mq(1160px) {
-    left: $au-unit-huge * 3;
-    width: calc(100% - #{$au-unit-huge * 3});
-  }
-
-  @include mq(large) {
-    left: $au-unit-huge * 3.5;
-    width: calc(100% - #{$au-unit-huge * 3.5});
-    padding-right: $au-unit-huge * 4;
-  }
 }
 
 .au-c-meeting-chrome__paper {
   @include au-font-size($au-h6);
   position: relative;
   width: 100%;
-  min-height: calc(100vh + #{$au-unit});
   background-color: $au-white;
   padding: $au-unit-large;
   box-shadow:
@@ -50,6 +36,14 @@
 
   &:focus {
     outline: none;
+  }
+
+  @include mq(small) {
+    width: 100%;
+  }
+
+  @include mq(large) {
+    width: 75%;
   }
 }
 
@@ -346,17 +340,16 @@
 
 .au-c-meeting-sidebar {
   @include au-font-size($au-h6);
+  flex-shrink: 0;
   opacity: 0.7;
-  position: fixed;
-  top: $au-unit-huge;
   left: 0;
   bottom: 0;
   padding-top: $au-unit;
   padding-left: $au-unit-small;
-  padding-right: $au-unit-small;
+  padding-right: $au-unit;
   transition: opacity $au-transition;
   display: none;
-  overflow: auto;
+  overflow: scroll;
 
   @include mq(1160px) {
     display: block;


### PR DESCRIPTION
### Overview
This PR slightly modernizes the meeting page css by moving to a flex-based layout.
In terms of UX/UI the behaviour should have stayed more-or-less the same.

##### connected issues and PRs:
None

### Setup
None

### How to test/reproduce
- Login as a municipality and open/create a meeting
- Both the behaviour of the sidebar and main content should have stayed the same:
  * Both containers scroll independently
  * Paddings have remained the same/similar
  * The page is still more-or-less responsive: the sidebar disappears when reducing the width of the page + the main section takes full width

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
