### PR TITLE
Feat/wrap dowloaded docs for utf8

### DIFF
--- a/.changeset/serious-moons-sleep.md
+++ b/.changeset/serious-moons-sleep.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Wrap downloaded docs for correct uf8

--- a/app/components/download-meeting-part.gjs
+++ b/app/components/download-meeting-part.gjs
@@ -5,8 +5,9 @@ import { on } from '@ember/modifier';
 import { task } from 'ember-concurrency';
 import perform from 'ember-concurrency/helpers/perform';
 import { generateExportTextFromEditorDocument } from 'frontend-gelinkt-notuleren/utils/generate-export-from-editor-document';
+import { wrapDownloadedDocument } from 'frontend-gelinkt-notuleren/utils/wrap-downloaded-document';
 
-export default class DownloadMeetingComponent extends Component {
+export default class DownloadMeetingPartComponent extends Component {
   @service publish;
   @service intl;
 
@@ -14,7 +15,7 @@ export default class DownloadMeetingComponent extends Component {
     return this.args.buttonSkin || 'link';
   }
   get icon() {
-    return this.downloadMeeting.last?.isSuccessful
+    return this.downloadMeetingPart.last?.isSuccessful
       ? 'circle-check'
       : this.args.icon;
   }
@@ -29,7 +30,7 @@ export default class DownloadMeetingComponent extends Component {
     );
   }
 
-  downloadMeeting = task(async () => {
+  downloadMeetingPart = task(async () => {
     let route = `/prepublish/${this.args.documentType}`;
     let html;
     switch (this.args.documentType) {
@@ -59,7 +60,9 @@ export default class DownloadMeetingComponent extends Component {
     if (this.args.callback) {
       return this.args.callback(html);
     } else {
-      const file = new Blob([html], { type: 'text/html' });
+      const file = new Blob([wrapDownloadedDocument(html)], {
+        type: 'text/html',
+      });
       const linkElement = document.createElement('a');
       linkElement.href = URL.createObjectURL(file);
       linkElement.download = `${this.args.documentType}.html`;
@@ -109,15 +112,15 @@ export default class DownloadMeetingComponent extends Component {
     <AuButton
       @skin={{this.buttonSkin}}
       @icon={{this.icon}}
-      @loading={{this.downloadMeeting.isRunning}}
+      @loading={{this.downloadMeetingPart.isRunning}}
       @loadingMessage={{this.loadingText}}
       class={{if
-        this.downloadMeeting.last.isSuccessful
+        this.downloadMeetingPart.last.isSuccessful
         'download-meeting-part-downloaded'
       }}
-      {{on 'click' (perform this.downloadMeeting)}}
+      {{on 'click' (perform this.downloadMeetingPart)}}
     >
-      {{#if this.downloadMeeting.last.isSuccessful}}
+      {{#if this.downloadMeetingPart.last.isSuccessful}}
         {{this.completedText}}
       {{else}}
         {{this.buttonText}}

--- a/app/controllers/meetings/download/index.js
+++ b/app/controllers/meetings/download/index.js
@@ -4,6 +4,7 @@ import { restartableTask, task } from 'ember-concurrency';
 import { trackedTask } from 'reactiveweb/ember-concurrency';
 import InstallatieVergaderingModel from 'frontend-gelinkt-notuleren/models/installatievergadering';
 import { service } from '@ember/service';
+import { wrapDownloadedDocument } from '../../../utils/wrap-downloaded-document';
 
 export default class MeetingsDownloadController extends Controller {
   @service publish;
@@ -53,7 +54,9 @@ export default class MeetingsDownloadController extends Controller {
   });
 
   downloadHtml(html, documentName) {
-    const file = new Blob([html], { type: 'text/html' });
+    const file = new Blob([wrapDownloadedDocument(html)], {
+      type: 'text/html',
+    });
     const linkElement = document.createElement('a');
     linkElement.href = URL.createObjectURL(file);
     linkElement.download = `${documentName}.html`;

--- a/app/utils/wrap-downloaded-document.js
+++ b/app/utils/wrap-downloaded-document.js
@@ -1,0 +1,13 @@
+export function wrapDownloadedDocument(html) {
+  const document = `
+      <html>
+        <head>
+          <meta charset="utf-8" />
+        </head>
+        <body>
+          ${html}
+        </body>
+      </html>
+  `;
+  return document;
+}

--- a/app/utils/wrap-downloaded-document.js
+++ b/app/utils/wrap-downloaded-document.js
@@ -1,5 +1,6 @@
 export function wrapDownloadedDocument(html) {
   const document = `
+      <!doctype html>
       <html>
         <head>
           <meta charset="utf-8" />


### PR DESCRIPTION
### Overview
Wrap the downloaded docs in correct html so we can specify in the head that is utf-8

##### connected issues and PRs:
Solved GN-5286


### Setup
None

### How to test/reproduce
Hard to reproduce but if you go to a prod copy of the Gemeente Oostkamp and try to download the agendapoint 1 of their IV the name should of the Tjörven mandatee should be correct

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
