### PR TITLE
Sort mandatee tables by list results not candidate results

### DIFF
--- a/.changeset/quiet-phones-grow.md
+++ b/.changeset/quiet-phones-grow.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': minor
+---
+
+Use list-based election results to sort mandatee tables not candidate-based

--- a/app/config/mandatee-table-config.js
+++ b/app/config/mandatee-table-config.js
@@ -513,13 +513,8 @@ export const mandateeTableConfigIVGR = (meeting) => {
           ?lid a person:Person.
           ?mandataris mandaat:isBestuurlijkeAliasVan ?lid.
 
-          <${bestuurseenheid.uri}> skos:prefLabel ?_bestuurseenheid_naam.
-          ?fractie ext:geproduceerdDoor/skos:prefLabel ?_lijst.
+          ?fractie ext:geproduceerdDoor/ext:matched_stemmen ?fractie_stemmen.
 
-          ?_kieslijst_result a ext:KieslijstResult;
-                ext:kieskring ?_bestuurseenheid_naam;
-                ext:lijst ?_lijst;
-                ext:stemcijfer ?fractie_stemmen.
         }
         ORDER BY DESC(?fractie_aantal_zetels) DESC(?fractie_stemmen) ?fractie
       `;

--- a/app/config/mandatee-table-config.js
+++ b/app/config/mandatee-table-config.js
@@ -64,6 +64,8 @@ export const mandateeTableConfigIVGR = (meeting) => {
         PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
         PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
         PREFIX regorg: <https://www.w3.org/ns/regorg#>
+        PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+        PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 
         SELECT DISTINCT ?persoon ?persoon_naam WHERE {
           ?persoon a person:Person .
@@ -71,8 +73,9 @@ export const mandateeTableConfigIVGR = (meeting) => {
           ?persoon foaf:familyName ?achternaam.
           BIND(CONCAT(?voornaam, " ", ?achternaam) AS ?persoon_naam)
 
-          ?mandataris a mandaat:Mandataris.
           ?mandataris mandaat:isBestuurlijkeAliasVan ?persoon.
+          ?mandataris a mandaat:Mandataris.
+          ?mandataris org:hasMembership/org:organisation ?fractie.
           ?mandataris org:holds ?mandaat.
 
           ?mandaat org:role <${BESTUURSFUNCTIE_CODES.GEMEENTERAADSLID}>.
@@ -80,15 +83,15 @@ export const mandateeTableConfigIVGR = (meeting) => {
           ?bestuursorgaanIT org:hasPost ?mandaat.
           ?bestuursorgaanIT lmb:heeftBestuursperiode <${BESTUURSPERIODES['2024-heden']}>.
           ?bestuursorgaanIT mandaat:isTijdspecialisatieVan ?bestuursorgaan.
+          ?bestuursorgaan besluit:bestuurt <${bestuurseenheid.uri}>.
           ?bestuursorgaan besluit:classificatie ?classificatie.
           VALUES ?classificatie {
             <${BESTUURSORGAAN_CLASSIFICATIE_CODES.GEMEENTERAAD}>
           }
-          ?bestuursorgaan besluit:bestuurt <${bestuurseenheid.uri}>.
 
-          ?mandataris org:hasMembership/org:organisation ?fractie.
 
           ${fractieOrderingSubquery(
+            bestuurseenheid.uri,
             BESTUURSFUNCTIE_CODES.GEMEENTERAADSLID,
             BESTUURSPERIODES['2024-heden'],
           )}
@@ -154,6 +157,7 @@ export const mandateeTableConfigIVGR = (meeting) => {
         PREFIX foaf: <http://xmlns.com/foaf/0.1/>
         PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
         PREFIX regorg: <https://www.w3.org/ns/regorg#>
+        PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 
         SELECT DISTINCT ?mandataris ?mandataris_naam WHERE {
           ?mandaat org:role <${BESTUURSFUNCTIE_CODES.GEMEENTERAADSLID}>.
@@ -179,6 +183,7 @@ export const mandateeTableConfigIVGR = (meeting) => {
           ?mandataris org:hasMembership/org:organisation ?fractie.
 
           ${fractieOrderingSubquery(
+            bestuurseenheid.uri,
             BESTUURSFUNCTIE_CODES.GEMEENTERAADSLID,
             BESTUURSPERIODES['2024-heden'],
           )}
@@ -484,6 +489,7 @@ export const mandateeTableConfigIVGR = (meeting) => {
         PREFIX foaf: <http://xmlns.com/foaf/0.1/>
         PREFIX regorg: <https://www.w3.org/ns/regorg#>
         PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+        PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 
         SELECT DISTINCT ?fractie ?fractie_naam (COUNT(DISTINCT ?lid) as ?fractie_aantal_zetels) WHERE {
           ?fractie a mandaat:Fractie.
@@ -507,12 +513,15 @@ export const mandateeTableConfigIVGR = (meeting) => {
           ?lid a person:Person.
           ?mandataris mandaat:isBestuurlijkeAliasVan ?lid.
 
-          ?verkiezing mandaat:steltSamen ?bestuursorgaanIT.
-          ?verkiezingsresultaat mandaat:isResultaatVoor/mandaat:behoortTot ?verkiezing.
-          ?verkiezingsresultaat mandaat:isResultaatVan ?lid.
-          ?verkiezingsresultaat mandaat:aantalNaamstemmen ?aantal_stemmen.
+          <${bestuurseenheid.uri}> skos:prefLabel ?_bestuurseenheid_naam.
+          ?fractie ext:geproduceerdDoor/skos:prefLabel ?_lijst.
+
+          ?_kieslijst_result a ext:KieslijstResult;
+                ext:kieskring ?_bestuurseenheid_naam;
+                ext:lijst ?_lijst;
+                ext:stemcijfer ?fractie_stemmen.
         }
-        ORDER BY DESC(?fractie_aantal_zetels) DESC(SUM(?aantal_stemmen)) ?fractie
+        ORDER BY DESC(?fractie_aantal_zetels) DESC(?fractie_stemmen) ?fractie
       `;
         return executeQuery({
           query: sparqlQuery,
@@ -572,6 +581,7 @@ export const mandateeTableConfigIVGR = (meeting) => {
         PREFIX regorg: <https://www.w3.org/ns/regorg#>
         PREFIX person: <http://www.w3.org/ns/person#>
         PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+        PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 
         SELECT DISTINCT ?persoon ?persoon_naam ?fractie ?fractie_naam WHERE {
           ?persoon a person:Person.
@@ -596,6 +606,7 @@ export const mandateeTableConfigIVGR = (meeting) => {
           ?bestuursorgaan besluit:bestuurt <${bestuurseenheid.uri}>.
 
           ${fractieOrderingSubquery(
+            bestuurseenheid.uri,
             BESTUURSFUNCTIE_CODES.GEMEENTERAADSLID,
             BESTUURSPERIODES['2024-heden'],
           )}
@@ -1336,6 +1347,7 @@ export const mandateeTableConfigRMW = (meeting) => {
             ?bestuursorgaan besluit:bestuurt <${bestuurseenheid.uri}>.
 
             ${fractieOrderingSubquery(
+              bestuurseenheid.uri,
               BESTUURSFUNCTIE_CODES.LID_BCSD,
               BESTUURSPERIODES['2024-heden'],
               true,
@@ -1439,6 +1451,7 @@ export const mandateeTableConfigRMW = (meeting) => {
             ?bestuursorgaan besluit:bestuurt <${bestuurseenheid.uri}>.
 
             ${fractieOrderingSubquery(
+              bestuurseenheid.uri,
               BESTUURSFUNCTIE_CODES.LID_BCSD,
               BESTUURSPERIODES['2024-heden'],
               true,
@@ -1531,6 +1544,7 @@ export const mandateeTableConfigRMW = (meeting) => {
             ?bestuursorgaan besluit:bestuurt <${bestuurseenheid.uri}>.
 
             ${fractieOrderingSubquery(
+              bestuurseenheid.uri,
               BESTUURSFUNCTIE_CODES.LID_BCSD,
               BESTUURSPERIODES['2024-heden'],
               true,
@@ -1618,6 +1632,7 @@ export const mandateeTableConfigRMW = (meeting) => {
             ?bestuursorgaan besluit:bestuurt <${bestuurseenheid.uri}>.
 
             ${fractieOrderingSubquery(
+              bestuurseenheid.uri,
               BESTUURSFUNCTIE_CODES.LID_BCSD,
               BESTUURSPERIODES['2024-heden'],
               true,

--- a/app/config/mandatee-table-query-fragments.js
+++ b/app/config/mandatee-table-query-fragments.js
@@ -27,14 +27,7 @@ export const fractieOrderingSubquery = (
     ${
       ignoreVotes
         ? ''
-        : `
-    <${bestuurseenheid}> skos:prefLabel ?_bestuurseenheid_naam.
-    ?fractie ext:geproduceerdDoor/skos:prefLabel ?_lijst.
-
-    ?_kieslijst_result a ext:KieslijstResult;
-          ext:kieskring ?_bestuurseenheid_naam;
-          ext:lijst ?_lijst;
-          ext:stemcijfer ?fractie_stemmen.`
+        : `?fractie ext:geproduceerdDoor/ext:matched_stemmen ?fractie_stemmen.`
     }
   }
 }`;

--- a/app/config/mandatee-table-query-fragments.js
+++ b/app/config/mandatee-table-query-fragments.js
@@ -1,5 +1,10 @@
-export const fractieOrderingSubquery = (role, period, ignoreVotes) => `{
-  SELECT ?fractie ?fractie_naam (COUNT(DISTINCT ?_persoon) AS ?fractie_grootte) (SUM(?_aantal_stemmen) AS ?fractie_stemmen)
+export const fractieOrderingSubquery = (
+  bestuurseenheid,
+  role,
+  period,
+  ignoreVotes,
+) => `{
+  SELECT ?fractie ?fractie_naam (COUNT(DISTINCT ?_persoon) AS ?fractie_grootte) ?fractie_stemmen
   WHERE {
     ?_mandataris a mandaat:Mandataris.
     ?_mandataris org:hasMembership/org:organisation ?fractie.
@@ -13,6 +18,9 @@ export const fractieOrderingSubquery = (role, period, ignoreVotes) => `{
     ?_bestuursorgaanIT org:hasPost ?_mandaat.
     ?_bestuursorgaanIT lmb:heeftBestuursperiode <${period}>.
 
+    ?_bestuursorgaanIT mandaat:isTijdspecialisatieVan ?_bestuursorgaan.
+    ?_bestuursorgaan besluit:bestuurt <${bestuurseenheid}>.
+
     ?_persoon a person:Person.
     ?_mandataris mandaat:isBestuurlijkeAliasVan ?_persoon.
 
@@ -20,10 +28,13 @@ export const fractieOrderingSubquery = (role, period, ignoreVotes) => `{
       ignoreVotes
         ? ''
         : `
-    ?_verkiezing mandaat:steltSamen ?_bestuursorgaanIT.
-    ?_verkiezingsresultaat mandaat:isResultaatVoor/mandaat:behoortTot ?_verkiezing.
-    ?_verkiezingsresultaat mandaat:isResultaatVan ?_persoon.
-    ?_verkiezingsresultaat mandaat:aantalNaamstemmen ?_aantal_stemmen.`
+    <${bestuurseenheid}> skos:prefLabel ?_bestuurseenheid_naam.
+    ?fractie ext:geproduceerdDoor/skos:prefLabel ?_lijst.
+
+    ?_kieslijst_result a ext:KieslijstResult;
+          ext:kieskring ?_bestuurseenheid_naam;
+          ext:lijst ?_lijst;
+          ext:stemcijfer ?fractie_stemmen.`
     }
   }
 }`;


### PR DESCRIPTION
### Overview
Uses the new hack of throwing the right election results into the db...

##### connected issues and PRs:
Jira ticket: [binnenland.atlassian.net/browse/GN-5315](https://binnenland.atlassian.net/browse/GN-5315)
Corrects: https://github.com/lblod/frontend-gelinkt-notuleren/pull/784
Needs the migrations from: https://github.com/lblod/app-gelinkt-notuleren/pull/221

### Setup
Run pointing to a backend with the migrations.

### How to test/reproduce
Syncing an IV should produce the correct mandatee table sorting. It's especially useful to test for municipalities that have fractions with the same numbers of seats and those with lists made up of more than one fractie.

### Challenges/uncertainties
...

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [ ] npm lint
- [ ] no new deprecations
