### PR TITLE
Add copy parts to the agendapoint

### DIFF
--- a/.changeset/quiet-news-compete.md
+++ b/.changeset/quiet-news-compete.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': minor
+---
+
+Add copy parts link to the agendapoint file options

--- a/app/components/decision-copy.gjs
+++ b/app/components/decision-copy.gjs
@@ -1,0 +1,71 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { htmlSafe } from '@ember/template';
+import { generateExportTextFromEditorDocument } from 'frontend-gelinkt-notuleren/utils/generate-export-from-editor-document';
+import { copyStringToClipboard } from 'frontend-gelinkt-notuleren/utils/copy-string-to-clipboard';
+import AuToolbar from '@appuniversum/ember-appuniversum/components/au-toolbar';
+import AuMainContainer from '@appuniversum/ember-appuniversum/components/au-main-container';
+import AuHeading from '@appuniversum/ember-appuniversum/components/au-heading';
+import DownloadMeetingPart from './download-meeting-part';
+import DecisionCopyParts from './decision-copy-parts';
+import t from 'ember-intl/helpers/t';
+export default class DecisionCopy extends Component {
+  @action
+  async copyToClipboard(text) {
+    await copyStringToClipboard({ html: text });
+  }
+
+  get previewDocument() {
+    return htmlSafe(
+      generateExportTextFromEditorDocument(this.model.document, true),
+    );
+  }
+
+  <template>
+    <div class='au-c-app-chrome'>
+      <AuToolbar
+        @size='small'
+        class='au-u-padding-top-none au-u-padding-bottom-none'
+        as |Group|
+      >
+        <Group>
+          {{yield to='links'}}
+        </Group>
+      </AuToolbar>
+    </div>
+    <AuMainContainer as |m|>
+      <m.content @scroll={{true}}>
+        <AuToolbar @size='large' as |Group|>
+          <Group>
+            <AuHeading @level='1' @skin='2'>
+              {{t 'copy-options.heading'}}
+              <span
+                class='au-c-meeting-chrome__highlight'
+              >{{@document.title}}</span>
+            </AuHeading>
+          </Group>
+          <Group>
+            <DownloadMeetingPart
+              @documentType='besluit'
+              @documentContainer={{@container}}
+              @buttonText={{t 'copy-options.copy-all'}}
+              @loadingText={{t 'copy-options.copying'}}
+              @completedText={{t 'copy-options.completed'}}
+              @icon='copy-paste'
+              @buttonSkin='secondary'
+              @callback={{this.copyToClipboard}}
+            />
+          </Group>
+        </AuToolbar>
+        <p class='au-u-margin-left au-u-margin-bottom'>{{t
+            'copy-options.disclaimer'
+          }}</p>
+        <div
+          class='au-u-flex au-u-flex--column au-u-flex--vertical-center au-u-margin-bottom-large'
+        >
+          <DecisionCopyParts @decision={{@document}} />
+        </div>
+      </m.content>
+    </AuMainContainer>
+  </template>
+}

--- a/app/controllers/agendapoints/copy.js
+++ b/app/controllers/agendapoints/copy.js
@@ -1,18 +1,3 @@
 import Controller from '@ember/controller';
-import { action } from '@ember/object';
-import { htmlSafe } from '@ember/template';
-import { generateExportTextFromEditorDocument } from 'frontend-gelinkt-notuleren/utils/generate-export-from-editor-document';
-import { copyStringToClipboard } from 'frontend-gelinkt-notuleren/utils/copy-string-to-clipboard';
 
-export default class MeetingsDownloadCopyController extends Controller {
-  @action
-  async copyToClipboard(text) {
-    await copyStringToClipboard({ html: text });
-  }
-
-  get previewDocument() {
-    return htmlSafe(
-      generateExportTextFromEditorDocument(this.model.document, true),
-    );
-  }
-}
+export default class MeetingsDownloadCopyController extends Controller {}

