### PR TITLE
update the date time picker to use the au time picker

### DIFF
--- a/.changeset/two-walls-move.md
+++ b/.changeset/two-walls-move.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Update the date time picker to use the au time picker

--- a/app/components/date-time-picker.hbs
+++ b/app/components/date-time-picker.hbs
@@ -11,30 +11,16 @@
       />
     {{/let}}
   </div>
-  <div class='au-o-grid__item au-u-1-5 au-u-1-6@small'>
-    {{#let (unique-id) as |id|}}
-      <AuLabel for={{id}}>{{t 'date-time-picker.hours'}}</AuLabel>
-      <Input
-        class='au-c-input au-c-input--block'
-        @type='number'
-        {{on 'input' (fn this.onChangeTime 'hours')}}
-        @value={{this.hours}}
-        max={{24}}
-        id={{id}}
-      />
-    {{/let}}
-  </div>
-  <div class='au-o-grid__item au-u-1-5 au-u-1-6@small'>
-    {{#let (unique-id) as |id|}}
-      <AuLabel for={{id}}>{{t 'date-time-picker.minutes'}}</AuLabel>
-      <Input
-        class='au-c-input au-c-input--block'
-        @type='number'
-        {{on 'input' (fn this.onChangeTime 'minutes')}}
-        @value={{this.minutes}}
-        max={{60}}
-        id={{id}}
-      />
-    {{/let}}
+  <div class='au-o-grid__item au-u-2-5 au-u-2-6@small'>
+    <AuTimePicker
+      @hoursLabel={{t 'date-time-picker.hours'}}
+      @minutesLabel={{t 'date-time-picker.minutes'}}
+      @nowLabel={{t 'date-plugin.card.now'}}
+      @hours={{this.hours}}
+      @minutes={{this.minutes}}
+      @showSeconds={{false}}
+      @showNow={{false}}
+      @onChange={{this.onChangeTime}}
+    />
   </div>
 </div>

--- a/app/components/date-time-picker.js
+++ b/app/components/date-time-picker.js
@@ -49,18 +49,11 @@ export default class DateTimePicker extends Component {
   }
 
   @action
-  onChangeTime(type, event) {
-    const value = event.target.value;
-    if (!this.date) {
-      this.date = new Date();
-    }
-    if (type === 'hours') {
-      if (value < 0 || value > 24) return;
-      this.date.setHours(value);
-    } else {
-      if (value < 0 || value > 60) return;
-      this.date.setMinutes(value);
-    }
+  onChangeTime(timeObject) {
+    if (!this.date) this.date = new Date();
+    this.date.setHours(timeObject.hours);
+    this.date.setMinutes(timeObject.minutes);
+    this.date.setSeconds(timeObject.seconds);
     this.args.onChange(this.date);
   }
 }


### PR DESCRIPTION
### Overview
Use the au time picker instead of manual implementation of the same behaviour.

##### connected issues and PRs:
Solves GN-5280


### Setup
None

### How to test/reproduce
Create a new meeting and check the time picker works as expected

### Challenges/uncertainties
The UI changes a little bit



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
