### PR TITLE
Link locations to the surrounding document on insertion

### DIFF
--- a/.changeset/dirty-buses-kick.md
+++ b/.changeset/dirty-buses-kick.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': minor
+---
+
+Link locations to the surrounding article or decision on insertion

--- a/app/controllers/regulatory-statements/edit.js
+++ b/app/controllers/regulatory-statements/edit.js
@@ -110,6 +110,7 @@ import {
 
 import SnippetInsertRdfaComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/snippet-plugin/snippet-insert-rdfa';
 import { variableAutofillerPlugin } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/plugins/autofiller';
+import { SAY } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 
 export default class RegulatoryStatementsRoute extends Controller {
   @service documentService;
@@ -287,6 +288,12 @@ export default class RegulatoryStatementsRoute extends Controller {
           'https://publicatie.gelinkt-notuleren.vlaanderen.be/id/plaats/',
         defaultAddressUriRoot:
           'https://publicatie.gelinkt-notuleren.vlaanderen.be/id/adres/',
+        subjectTypesToLinkTo: [
+          SAY('Article'),
+          SAY('Subsection'),
+          SAY('Section'),
+          SAY('Chapter'),
+        ],
       },
       lmb: {
         endpoint: '/raw-sparql',

--- a/app/services/editor/agendapoint.js
+++ b/app/services/editor/agendapoint.js
@@ -198,6 +198,7 @@ export default class AgendapointEditorService extends Service {
           'https://publicatie.gelinkt-notuleren.vlaanderen.be/id/plaats/',
         defaultAddressUriRoot:
           'https://publicatie.gelinkt-notuleren.vlaanderen.be/id/adres/',
+        subjectTypesToLinkTo: [BESLUIT('Artikel'), BESLUIT('Besluit')],
       },
       lpdc: {
         endpoint: '/lpdc-service',

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@lblod/ember-environment-banner": "^0.5.0",
         "@lblod/ember-mock-login": "^0.10.0",
         "@lblod/ember-rdfa-editor": "10.9.0",
-        "@lblod/ember-rdfa-editor-lblod-plugins": "26.1.0-dev.05d24394216b47fd361f189d4ee4290599468733",
+        "@lblod/ember-rdfa-editor-lblod-plugins": "26.2.0",
         "@lblod/template-uuid-instantiator": "^1.0.3",
         "@release-it-plugins/lerna-changelog": "^6.0.0",
         "@tsconfig/ember": "^3.0.8",
@@ -7571,9 +7571,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor-lblod-plugins": {
-      "version": "26.1.0-dev.05d24394216b47fd361f189d4ee4290599468733",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-26.1.0-dev.05d24394216b47fd361f189d4ee4290599468733.tgz",
-      "integrity": "sha512-Wgx5p6qgvi25/NOsZ80tAzkCBYFwpDnR5/Es3dPOQk4iUmHUdplie3HCWcM9/rUAAJXXxDcBfuSgV4io6Z2frA==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-26.2.0.tgz",
+      "integrity": "sha512-DYjmKQeDaXYFeNh8dx8+rGj0yW+zS1gfuTuxtY5++zLRAWKmwQKt+uTxCl6l7W9l8XUuSBlykwpf92hswmrVkQ==",
       "dev": true,
       "dependencies": {
         "@codemirror/lang-html": "^6.4.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@lblod/ember-environment-banner": "^0.5.0",
         "@lblod/ember-mock-login": "^0.10.0",
         "@lblod/ember-rdfa-editor": "10.9.0",
-        "@lblod/ember-rdfa-editor-lblod-plugins": "26.1.0-dev.23bbb85064dc86744df1e40778809fbb82cbbdb7",
+        "@lblod/ember-rdfa-editor-lblod-plugins": "26.1.0-dev.05d24394216b47fd361f189d4ee4290599468733",
         "@lblod/template-uuid-instantiator": "^1.0.3",
         "@release-it-plugins/lerna-changelog": "^6.0.0",
         "@tsconfig/ember": "^3.0.8",
@@ -7571,9 +7571,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor-lblod-plugins": {
-      "version": "26.1.0-dev.23bbb85064dc86744df1e40778809fbb82cbbdb7",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-26.1.0-dev.23bbb85064dc86744df1e40778809fbb82cbbdb7.tgz",
-      "integrity": "sha512-l/isOAUhWIdRP5l8PdEfJ+JAwldRWh1EaZydHiLwyJX57BmJEk+8YIs/HMTpHDt/t8/4LUi1SoFSeEGFR7f/fQ==",
+      "version": "26.1.0-dev.05d24394216b47fd361f189d4ee4290599468733",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-26.1.0-dev.05d24394216b47fd361f189d4ee4290599468733.tgz",
+      "integrity": "sha512-Wgx5p6qgvi25/NOsZ80tAzkCBYFwpDnR5/Es3dPOQk4iUmHUdplie3HCWcM9/rUAAJXXxDcBfuSgV4io6Z2frA==",
       "dev": true,
       "dependencies": {
         "@codemirror/lang-html": "^6.4.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@lblod/ember-environment-banner": "^0.5.0",
         "@lblod/ember-mock-login": "^0.10.0",
         "@lblod/ember-rdfa-editor": "10.9.0",
-        "@lblod/ember-rdfa-editor-lblod-plugins": "26.1.0",
+        "@lblod/ember-rdfa-editor-lblod-plugins": "26.1.0-dev.23bbb85064dc86744df1e40778809fbb82cbbdb7",
         "@lblod/template-uuid-instantiator": "^1.0.3",
         "@release-it-plugins/lerna-changelog": "^6.0.0",
         "@tsconfig/ember": "^3.0.8",
@@ -7571,9 +7571,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor-lblod-plugins": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-26.1.0.tgz",
-      "integrity": "sha512-XEWcQFsDrJ6AMj5Q6oW9D83gNZ00y/ADE432bme1C3ULGTfvar2g8VHv4m5wBi9SlBa8PC9cQLHMogPeDt8HFQ==",
+      "version": "26.1.0-dev.23bbb85064dc86744df1e40778809fbb82cbbdb7",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-26.1.0-dev.23bbb85064dc86744df1e40778809fbb82cbbdb7.tgz",
+      "integrity": "sha512-l/isOAUhWIdRP5l8PdEfJ+JAwldRWh1EaZydHiLwyJX57BmJEk+8YIs/HMTpHDt/t8/4LUi1SoFSeEGFR7f/fQ==",
       "dev": true,
       "dependencies": {
         "@codemirror/lang-html": "^6.4.9",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@lblod/ember-environment-banner": "^0.5.0",
     "@lblod/ember-mock-login": "^0.10.0",
     "@lblod/ember-rdfa-editor": "10.9.0",
-    "@lblod/ember-rdfa-editor-lblod-plugins": "26.1.0-dev.23bbb85064dc86744df1e40778809fbb82cbbdb7",
+    "@lblod/ember-rdfa-editor-lblod-plugins": "26.1.0-dev.05d24394216b47fd361f189d4ee4290599468733",
     "@lblod/template-uuid-instantiator": "^1.0.3",
     "@release-it-plugins/lerna-changelog": "^6.0.0",
     "@tsconfig/ember": "^3.0.8",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@lblod/ember-environment-banner": "^0.5.0",
     "@lblod/ember-mock-login": "^0.10.0",
     "@lblod/ember-rdfa-editor": "10.9.0",
-    "@lblod/ember-rdfa-editor-lblod-plugins": "26.1.0-dev.05d24394216b47fd361f189d4ee4290599468733",
+    "@lblod/ember-rdfa-editor-lblod-plugins": "26.2.0",
     "@lblod/template-uuid-instantiator": "^1.0.3",
     "@release-it-plugins/lerna-changelog": "^6.0.0",
     "@tsconfig/ember": "^3.0.8",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@lblod/ember-environment-banner": "^0.5.0",
     "@lblod/ember-mock-login": "^0.10.0",
     "@lblod/ember-rdfa-editor": "10.9.0",
-    "@lblod/ember-rdfa-editor-lblod-plugins": "26.1.0",
+    "@lblod/ember-rdfa-editor-lblod-plugins": "26.1.0-dev.23bbb85064dc86744df1e40778809fbb82cbbdb7",
     "@lblod/template-uuid-instantiator": "^1.0.3",
     "@release-it-plugins/lerna-changelog": "^6.0.0",
     "@tsconfig/ember": "^3.0.8",


### PR DESCRIPTION
### Overview
Just a matter of adding the new configuration.

Edit: now also includes location RDFa fix

A draft until the Plugins PR is in a release.

##### connected issues and PRs:
Plugins PR: https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/517
RB PR: https://github.com/lblod/frontend-reglementaire-bijlage/pull/306
Jira ticket: https://binnenland.atlassian.net/browse/GN-5022

### Setup
N/A

### How to test/reproduce
Same as plugins PR, for agendapoints or RSs.

### Challenges/uncertainties
I wasn't sure if we should do this on RSs, but I made a guess.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