--- a/app/controllers/agendapoints/copy.js
+++ b/app/controllers/agendapoints/copy.js
@@ -1,0 +1,18 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { htmlSafe } from '@ember/template';
+import { generateExportTextFromEditorDocument } from 'frontend-gelinkt-notuleren/utils/generate-export-from-editor-document';
+import { copyStringToClipboard } from 'frontend-gelinkt-notuleren/utils/copy-string-to-clipboard';
+
+export default class MeetingsDownloadCopyController extends Controller {
+  @action
+  async copyToClipboard(text) {
+    await copyStringToClipboard({ html: text });
+  }
+
+  get previewDocument() {
+    return htmlSafe(
+      generateExportTextFromEditorDocument(this.model.document, true),
+    );
+  }
+}

--- a/app/controllers/agendapoints/copy.js
+++ b/app/controllers/agendapoints/copy.js
@@ -1,3 +1,0 @@
-import Controller from '@ember/controller';
-
-export default class MeetingsDownloadCopyController extends Controller {}

--- a/app/controllers/meetings/download/copy.js
+++ b/app/controllers/meetings/download/copy.js
@@ -1,3 +1,0 @@
-import Controller from '@ember/controller';
-
-export default class MeetingsDownloadCopyController extends Controller {}

--- a/app/controllers/meetings/download/copy.js
+++ b/app/controllers/meetings/download/copy.js
@@ -1,18 +1,3 @@
 import Controller from '@ember/controller';
-import { action } from '@ember/object';
-import { htmlSafe } from '@ember/template';
-import { generateExportTextFromEditorDocument } from '../../../utils/generate-export-from-editor-document';
-import { copyStringToClipboard } from '../../../utils/copy-string-to-clipboard';
 
-export default class MeetingsDownloadCopyController extends Controller {
-  @action
-  async copyToClipboard(text) {
-    await copyStringToClipboard({ html: text });
-  }
-
-  get previewDocument() {
-    return htmlSafe(
-      generateExportTextFromEditorDocument(this.model.document, true),
-    );
-  }
-}
+export default class MeetingsDownloadCopyController extends Controller {}

