### PR TITLE
GN-5323: include 'toegevoegde schepen' in IVGR8 mandatee table

### DIFF
--- a/.changeset/early-rings-hope.md
+++ b/.changeset/early-rings-hope.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Ensure mandatees with the 'Toegevoegde schepen' mandate are also shown in the 'Verkozen schepenen' table of IVGR8 (`IVGR8-LMB-1-verkozen-schepenen`)

--- a/app/config/constants.js
+++ b/app/config/constants.js
@@ -40,6 +40,8 @@ export const BESTUURSFUNCTIE_CODES = {
     'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000011',
   SCHEPEN:
     'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000014',
+  TOEGEVOEGDE_SCHEPEN:
+    'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/59a90e03-4f22-4bb9-8c91-132618db4b38',
   BURGEMEESTER:
     'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000011',
   VOORZITTER_GEMEENTERAAD:

--- a/app/config/mandatee-table-config.js
+++ b/app/config/mandatee-table-config.js
@@ -981,7 +981,11 @@ export const mandateeTableConfigIVGR = (meeting) => {
         PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
 
         SELECT DISTINCT ?mandataris ?mandataris_naam ?fractie ?fractie_naam WHERE {
-          ?mandaat org:role <${BESTUURSFUNCTIE_CODES.SCHEPEN}>.
+          ?mandaat org:role ?role.
+          VALUES ?role {
+            <${BESTUURSFUNCTIE_CODES.SCHEPEN}>
+            <${BESTUURSFUNCTIE_CODES.TOEGEVOEGDE_SCHEPEN}>
+          }
 
           ?bestuursorgaanIT org:hasPost ?mandaat.
           ?bestuursorgaanIT lmb:heeftBestuursperiode <${BESTUURSPERIODES['2024-heden']}>.
@@ -1081,6 +1085,7 @@ export const mandateeTableConfigIVGR = (meeting) => {
           ?mandaat org:role ?role.
           VALUES ?role {
             <${BESTUURSFUNCTIE_CODES.SCHEPEN}>
+            <${BESTUURSFUNCTIE_CODES.TOEGEVOEGDE_SCHEPEN}>
           }
 
           ?bestuursorgaanIT org:hasPost ?mandaat.


### PR DESCRIPTION
### Overview
This PR ensures that we include people with the 'Toegevoegde schepen' mandate in the 'Verkozen schepenen' table of IVGR8 (`IVGR8-LMB-1-verkozen-schepenen`)

##### connected issues and PRs:
[GN-5323](https://binnenland.atlassian.net/browse/GN-5323)

### How to test/reproduce
- Start the frontend
- Login as a municipality which contains a 'Toegevoegde schepen' in LMB
- Create/open an IV
- Sync the meeting
- In AP7: the 'toegevoegde schepen' should not be included in the tables (they are not known yet by that time)
- In AP8: the 'toegevoegde schepen' should be included in the table

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
