### PR TITLE
Fix publish service to handle non-200 success status codes

### DIFF
--- a/.changeset/breezy-eyes-refuse.md
+++ b/.changeset/breezy-eyes-refuse.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Fix publish service to handle non-200 success status codes

--- a/app/controllers/meetings/publish/besluitenlijst.js
+++ b/app/controllers/meetings/publish/besluitenlijst.js
@@ -64,7 +64,7 @@ export default class MeetingsPublishBesluitenlijstController extends Controller 
       maxIterations--;
     } while (resp.status === 404 && maxIterations > 0);
 
-    if (resp.status !== 200) {
+    if (!resp.ok) {
       throw new Error(await resp.text());
     } else {
       return await resp.json();

--- a/app/controllers/meetings/publish/notulen.js
+++ b/app/controllers/meetings/publish/notulen.js
@@ -363,8 +363,8 @@ export default class MeetingsPublishNotulenController extends Controller {
       const previewHtml = json.data.attributes.html;
       this.preview = previewHtml;
     } catch (e) {
-      console.error(e);
-      this.errors = [JSON.stringify(e)];
+      console.error('Error generating notulen preview', e);
+      this.errors = [e.message];
     }
   });
 

--- a/app/services/publish.js
+++ b/app/services/publish.js
@@ -83,7 +83,7 @@ export default class PublishService extends Service {
         maxIterations--;
       } while (resp.status === 404 && maxIterations > 0);
 
-      if (resp.status !== 200) {
+      if (!resp.ok) {
         let errors;
         try {
           const json = await resp.json();

--- a/app/services/template-fetcher.js
+++ b/app/services/template-fetcher.js
@@ -51,7 +51,7 @@ export default class TemplateFetcher extends Service {
     `;
 
     const response = await this.sendQuery(sparqlEndpoint, sparqlQuery);
-    if (response.status === 200) {
+    if (!response.ok) {
       const json = await response.json();
       const bindings = json.results.bindings;
       const templates = bindings.map(this.bindingToTemplate(fileEndpoint));
@@ -99,7 +99,7 @@ export default class TemplateFetcher extends Service {
     `;
 
     const response = await this.sendQuery(sparqlEndpoint, sparqlQuery);
-    if (response.status === 200) {
+    if (!response.ok) {
       const json = await response.json();
       const bindings = json.results.bindings;
       const templates = bindings.map(this.bindingToTemplate(fileEndpoint));
@@ -145,7 +145,7 @@ export default class TemplateFetcher extends Service {
       ORDER BY LCASE(REPLACE(STR(?title), '^ +| +$', ''))
     `;
     const response = await this.sendQuery(sparqlEndpoint, sparqlQuery);
-    if (response.status === 200) {
+    if (!response.ok) {
       const json = await response.json();
       const bindings = json.results.bindings;
       const templates = bindings.map(this.bindingToTemplate(fileEndpoint));


### PR DESCRIPTION
### Overview
When testing calls to prepublish service, I noticed that one of the calls was returning a 201 `created` status code, which was being interpreted as a failure. I changed this call and some others I found to use the `Response.ok` field instead of checking for 200. I also replaced the confusing `JSON.stringify(error)` call as an error always serialises as `{}`.

##### connected issues and PRs:
Found when creating https://github.com/lblod/notulen-prepublish-service/pull/124

### Setup
This was found when working with an in-progress prepublisher which returned a 201 in place of a 200 for a job status. So, to test, you can run app-gn with a local version of the prepublisher. Modify the [`/prepublish/job-result/:jobUuid` route](https://github.com/lblod/notulen-prepublish-service/blob/b5cff84c0924b8cef5c0d5082591bebd13f60678/routes/preview.js#L74) to return a 201 status on success.

### How to test/reproduce
This was visible when creating a job on the endpoint `/meeting-notes-previews`, so when producing the publish preview for a notulen.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