--- a/app/router.js
+++ b/app/router.js
@@ -51,6 +51,7 @@ Router.map(function () {
     this.route('attachments');
     this.route('show');
     this.route('revisions');
+    this.route('copy');
   });
 
   this.route('meetings', function () {

--- a/app/routes/agendapoints/copy.js
+++ b/app/routes/agendapoints/copy.js
@@ -1,0 +1,14 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class MeetingsDownloadCopyRoute extends Route {
+  @service store;
+  async model(params) {
+    const { documentContainer, returnToMeeting } =
+      this.modelFor('agendapoints');
+    const document = await documentContainer.currentVersion;
+    console.log(document);
+    console.log(documentContainer);
+    return { container: documentContainer, document };
+  }
+}

--- a/app/routes/agendapoints/copy.js
+++ b/app/routes/agendapoints/copy.js
@@ -3,12 +3,9 @@ import { service } from '@ember/service';
 
 export default class MeetingsDownloadCopyRoute extends Route {
   @service store;
-  async model(params) {
-    const { documentContainer, returnToMeeting } =
-      this.modelFor('agendapoints');
+  async model() {
+    const { documentContainer } = this.modelFor('agendapoints');
     const document = await documentContainer.currentVersion;
-    console.log(document);
-    console.log(documentContainer);
     return { container: documentContainer, document };
   }
 }

--- a/app/templates/agendapoints/copy.hbs
+++ b/app/templates/agendapoints/copy.hbs
@@ -1,50 +1,13 @@
-<div class='au-c-app-chrome'>
-  <AuToolbar
-    @size='small'
-    class='au-u-padding-top-none au-u-padding-bottom-none'
-    as |Group|
-  >
-    <Group>
-      <AuLink @route='agendapoints.edit' @skin='secondary'>
+<DecisionCopy
+  @document={{@model.document}}
+  @container={{@model.container}}
+>
+  <:links>
+    <AuLink @route='agendapoints.edit' @skin='secondary'>
         <AuIcon @icon='arrow-left' @alignment='left' />
         {{t 'agendapoint.back-to-agendapoint'}}
       </AuLink>
       <span class='au-c-app-chrome__entity'>{{t 'copy-options.heading'}}
         {{@model.document.title}}</span>
-    </Group>
-  </AuToolbar>
-</div>
-<AuMainContainer as |m|>
-  <m.content @scroll={{true}}>
-    <AuToolbar @size='large' as |Group|>
-      <Group>
-        <AuHeading @level='1' @skin='2'>
-          {{t 'copy-options.heading'}}
-          <span
-            class='au-c-meeting-chrome__highlight'
-          >{{@model.document.title}}</span>
-        </AuHeading>
-      </Group>
-      <Group>
-        <DownloadMeetingPart
-          @documentType='besluit'
-          @documentContainer={{@model.container}}
-          @buttonText={{t 'copy-options.copy-all'}}
-          @loadingText={{t 'copy-options.copying'}}
-          @completedText={{t 'copy-options.completed'}}
-          @icon='copy-paste'
-          @buttonSkin='secondary'
-          @callback={{this.copyToClipboard}}
-        />
-      </Group>
-    </AuToolbar>
-    <p class='au-u-margin-left au-u-margin-bottom'>{{t
-        'copy-options.disclaimer'
-      }}</p>
-    <div
-      class='au-u-flex au-u-flex--column au-u-flex--vertical-center au-u-margin-bottom-large'
-    >
-      <DecisionCopyParts @decision={{@model.document}} />
-    </div>
-  </m.content>
-</AuMainContainer>
+  </:links>
+</DecisionCopy>

--- a/app/templates/agendapoints/copy.hbs
+++ b/app/templates/agendapoints/copy.hbs
@@ -1,0 +1,50 @@
+<div class='au-c-app-chrome'>
+  <AuToolbar
+    @size='small'
+    class='au-u-padding-top-none au-u-padding-bottom-none'
+    as |Group|
+  >
+    <Group>
+      <AuLink @route='agendapoints.edit' @skin='secondary'>
+        <AuIcon @icon='arrow-left' @alignment='left' />
+       {{t 'agendapoint.back-to-agendapoint'}}
+      </AuLink>
+      <span class='au-c-app-chrome__entity'>{{t 'copy-options.heading'}}
+        {{@model.document.title}}</span>
+    </Group>
+  </AuToolbar>
+</div>
+<AuMainContainer as |m|>
+  <m.content @scroll={{true}}>
+    <AuToolbar @size='large' as |Group|>
+      <Group>
+        <AuHeading @level='1' @skin='2'>
+          {{t 'copy-options.heading'}}
+          <span
+            class='au-c-meeting-chrome__highlight'
+          >{{@model.document.title}}</span>
+        </AuHeading>
+      </Group>
+      <Group>
+        <DownloadMeetingPart
+          @documentType='besluit'
+          @documentContainer={{@model.container}}
+          @buttonText={{t 'copy-options.copy-all'}}
+          @loadingText={{t 'copy-options.copying'}}
+          @completedText={{t 'copy-options.completed'}}
+          @icon='copy-paste'
+          @buttonSkin='secondary'
+          @callback={{this.copyToClipboard}}
+        />
+      </Group>
+    </AuToolbar>
+    <p class='au-u-margin-left au-u-margin-bottom'>{{t
+        'copy-options.disclaimer'
+      }}</p>
+    <div
+      class='au-u-flex au-u-flex--column au-u-flex--vertical-center au-u-margin-bottom-large'
+    >
+      <DecisionCopyParts @decision={{@model.document}} />
+    </div>
+  </m.content>
+</AuMainContainer>

--- a/app/templates/agendapoints/copy.hbs
+++ b/app/templates/agendapoints/copy.hbs
@@ -7,7 +7,7 @@
     <Group>
       <AuLink @route='agendapoints.edit' @skin='secondary'>
         <AuIcon @icon='arrow-left' @alignment='left' />
-       {{t 'agendapoint.back-to-agendapoint'}}
+        {{t 'agendapoint.back-to-agendapoint'}}
       </AuLink>
       <span class='au-c-app-chrome__entity'>{{t 'copy-options.heading'}}
         {{@model.document.title}}</span>

--- a/app/templates/agendapoints/copy.hbs
+++ b/app/templates/agendapoints/copy.hbs
@@ -1,13 +1,10 @@
-<DecisionCopy
-  @document={{@model.document}}
-  @container={{@model.container}}
->
+<DecisionCopy @document={{@model.document}} @container={{@model.container}}>
   <:links>
     <AuLink @route='agendapoints.edit' @skin='secondary'>
-        <AuIcon @icon='arrow-left' @alignment='left' />
-        {{t 'agendapoint.back-to-agendapoint'}}
-      </AuLink>
-      <span class='au-c-app-chrome__entity'>{{t 'copy-options.heading'}}
-        {{@model.document.title}}</span>
+      <AuIcon @icon='arrow-left' @alignment='left' />
+      {{t 'agendapoint.back-to-agendapoint'}}
+    </AuLink>
+    <span class='au-c-app-chrome__entity'>{{t 'copy-options.heading'}}
+      {{@model.document.title}}</span>
   </:links>
 </DecisionCopy>

--- a/app/templates/agendapoints/edit.hbs
+++ b/app/templates/agendapoints/edit.hbs
@@ -36,6 +36,10 @@
         @document={{this.editorDocument}}
         @forPublish={{true}}
       />
+      <AuLink @route='agendapoints.copy' role='menuitem'>
+        <AuIcon @icon='copy' @alignment='left' />
+        {{t 'agendapoint.copy-parts-link'}}
+      </AuLink>
       <AuButton
         {{on 'click' this.toggleDeleteModal}}
         @skin='link'

--- a/app/templates/meetings/download/copy.hbs
+++ b/app/templates/meetings/download/copy.hbs
@@ -1,26 +1,23 @@
-<DecisionCopy
-  @document={{@model.document}}
-  @container={{@model.container}}
->
+<DecisionCopy @document={{@model.document}} @container={{@model.container}}>
   <:links>
     <AuLink
-        @route='meetings.edit'
-        @model={{@model.zitting.id}}
-        @skin='secondary'
-        @icon='arrow-left'
-        @iconAlignment='left'
-      >
-        {{t 'download.back-to-meeting'}}
-      </AuLink>
-      <AuLink
-        @route='meetings.download'
-        @model={{@model.zitting.id}}
-        @skin='secondary'
-        class='au-c-app-chrome__entity'
-      >
-        {{t 'download.back-to-download'}}
-      </AuLink>
-      <span class='au-c-app-chrome__entity'>{{t 'copy-options.heading'}}
-        {{@model.document.title}}</span>
+      @route='meetings.edit'
+      @model={{@model.zitting.id}}
+      @skin='secondary'
+      @icon='arrow-left'
+      @iconAlignment='left'
+    >
+      {{t 'download.back-to-meeting'}}
+    </AuLink>
+    <AuLink
+      @route='meetings.download'
+      @model={{@model.zitting.id}}
+      @skin='secondary'
+      class='au-c-app-chrome__entity'
+    >
+      {{t 'download.back-to-download'}}
+    </AuLink>
+    <span class='au-c-app-chrome__entity'>{{t 'copy-options.heading'}}
+      {{@model.document.title}}</span>
   </:links>
 </DecisionCopy>

--- a/app/templates/meetings/download/copy.hbs
+++ b/app/templates/meetings/download/copy.hbs
@@ -1,11 +1,9 @@
-<div class='au-c-app-chrome'>
-  <AuToolbar
-    @size='small'
-    class='au-u-padding-top-none au-u-padding-bottom-none'
-    as |Group|
-  >
-    <Group>
-      <AuLink
+<DecisionCopy
+  @document={{@model.document}}
+  @container={{@model.container}}
+>
+  <:links>
+    <AuLink
         @route='meetings.edit'
         @model={{@model.zitting.id}}
         @skin='secondary'
@@ -24,40 +22,5 @@
       </AuLink>
       <span class='au-c-app-chrome__entity'>{{t 'copy-options.heading'}}
         {{@model.document.title}}</span>
-    </Group>
-  </AuToolbar>
-</div>
-<AuMainContainer as |m|>
-  <m.content @scroll={{true}}>
-    <AuToolbar @size='large' as |Group|>
-      <Group>
-        <AuHeading @level='1' @skin='2'>
-          {{t 'copy-options.heading'}}
-          <span
-            class='au-c-meeting-chrome__highlight'
-          >{{@model.document.title}}</span>
-        </AuHeading>
-      </Group>
-      <Group>
-        <DownloadMeetingPart
-          @documentType='besluit'
-          @documentContainer={{@model.container}}
-          @buttonText={{t 'copy-options.copy-all'}}
-          @loadingText={{t 'copy-options.copying'}}
-          @completedText={{t 'copy-options.completed'}}
-          @icon='copy-paste'
-          @buttonSkin='secondary'
-          @callback={{this.copyToClipboard}}
-        />
-      </Group>
-    </AuToolbar>
-    <p class='au-u-margin-left au-u-margin-bottom'>{{t
-        'copy-options.disclaimer'
-      }}</p>
-    <div
-      class='au-u-flex au-u-flex--column au-u-flex--vertical-center au-u-margin-bottom-large'
-    >
-      <DecisionCopyParts @decision={{@model.document}} />
-    </div>
-  </m.content>
-</AuMainContainer>
+  </:links>
+</DecisionCopy>

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -5,6 +5,7 @@ agendapoint:
   revisions: Revisions
   restore: Restore
   back-to-meeting: Return to the meeting of {adminBody} on {date}
+  back-to-agendapoint: Return to the agendapoint
   saved-versions: 'Saved document versions:'
   current-version: Current version
   modify-warning: 'When modifying the document to an older version, subsequent newer versions disappear irretrievably:'
@@ -15,6 +16,7 @@ agendapoint:
   published: This article has already been published. Published agenda items are not editable.
   saving: Saving...
   making-copy: Making copy...
+  copy-parts-link: Copy decision parts
 
 administrative-body-select:
   period: 'period'

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -5,6 +5,7 @@ agendapoint:
   revisions: Versies
   restore: Herstel
   back-to-meeting: Terug naar zitting van {adminBody} op {date}
+  back-to-agendapoint: Terug naar agendapunt
   saved-versions: 'Opgeslagen documentversies:'
   current-version: Huidige versie
   modify-warning: 'Bij het aanpassen van het document naar een oudere versie, verdwijnen volgende nieuwere versies onherroepelijk:'
@@ -15,6 +16,7 @@ agendapoint:
   published: Dit artikel is reeds gepubliceerd. Gepubliceerde agendapunten zijn niet editeerbaar.
   saving: Bezig met opslaan
   making-copy: Kopie aan het maken
+  copy-parts-link: Kopieer besluit en onderdelen
 
 administrative-body-select:
   period: 'period'


### PR DESCRIPTION
### Overview
Add a way of copying the parts of an agendapoint direclty from the agendapoint and not from the meeting

##### connected issues and PRs:
GN-5321


### Setup
None

### How to test/reproduce
Go to an agendapoint, in the file options you should have a copy decision parts button that should lead you to a new page where you can copy the decision parts

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
