### PR TITLE
add loading indicator to participation list

### DIFF
--- a/.changeset/good-roses-run.md
+++ b/.changeset/good-roses-run.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': minor
+---
+
+Add loading indicator to participation list

--- a/app/components/behandeling-van-agendapunt.hbs
+++ b/app/components/behandeling-van-agendapunt.hbs
@@ -97,6 +97,7 @@
         this.canEditParticipants
         (t 'behandeling-van-agendapunten.cannot-edit-participants')
       }}
+      @loading={{@loadingParticipants}}
     />
   {{/if}}
   <Common::MeetingSubSection

--- a/app/components/meeting-form.hbs
+++ b/app/components/meeting-form.hbs
@@ -267,6 +267,7 @@
                 @meeting={{this.zitting}}
                 @modalTitle={{t 'generic.edit'}}
                 @readOnly={{this.readOnly}}
+                @loading={{this.possibleParticipantsData.isRunning }}
               />
             </Common::MeetingSection>
           {{/unless}}
@@ -335,6 +336,7 @@
                       @bestuursorgaan={{this.bestuursorgaan}}
                       @meeting={{this.zitting}}
                       @focusMode={{@focused}}
+                      @loadingParticipants={{this.possibleParticipantsData.isRunning }}
                     />
                   </li>
                 {{/each}}

--- a/app/components/meeting-form.hbs
+++ b/app/components/meeting-form.hbs
@@ -267,7 +267,7 @@
                 @meeting={{this.zitting}}
                 @modalTitle={{t 'generic.edit'}}
                 @readOnly={{this.readOnly}}
-                @loading={{this.possibleParticipantsData.isRunning }}
+                @loading={{this.possibleParticipantsData.isRunning}}
               />
             </Common::MeetingSection>
           {{/unless}}
@@ -336,7 +336,7 @@
                       @bestuursorgaan={{this.bestuursorgaan}}
                       @meeting={{this.zitting}}
                       @focusMode={{@focused}}
-                      @loadingParticipants={{this.possibleParticipantsData.isRunning }}
+                      @loadingParticipants={{this.possibleParticipantsData.isRunning}}
                     />
                   </li>
                 {{/each}}

--- a/app/components/participation-list.hbs
+++ b/app/components/participation-list.hbs
@@ -40,4 +40,5 @@
   @onSave={{@onSave}}
   @bestuursorgaan={{@bestuursorgaan}}
   @meeting={{@meeting}}
+  @loading={{@loading}}
 />

--- a/app/components/participation-list/modal.hbs
+++ b/app/components/participation-list/modal.hbs
@@ -31,17 +31,21 @@
           @toggleParticipant={{this.toggleParticipant}}
           as |Table|
         >
-          {{#each this.participants as |participant|}}
-            <Table.Row
-              @mandataris={{participant.person}}
-              @selected={{participant.participating}}
-              @disabled={{eq participant.person this.chairman}}
-            />
+          {{#if @loading}}
+            <td colspan='4'><AuLoader /></td>
           {{else}}
-            <td colspan='4'>{{t
-                'participation-list-modal-table.no-data-message'
-              }}</td>
-          {{/each}}
+            {{#each this.participants as |participant|}}
+              <Table.Row
+                @mandataris={{participant.person}}
+                @selected={{participant.participating}}
+                @disabled={{eq participant.person this.chairman}}
+              />
+            {{else}}
+              <td colspan='4'>{{t
+                  'participation-list-modal-table.no-data-message'
+                }}</td>
+            {{/each}}
+          {{/if}}
         </ParticipationList::MandatarissenTable>
       </div>
     </div>


### PR DESCRIPTION
### Overview
Add loading indicator to the participation list of the meeting

##### connected issues and PRs:
GN-5012


### Setup
None

### How to test/reproduce
Go to a meeting and notice that there's a loading indicator when you open the participation list of the meeting, you might need to activate throttling

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
