### PR TITLE
Bugfix/autofill variable bug

### DIFF
--- a/.changeset/flat-tomatoes-develop.md
+++ b/.changeset/flat-tomatoes-develop.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Wait until everything has loaded to setup plugins, schema and nodeviews

--- a/app/controllers/agendapoints/edit.js
+++ b/app/controllers/agendapoints/edit.js
@@ -31,7 +31,6 @@ export default class AgendapointsEditController extends Controller {
   @tracked schema;
   @tracked plugins;
   @tracked editorSetup = false;
-  @tracked citationPlugin;
 
   StructureControlCard = StructureControlCardComponent;
   InsertArticle = InsertArticleComponent;
@@ -94,11 +93,8 @@ export default class AgendapointsEditController extends Controller {
     const { schema, plugins } =
       this.agendapointEditor.getSchemaAndPlugins(false);
     this.schema = schema;
-    const citationPlugin = this.agendapointEditor.citationPlugin;
-    this.plugins = [...plugins, citationPlugin];
-    this.citationPlugin = citationPlugin;
+    this.plugins = plugins;
     this.editorSetup = true;
-    console.log('setting up');
     return () => {
       this.editorSetup = false;
     };

--- a/app/controllers/agendapoints/edit.js
+++ b/app/controllers/agendapoints/edit.js
@@ -49,11 +49,11 @@ export default class AgendapointsEditController extends Controller {
   }
 
   get schema() {
-    return this.agendapointEditor.schema;
+    return this.agendapointEditor.getSchemaAndPlugins(false).schema;
   }
 
   get plugins() {
-    return this.agendapointEditor.getPlugins(false);
+    return this.agendapointEditor.getSchemaAndPlugins(false).plugins;
   }
 
   get dirty() {

--- a/app/controllers/agendapoints/edit.js
+++ b/app/controllers/agendapoints/edit.js
@@ -93,7 +93,7 @@ export default class AgendapointsEditController extends Controller {
     return '';
   }
 
-  setSchemaAndPlugins = modifier((element) => {
+  setSchemaAndPlugins = modifier(() => {
     const { schema, plugins } =
       this.agendapointEditor.getSchemaAndPlugins(false);
     this.schema = schema;

--- a/app/controllers/agendapoints/edit.js
+++ b/app/controllers/agendapoints/edit.js
@@ -49,11 +49,11 @@ export default class AgendapointsEditController extends Controller {
   }
 
   get schema() {
-    return this.agendapointEditor.getSchemaAndPlugins(false).schema;
+    return this.agendapointEditor.schema;
   }
 
   get plugins() {
-    return this.agendapointEditor.getSchemaAndPlugins(false).plugins;
+    return this.agendapointEditor.getPlugins(false);
   }
 
   get dirty() {

--- a/app/controllers/agendapoints/edit.js
+++ b/app/controllers/agendapoints/edit.js
@@ -93,6 +93,7 @@ export default class AgendapointsEditController extends Controller {
     if (this.copyAgendapunt.isRunning) {
       return this.intl.t('rdfa-editor-container.saving');
     }
+    return '';
   }
 
   @action

--- a/app/controllers/agendapoints/edit.js
+++ b/app/controllers/agendapoints/edit.js
@@ -36,10 +36,6 @@ export default class AgendapointsEditController extends Controller {
 
   SnippetInsert = SnippetInsertRdfaComponent;
 
-  constructor(...args) {
-    super(...args);
-  }
-
   get config() {
     return this.agendapointEditor.config;
   }

--- a/app/controllers/agendapoints/edit.js
+++ b/app/controllers/agendapoints/edit.js
@@ -13,6 +13,7 @@ import { getActiveEditableNode } from '@lblod/ember-rdfa-editor/plugins/_private
 
 import SnippetInsertRdfaComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/snippet-plugin/snippet-insert-rdfa';
 import { fixArticleConnections } from '../../utils/fix-article-connections';
+import { modifier } from 'ember-modifier';
 
 export default class AgendapointsEditController extends Controller {
   @service store;
@@ -92,16 +93,17 @@ export default class AgendapointsEditController extends Controller {
     return '';
   }
 
-  @action
-  setSchemaAndPlugins() {
-    if (!this.editorSetup) {
-      const { schema, plugins } =
-        this.agendapointEditor.getSchemaAndPlugins(false);
-      this.schema = schema;
-      this.plugins = plugins;
-      this.editorSetup = true;
-    }
-  }
+  setSchemaAndPlugins = modifier((element) => {
+    const { schema, plugins } =
+      this.agendapointEditor.getSchemaAndPlugins(false);
+    this.schema = schema;
+    this.plugins = plugins;
+    this.editorSetup = true;
+    console.log('setting up');
+    return () => {
+      this.editorSetup = false;
+    };
+  });
 
   @action
   async handleRdfaEditorInit(editor) {

--- a/app/controllers/agendapoints/edit.js
+++ b/app/controllers/agendapoints/edit.js
@@ -31,6 +31,7 @@ export default class AgendapointsEditController extends Controller {
   @tracked schema;
   @tracked plugins;
   @tracked editorSetup = false;
+  @tracked citationPlugin;
 
   StructureControlCard = StructureControlCardComponent;
   InsertArticle = InsertArticleComponent;
@@ -43,10 +44,6 @@ export default class AgendapointsEditController extends Controller {
 
   get nodeViews() {
     return this.agendapointEditor.nodeViews;
-  }
-
-  get citationPlugin() {
-    return this.agendapointEditor.citationPlugin;
   }
 
   get dirty() {
@@ -97,7 +94,9 @@ export default class AgendapointsEditController extends Controller {
     const { schema, plugins } =
       this.agendapointEditor.getSchemaAndPlugins(false);
     this.schema = schema;
-    this.plugins = plugins;
+    const citationPlugin = this.agendapointEditor.citationPlugin;
+    this.plugins = [...plugins, citationPlugin];
+    this.citationPlugin = citationPlugin;
     this.editorSetup = true;
     console.log('setting up');
     return () => {

--- a/app/controllers/agendapoints/edit.js
+++ b/app/controllers/agendapoints/edit.js
@@ -18,6 +18,7 @@ export default class AgendapointsEditController extends Controller {
   @service store;
   @service router;
   @service documentService;
+  @service intl;
 
   @service('editor/agendapoint') agendapointEditor;
 
@@ -26,6 +27,9 @@ export default class AgendapointsEditController extends Controller {
   @tracked _editorDocument;
   @tracked controller;
   @service features;
+  @tracked schema;
+  @tracked plugins;
+  @tracked editorSetup = false;
 
   StructureControlCard = StructureControlCardComponent;
   InsertArticle = InsertArticleComponent;
@@ -46,14 +50,6 @@ export default class AgendapointsEditController extends Controller {
 
   get citationPlugin() {
     return this.agendapointEditor.citationPlugin;
-  }
-
-  get schema() {
-    return this.agendapointEditor.getSchemaAndPlugins(false).schema;
-  }
-
-  get plugins() {
-    return this.agendapointEditor.getSchemaAndPlugins(false).plugins;
   }
 
   get dirty() {
@@ -77,6 +73,37 @@ export default class AgendapointsEditController extends Controller {
       return getActiveEditableNode(this.controller.activeEditorState);
     }
     return null;
+  }
+
+  get isBusy() {
+    return (
+      !this.editorSetup ||
+      this.saveTask.isRunning ||
+      this.copyAgendapunt.isRunning
+    );
+  }
+
+  get busyText() {
+    if (!this.editorSetup) {
+      return this.intl.t('rdfa-editor-container.loading');
+    }
+    if (this.saveTask.isRunning) {
+      return this.intl.t('rdfa-editor-container.making-copy');
+    }
+    if (this.copyAgendapunt.isRunning) {
+      return this.intl.t('rdfa-editor-container.saving');
+    }
+  }
+
+  @action
+  setSchemaAndPlugins() {
+    if (!this.editorSetup) {
+      const { schema, plugins } =
+        this.agendapointEditor.getSchemaAndPlugins(false);
+      this.schema = schema;
+      this.plugins = plugins;
+      this.editorSetup = true;
+    }
   }
 
   @action

--- a/app/controllers/agendapoints/edit.js
+++ b/app/controllers/agendapoints/edit.js
@@ -32,18 +32,28 @@ export default class AgendapointsEditController extends Controller {
 
   SnippetInsert = SnippetInsertRdfaComponent;
 
-  config = this.agendapointEditor.config;
-
-  nodeViews = this.agendapointEditor.nodeViews;
-
-  citationPlugin = this.agendapointEditor.citationPlugin;
-
   constructor(...args) {
     super(...args);
-    const { schema, plugins } =
-      this.agendapointEditor.getSchemaAndPlugins(false);
-    this.schema = schema;
-    this.plugins = plugins;
+  }
+
+  get config() {
+    return this.agendapointEditor.config;
+  }
+
+  get nodeViews() {
+    return this.agendapointEditor.nodeViews;
+  }
+
+  get citationPlugin() {
+    return this.agendapointEditor.citationPlugin;
+  }
+
+  get schema() {
+    return this.agendapointEditor.getSchemaAndPlugins(false).schema;
+  }
+
+  get plugins() {
+    return this.agendapointEditor.getSchemaAndPlugins(false).plugins;
   }
 
   get dirty() {

--- a/app/services/editor/agendapoint.js
+++ b/app/services/editor/agendapoint.js
@@ -3,7 +3,6 @@ import { v4 as uuidv4 } from 'uuid';
 import { removePropertiesOfDeletedNodes } from '@lblod/ember-rdfa-editor/plugins/remove-properties-of-deleted-nodes';
 import { defaultAttributeValueGeneration } from '@lblod/ember-rdfa-editor/plugins/default-attribute-value-generation';
 import { rdfaInfoPlugin } from '@lblod/ember-rdfa-editor/plugins/rdfa-info';
-import { tracked } from '@glimmer/tracking';
 
 import { Schema } from '@lblod/ember-rdfa-editor';
 import {
@@ -127,7 +126,9 @@ export default class AgendapointEditorService extends Service {
   @service intl;
   @service currentSession;
 
-  @tracked citationPlugin;
+  get citationPlugin() {
+    return citationPlugin(this.config.citation);
+  }
   get config() {
     const classificatie = this.currentSession.classificatie;
     const municipality = this.currentSession.group;
@@ -334,8 +335,6 @@ export default class AgendapointEditorService extends Service {
         color,
       },
     });
-
-    this.citationPlugin = citationPlugin(this.config.citation);
 
     const plugins = [
       ...tablePlugins,

--- a/app/services/editor/agendapoint.js
+++ b/app/services/editor/agendapoint.js
@@ -126,8 +126,9 @@ export default class AgendapointEditorService extends Service {
   @service intl;
   @service currentSession;
 
-  citationPlugin = citationPlugin(this.config.citation);
-
+  get citationPlugin() {
+    return citationPlugin(this.config.citation);
+  }
   get config() {
     const classificatie = this.currentSession.classificatie;
     const municipality = this.defaultMunicipality;

--- a/app/services/editor/agendapoint.js
+++ b/app/services/editor/agendapoint.js
@@ -126,9 +126,6 @@ export default class AgendapointEditorService extends Service {
   @service intl;
   @service currentSession;
 
-  get citationPlugin() {
-    return citationPlugin(this.config.citation);
-  }
   get config() {
     const classificatie = this.currentSession.classificatie;
     const municipality = this.currentSession.group;
@@ -339,7 +336,7 @@ export default class AgendapointEditorService extends Service {
     const plugins = [
       ...tablePlugins,
       tableKeymap,
-      this.citationPlugin,
+      citationPlugin(this.config.citation),
       createInvisiblesPlugin(
         [hardBreak, paragraphInvisible, headingInvisible],
         {

--- a/app/services/editor/agendapoint.js
+++ b/app/services/editor/agendapoint.js
@@ -131,7 +131,7 @@ export default class AgendapointEditorService extends Service {
   }
   get config() {
     const classificatie = this.currentSession.classificatie;
-    const municipality = this.defaultMunicipality;
+    const municipality = this.currentSession.group;
     return {
       date: {
         formats: [
@@ -281,13 +281,8 @@ export default class AgendapointEditorService extends Service {
     };
   }
 
-  /**
-   * Get the schema and plugins for the editor.
-   * @param {boolean} isHeadless - Whether this is for a headless editor, as this requires
-   * different config to work correctly
-   **/
-  getSchemaAndPlugins(isHeadless) {
-    const schema = new Schema({
+  get schema() {
+    return new Schema({
       nodes: {
         doc: docWithConfig({ rdfaAware: true }),
         paragraph,
@@ -335,7 +330,14 @@ export default class AgendapointEditorService extends Service {
         color,
       },
     });
+  }
 
+  /**
+   * Get the plugins for the editor.
+   * @param {boolean} isHeadless - Whether this is for a headless editor, as this requires
+   * different config to work correctly
+   **/
+  getPlugins(isHeadless) {
     const plugins = [
       ...tablePlugins,
       tableKeymap,
@@ -346,7 +348,7 @@ export default class AgendapointEditorService extends Service {
           shouldShowInvisibles: false,
         },
       ),
-      linkPasteHandler(schema.nodes.link),
+      linkPasteHandler(this.schema.nodes.link),
       listTrackingPlugin(),
 
       emberApplication({ application: getOwner(this) }),
@@ -358,12 +360,12 @@ export default class AgendapointEditorService extends Service {
     if (!isHeadless) {
       plugins.push(variableAutofillerPlugin(this.config.autofilledVariable));
     }
-
-    return { schema, plugins };
+    return plugins;
   }
 
   getState = (html) => {
-    const { schema, plugins } = this.getSchemaAndPlugins(true);
+    const schema = this.schema;
+    const plugins = this.getPlugins(true);
     const parser = ProseParser.fromSchema(schema);
     const doc = htmlToDoc(html, {
       schema: schema,

--- a/app/services/editor/agendapoint.js
+++ b/app/services/editor/agendapoint.js
@@ -131,7 +131,7 @@ export default class AgendapointEditorService extends Service {
   }
   get config() {
     const classificatie = this.currentSession.classificatie;
-    const municipality = this.defaultMunicipality;
+    const municipality = this.currentSession.group;
     return {
       date: {
         formats: [

--- a/app/services/editor/agendapoint.js
+++ b/app/services/editor/agendapoint.js
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { removePropertiesOfDeletedNodes } from '@lblod/ember-rdfa-editor/plugins/remove-properties-of-deleted-nodes';
 import { defaultAttributeValueGeneration } from '@lblod/ember-rdfa-editor/plugins/default-attribute-value-generation';
 import { rdfaInfoPlugin } from '@lblod/ember-rdfa-editor/plugins/rdfa-info';
+import { tracked } from '@glimmer/tracking';
 
 import { Schema } from '@lblod/ember-rdfa-editor';
 import {
@@ -126,9 +127,7 @@ export default class AgendapointEditorService extends Service {
   @service intl;
   @service currentSession;
 
-  get citationPlugin() {
-    return citationPlugin(this.config.citation);
-  }
+  @tracked citationPlugin;
   get config() {
     const classificatie = this.currentSession.classificatie;
     const municipality = this.currentSession.group;
@@ -335,6 +334,8 @@ export default class AgendapointEditorService extends Service {
         color,
       },
     });
+
+    this.citationPlugin = citationPlugin(this.config.citation);
 
     const plugins = [
       ...tablePlugins,

--- a/app/templates/agendapoints/edit.hbs
+++ b/app/templates/agendapoints/edit.hbs
@@ -86,18 +86,15 @@
   role='tabpanel'
   tabindex='0'
   aria-labelledby='tab-1'
+  {{did-insert this.setSchemaAndPlugins}}
 >
   <RdfaEditorContainer
     @rdfaEditorInit={{this.handleRdfaEditorInit}}
     @typeOfWrappingDiv='besluit:BehandelingVanAgendapunt'
     @showToggleRdfaAnnotations={{true}}
     @editorDocument={{this.editorDocument}}
-    @busy={{or this.saveTask.isRunning this.copyAgendapunt.isRunning}}
-    @busyText={{if
-      this.copyAgendapunt.isRunning
-      (t 'rdfa-editor-container.making-copy')
-      (t 'rdfa-editor-container.saving')
-    }}
+    @busy={{this.isBusy}}
+    @busyText={{this.busyText}}
     @schema={{this.schema}}
     @widgets={{this.widgets}}
     @nodeViews={{this.nodeViews}}

--- a/app/templates/agendapoints/edit.hbs
+++ b/app/templates/agendapoints/edit.hbs
@@ -86,7 +86,7 @@
   role='tabpanel'
   tabindex='0'
   aria-labelledby='tab-1'
-  {{did-insert this.setSchemaAndPlugins}}
+  {{this.setSchemaAndPlugins}}
 >
   <RdfaEditorContainer
     @rdfaEditorInit={{this.handleRdfaEditorInit}}

--- a/app/templates/agendapoints/edit.hbs
+++ b/app/templates/agendapoints/edit.hbs
@@ -121,7 +121,6 @@
       />
       <CitationPlugin::CitationInsert
         @controller={{this.controller}}
-        @plugin={{this.citationPlugin}}
         @config={{this.config.citation}}
       />
       <VariablePlugin::Date::Insert
@@ -178,7 +177,6 @@
       <DecisionPlugin::DecisionPluginCard @controller={{this.controller}} />
       <CitationPlugin::CitationCard
         @controller={{this.controller}}
-        @plugin={{this.citationPlugin}}
         @config={{this.config.citation}}
       />
       <ImportSnippetPlugin::Card @controller={{this.controller}} />

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -593,6 +593,7 @@ rdfa-editor-container:
   default-busy-text: Processing
   saving: Saving
   making-copy: Making copy
+  loading: Loading
 
 regulatory-statements-plugin:
   type: Regulatory Statement

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -597,6 +597,7 @@ rdfa-editor-container:
   default-busy-text: Bezig met verwerken
   saving: Bezig met opslaan
   making-copy: Kopie aan het maken
+  loading: Bezig met laden
 
 regulatory-statements-plugin:
   type: Reglementaire bijlage


### PR DESCRIPTION
### Overview
The autofill variable bug described in GN-5210 was caused by the agendapoints.edit controller setting the plugins before the route was loaded and the current session object was filled. I reworked that interaction so nothing is called until everything has loaded correctly

##### connected issues and PRs:
GN-5210


### Setup
None

### How to test/reproduce
You can try reproducing the bug, basically if you create an IV, go to the first agendapoint and in the besluit snippet list you selected one of the options with the autofill variable the first time it should work, but if you refresh and do the same again it didn't work.
Now it always work, as the autofill plugin is not set up until everything has been loaded

### Challenges/uncertainties
Not enough knowledge of the headless editor so I think I did everything correctly so that also works, but please Elena verify :)



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
