### PR TITLE
Fix bug where the normal meeting was not filling the whole page

### DIFF
--- a/.changeset/forty-frogs-rule.md
+++ b/.changeset/forty-frogs-rule.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Fix bug where the normal meeting was not filling the whole page

--- a/app/styles/project/_c-meeting-chrome.scss
+++ b/app/styles/project/_c-meeting-chrome.scss
@@ -18,7 +18,7 @@
   padding: $au-unit $au-unit * 0.5;
   position: relative;
   overflow: scroll;
-
+  width: 100%;
   z-index: 2;
 }
 


### PR DESCRIPTION
### Overview
Fix regression only occurring on normal meetings where the meeting did not fill the whole horizontal space available 

##### connected issues and PRs:
None


### Setup
None

### How to test/reproduce
Go to a normal meeting and notice it displays correctly

### Challenges/uncertainties
This was introduced here https://github.com/lblod/frontend-gelinkt-notuleren/commit/3a90ef5a9ffc8cbe585dd77d933b4ba4344b4c5b it has special cases for certain screen sizes, but I don't think is needed anymore so I didn't added them



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
