### PR TITLE
GN-5245: apply new template instantiate method on built-in standard templates

### DIFF
--- a/.changeset/strong-rats-shave.md
+++ b/.changeset/strong-rats-shave.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Apply new `instantiateUuids` method onto built-in standard templates

--- a/app/components/document-creator.js
+++ b/app/components/document-creator.js
@@ -103,7 +103,8 @@ export default class DocumentCreatorComponent extends Component {
         return templateUuidInstantiator(trimmedHtml);
       } else {
         const trimmedHtml = this.template.body.replace(/>\s+</g, '><');
-        return instantiateUuids(trimmedHtml);
+        // If it's a built=in template, we apply both instantiate functions
+        return instantiateUuids(templateUuidInstantiator(trimmedHtml));
       }
     } else return '';
   }


### PR DESCRIPTION
### Overview
This PR ensures that we also apply the new `instantiateUuids` method when instantiating the built-in standard templates.

This PR should be backwards compatible and should thus also work with current versions of the backend.

##### connected issues and PRs:
[GN-5245](https://binnenland.atlassian.net/browse/GN-5245)
To be tested in conjunction with https://github.com/lblod/app-gelinkt-notuleren/pull/223


### Setup
Check-out https://github.com/lblod/app-gelinkt-notuleren/pull/223

### How to test/reproduce
See https://github.com/lblod/app-gelinkt-notuleren/pull/223 for instructions on how to test

