### PR TITLE
Fix incorrect error handling in template-fetcher service

### DIFF
--- a/.changeset/curvy-lizards-suffer.md
+++ b/.changeset/curvy-lizards-suffer.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Fix incorrect fetch error handling in template-fetcher

--- a/app/services/template-fetcher.js
+++ b/app/services/template-fetcher.js
@@ -51,7 +51,7 @@ export default class TemplateFetcher extends Service {
     `;
 
     const response = await this.sendQuery(sparqlEndpoint, sparqlQuery);
-    if (!response.ok) {
+    if (response.ok) {
       const json = await response.json();
       const bindings = json.results.bindings;
       const templates = bindings.map(this.bindingToTemplate(fileEndpoint));
@@ -99,7 +99,7 @@ export default class TemplateFetcher extends Service {
     `;
 
     const response = await this.sendQuery(sparqlEndpoint, sparqlQuery);
-    if (!response.ok) {
+    if (response.ok) {
       const json = await response.json();
       const bindings = json.results.bindings;
       const templates = bindings.map(this.bindingToTemplate(fileEndpoint));
@@ -145,7 +145,7 @@ export default class TemplateFetcher extends Service {
       ORDER BY LCASE(REPLACE(STR(?title), '^ +| +$', ''))
     `;
     const response = await this.sendQuery(sparqlEndpoint, sparqlQuery);
-    if (!response.ok) {
+    if (response.ok) {
       const json = await response.json();
       const bindings = json.results.bindings;
       const templates = bindings.map(this.bindingToTemplate(fileEndpoint));


### PR DESCRIPTION
### Overview
This PR solves an issue introduced in https://github.com/lblod/frontend-gelinkt-notuleren/pull/797
The `!response.ok` condition used in the `template-fetcher` should be `response.ok`.

##### connected issues and PRs:
None

### Setup
None

### How to test/reproduce
Ensure you can correctly fetch + instantiate templates coming from RB.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
