### PR TITLE
Remove `ember-drag-drop` dependency

### DIFF
--- a/.changeset/early-snails-cheat.md
+++ b/.changeset/early-snails-cheat.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Rework meeting agenda table using `ember-sortable` package

--- a/app/components/agenda-manager/agenda-context.js
+++ b/app/components/agenda-manager/agenda-context.js
@@ -151,7 +151,8 @@ export default class AgendaManagerAgendaContextComponent extends Component {
    * Handles a rearrangement of the this.items array
    * Takes the array index as source of truth.
    */
-  onSortTask = task(async () => {
+  onSortTask = task(async (items) => {
+    this.items = tracked(items);
     await this.repairPositionsTask.unlinked().perform();
     await this.saveItemsTask.unlinked().perform();
   });

--- a/app/components/agenda-manager/agenda-table/body.hbs
+++ b/app/components/agenda-manager/agenda-table/body.hbs
@@ -1,15 +1,8 @@
-<SortableObjects
-  @tagName='tbody'
-  @sortEndAction={{@onSort}}
-  @sortableObjectList={{@items}}
-  @enableSort={{true}}
-  @useSwap={{true}}
-  @inPlace={{true}}
->
+<tbody {{sortable-group onChange=@onSort}}>
   {{yield
     (hash
       Row=(component 'agenda-manager/agenda-table/row' readOnly=@readOnly)
       Empty=(component 'agenda-manager/agenda-table/empty' onCreate=@onCreate)
     )
   }}
-</SortableObjects>
+</tbody>

--- a/app/components/agenda-manager/agenda-table/header.hbs
+++ b/app/components/agenda-manager/agenda-table/header.hbs
@@ -6,10 +6,5 @@
         'manage-agenda-zitting-modal.title-label'
       }}</th>
     <th>{{t 'manage-agenda-zitting-modal.gepland-openbaar'}}</th>
-    <th class='au-u-table-right'>
-      <span class='au-u-hidden-visually'>{{t
-          'manage-agenda-zitting-modal.actions-label'
-        }}</span>
-    </th>
   </tr>
 </thead>

--- a/app/components/agenda-manager/agenda-table/row.hbs
+++ b/app/components/agenda-manager/agenda-table/row.hbs
@@ -22,12 +22,12 @@
     </td>
   </tr>
 {{else}}
-  <DraggableObject @tagName='tr' @content={{@item}} @isSortable={{true}}>
+  <tr {{sortable-item model=@item}}>
     <td>
-      <AuButton @skin='link' class='au-c-button--drag'>
-        <AuIcon @icon='drag' class='au-u-hide-on-print' />
+      <span class='drag-handle' {{sortable-handle}}>
+        <AuIcon @icon='drag' class='au-u-hide-on-print drag-handle__icon' />
         {{add @item.position 1}}
-      </AuButton>
+      </span>
     </td>
     <td>
       <AuButton
@@ -45,5 +45,5 @@
         (t 'manage-agenda-zitting-modal.gepland-openbaar-false-label')
       }}
     </td>
-  </DraggableObject>
+  </tr>
 {{/if}}

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -40,18 +40,6 @@ body {
   padding-bottom: $au-unit-tiny;
 }
 
-// Drag button
-.au-c-button--drag {
-  cursor: grab;
-  text-decoration: none;
-
-  .au-c-icon {
-    width: 1.75rem;
-    height: 1.75rem;
-    bottom: 0;
-  }
-}
-
 // Data table quick fix
 // @TODO port to appuniversum
 .au-c-data-table__header th {

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -28,6 +28,7 @@
 @import 'project/c-template';
 @import 'project/c-environment-banner';
 @import 'project/c-inauguration-meeting-synchronization';
+@import 'project/c-sortable';
 
 // PLUGINS
 @import 'ember-rdfa-editor';

--- a/app/styles/project/_c-meeting-chrome.scss
+++ b/app/styles/project/_c-meeting-chrome.scss
@@ -273,7 +273,7 @@
   position: relative;
   min-width: 50rem;
   width: 100%;
-  border-collapse: collapse;
+  border-collapse: separate;
   margin-bottom: -0.1rem;
 
   strong {
@@ -291,9 +291,9 @@
     @include au-font-size($au-base, 1.2);
   }
 
-  tbody tr {
-    border-bottom: 0.1rem solid $au-gray-300;
+  tr {
     background-color: $au-gray-100;
+    position: relative;
   }
 
   th {
@@ -313,6 +313,7 @@
 
   th,
   td {
+    border-bottom: 0.1rem solid $au-gray-300;
     max-width: 55ch;
     position: relative;
     vertical-align: middle;

--- a/app/styles/project/_c-sortable.scss
+++ b/app/styles/project/_c-sortable.scss
@@ -1,0 +1,23 @@
+tr.sortable-item {
+  transition: all 0.125s;
+}
+
+tr.sortable-item.is-dragging {
+  transition-duration: 0s;
+  z-index: 10;
+}
+
+.drag-handle {
+  cursor: grab;
+  color: var(--au-blue-700);
+  display: inline-flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0 0.6rem;
+}
+
+.drag-handle__icon {
+  width: 1.75rem;
+  height: 1.75rem;
+}

--- a/config/environment.js
+++ b/config/environment.js
@@ -20,10 +20,7 @@ module.exports = function (environment) {
         // Here you can enable experimental features on an ember canary build
         // e.g. EMBER_NATIVE_DECORATOR_SUPPORT: true
       },
-      // It doesn't look like we're making use of any prototype extensions in our code any more, but
-      // ember-drag-drop (v1.0.0) makes use of `.reset()`, so we can't turn this off until that lib
-      // has been updated. We should also keep an eye out for deprecations in our or other lib code.
-      // EXTEND_PROTOTYPES: false,
+      EXTEND_PROTOTYPES: false,
     },
     APP: {
       '@lblod/ember-rdfa-editor-date-plugin': {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@curvenote/prosemirror-utils": "^1.0.5",
         "ember-resources": "^7.0.2",
+        "ember-sortable": "^5.2.3",
         "reactiveweb": "^1.3.0",
         "tracked-toolbox": "^2.0.0"
       },
@@ -83,7 +84,6 @@
         "ember-data-resources": "^5.0.0",
         "ember-data-table": "^2.1.0",
         "ember-data-types": "5.4.0-alpha.131",
-        "ember-drag-drop": "^1.0.0",
         "ember-feature-flags": "^6.0.0",
         "ember-fetch": "^8.1.2",
         "ember-intl": "^7.0.3",
@@ -4337,7 +4337,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@ember/test-helpers/-/test-helpers-3.3.1.tgz",
       "integrity": "sha512-h4uFBy4pquBtHsHI+tx9S0wtMmn1L+8dkXiDiyoqG1+3e0Awk6GBujiFM9s4ANq6wC8uIhC3wEFyts10h2OAoQ==",
-      "dev": true,
       "dependencies": {
         "@ember/test-waiters": "^3.0.2",
         "@embroider/macros": "^1.10.0",
@@ -4360,7 +4359,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@ember/test-waiters/-/test-waiters-3.1.0.tgz",
       "integrity": "sha512-bb9h95ktG2wKY9+ja1sdsFBdOms2lB19VWs8wmNpzgHv1NCetonBoV5jHBV4DHt0uS1tg9z66cZqhUVlYs96KQ==",
-      "dev": true,
       "dependencies": {
         "calculate-cache-key-for-tree": "^2.0.0",
         "ember-cli-babel": "^7.26.6",
@@ -4376,7 +4374,6 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
       "integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
       "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
@@ -4395,7 +4392,6 @@
       "version": "7.12.18",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.18.tgz",
       "integrity": "sha512-BogPQ7ciE6SYAUPtlm9tWbgI9+2AgqSam6QivMgXgAT+fKbgppaj4ZX15MHeLC1PVF5sNk70huBu20XxWOs8Cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
@@ -4405,7 +4401,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.1.0.tgz",
       "integrity": "sha512-AInn5+UBFIK9FK5xc9yP5e3TQSPNNgjHByqYcj9g5elVBnDQcQL7PlO1CIRy2gWlbwK7UPYqi7vRvFA44dCmYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -4415,7 +4410,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
       "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "array-equal": "^1.0.0",
@@ -4440,7 +4434,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz",
       "integrity": "sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "promise-map-series": "^0.2.1",
@@ -4453,7 +4446,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/broccoli-source/-/broccoli-source-2.1.2.tgz",
       "integrity": "sha512-1lLayO4wfS0c0Sj50VfHJXNWf94FYY0WUhxj0R77thbs6uWI7USiOWFqQV5dRmhAJnoKaGN4WyLGQbgjgiYFwQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -4463,7 +4455,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -4473,7 +4464,6 @@
       "version": "7.26.11",
       "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-7.26.11.tgz",
       "integrity": "sha512-JJYeYjiz/JTn34q7F5DSOjkkZqy8qwFOOxXfE6pe9yEJqWGu4qErKxlz8I22JoVEQ/aBUO+OcKTpmctvykM9YA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.12.0",
@@ -4515,7 +4505,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-4.1.1.tgz",
       "integrity": "sha512-bzEWsTMXUGEJfxcAGWPe6kI7oHEGD3jaxUWDYPTqzqGhNkgPwXTBgoWs9zG1RaSMaOPFnloWuxRcoHi4TrYS3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve-package-path": "^2.0.0",
@@ -4530,7 +4519,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-2.0.0.tgz",
       "integrity": "sha512-/CLuzodHO2wyyHTzls5Qr+EFeG6RcW4u6//gjYvUfcfyuplIX1SSccU+A5A9A78Gmezkl3NBkFAMxLbzTY9TJA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-root": "^0.1.1",
@@ -4544,7 +4532,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -4555,7 +4542,6 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
@@ -4571,7 +4557,6 @@
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
@@ -4581,7 +4566,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/fixturify/-/fixturify-1.3.0.tgz",
       "integrity": "sha512-tL0svlOy56pIMMUQ4bU1xRe6NZbFSa/ABTWMxW2mH38lFGc9TrNAKWcMBQ7eIjo3wqSS8f2ICabFaatFyFmrVQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/fs-extra": "^5.0.5",
@@ -4598,7 +4582,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/fixturify-project/-/fixturify-project-1.10.0.tgz",
       "integrity": "sha512-L1k9uiBQuN0Yr8tA9Noy2VSQ0dfg0B8qMdvT7Wb5WQKc7f3dn3bzCbSrqlb+etLW+KDV4cBC7R1OvcMg3kcxmA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fixturify": "^1.2.0",
@@ -4609,7 +4592,6 @@
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.6"
@@ -4622,21 +4604,18 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@ember/test-waiters/node_modules/regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@ember/test-waiters/node_modules/resolve-package-path": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-3.1.0.tgz",
       "integrity": "sha512-2oC2EjWbMJwvSN6Z7DbDfJMnD8MYEouaLn5eIX0j8XwPsYCVIyY9bbnX88YHVkbr8XHqvZrYbxaLPibfTYKZMA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-root": "^0.1.1",
@@ -4650,7 +4629,6 @@
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
       "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -4662,7 +4640,6 @@
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "os-tmpdir": "~1.0.2"
@@ -15312,7 +15289,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/decorator-transforms/-/decorator-transforms-2.3.0.tgz",
       "integrity": "sha512-jo8c1ss9yFPudHuYYcrJ9jpkDZIoi+lOGvt+Uyp9B+dz32i50icRMx9Bfa8hEt7TnX1FyKWKkjV+cUdT/ep2kA==",
-      "dev": true,
       "dependencies": {
         "@babel/plugin-syntax-decorators": "^7.23.3",
         "babel-import-util": "^3.0.0"
@@ -15322,7 +15298,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-3.0.0.tgz",
       "integrity": "sha512-4YNPkuVsxAW5lnSTa6cn4Wk49RX6GAB6vX+M6LqEtN0YePqoFczv1/x0EyLK/o+4E1j9jEuYj5Su7IEPab5JHQ==",
-      "dev": true,
       "engines": {
         "node": ">= 12.*"
       }
@@ -15766,8 +15741,7 @@
     "node_modules/dom-element-descriptors": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/dom-element-descriptors/-/dom-element-descriptors-0.5.1.tgz",
-      "integrity": "sha512-DLayMRQ+yJaziF4JJX1FMjwjdr7wdTr1y9XvZ+NfHELfOMcYDnCHneAYXAS4FT1gLILh4V0juMZohhH1N5FsoQ==",
-      "dev": true
+      "integrity": "sha512-DLayMRQ+yJaziF4JJX1FMjwjdr7wdTr1y9XvZ+NfHELfOMcYDnCHneAYXAS4FT1gLILh4V0juMZohhH1N5FsoQ=="
     },
     "node_modules/domain-browser": {
       "version": "1.2.0",
@@ -19737,7 +19711,6 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-6.3.0.tgz",
       "integrity": "sha512-N9Y80oZfcfWLsqickMfRd9YByVcTGyhYRnYQ2XVPVrp6jyUyOeRWmEAPh7ERSXpp8Ws4hr/JB9QVQrn/yZa+Ag==",
-      "dev": true,
       "dependencies": {
         "@ember/edition-utils": "^1.2.0",
         "babel-plugin-ember-template-compilation": "^2.0.0",
@@ -19762,7 +19735,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
       "integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
-      "dev": true,
       "dependencies": {
         "debug": "^4.1.1",
         "heimdalljs": "^0.2.3",
@@ -19780,7 +19752,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.3.tgz",
       "integrity": "sha512-Q+8iezprZzL9voaBsDY3rQVl7c7H5h+bvv8SpzCZXPZgfBFCbx7KFQ2c3rZR6lW5k4Kwoqt7jG+rZMUg67Gwxw==",
-      "dev": true,
       "dependencies": {
         "async-disk-cache": "^2.0.0",
         "async-promise-queue": "^1.0.3",
@@ -19802,7 +19773,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
       "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
-      "dev": true,
       "dependencies": {
         "errlop": "^2.0.0",
         "semver": "^6.3.0"
@@ -19818,7 +19788,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -19827,7 +19796,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
       "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
-      "dev": true,
       "dependencies": {
         "@types/symlink-or-copy": "^1.2.0",
         "heimdalljs-logger": "^0.1.7",
@@ -19843,7 +19811,6 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
       "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
-      "dev": true,
       "dependencies": {
         "binaryextensions": "^2.1.2",
         "editions": "^2.2.0",
@@ -19860,7 +19827,6 @@
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -19873,7 +19839,6 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -19888,7 +19853,6 @@
       "version": "4.8.5",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-      "dev": true,
       "engines": {
         "node": "6.* || >= 7.*"
       }
@@ -19897,7 +19861,6 @@
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
       "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -19909,7 +19872,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
       "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-      "dev": true,
       "dependencies": {
         "@types/minimatch": "^3.0.3",
         "ensure-posix-path": "^1.1.0",
@@ -23924,34 +23886,6 @@
         "node": ">=0.6.0"
       }
     },
-    "node_modules/ember-drag-drop": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ember-drag-drop/-/ember-drag-drop-1.0.0.tgz",
-      "integrity": "sha512-e+KjktvQOe1gDGchev0A5AiGV4xzLQBaZ7WkzNBjZ4SNmJ7rBKLEohS1UhvviUCJDVDhWxHRS3Gh8lMkGvKhQw==",
-      "dev": true,
-      "dependencies": {
-        "@embroider/addon-shim": "^1.8.7",
-        "decorator-transforms": "^1.0.1"
-      },
-      "peerDependencies": {
-        "@ember/test-helpers": "*"
-      },
-      "peerDependenciesMeta": {
-        "@ember/test-helpers": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ember-drag-drop/node_modules/decorator-transforms": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/decorator-transforms/-/decorator-transforms-1.2.1.tgz",
-      "integrity": "sha512-UUtmyfdlHvYoX3VSG1w5rbvBQ2r5TX1JsE4hmKU9snleFymadA3VACjl6SRfi9YgBCSjBbfQvR1bs9PRW9yBKw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/plugin-syntax-decorators": "^7.23.3",
-        "babel-import-util": "^2.0.1"
-      }
-    },
     "node_modules/ember-element-helper": {
       "version": "0.8.6",
       "resolved": "https://registry.npmjs.org/ember-element-helper/-/ember-element-helper-0.8.6.tgz",
@@ -27407,7 +27341,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-4.2.0.tgz",
       "integrity": "sha512-BJ48eTEGxD8J7+lofwVmee7xDgNDgpr5dd6+MSu4gk+I6xb35099RMNorXY5hjjwMJEyi/IRR6Yn3M7iJMz8Zw==",
-      "dev": true,
       "dependencies": {
         "@embroider/addon-shim": "^1.8.7",
         "decorator-transforms": "^2.0.0",
@@ -30231,6 +30164,34 @@
         "@ember/test-helpers": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ember-sortable": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/ember-sortable/-/ember-sortable-5.2.3.tgz",
+      "integrity": "sha512-WEU4sxCWhPbgpvDqIN9yw50suyn4kyWQwFPliAcZJgERN/p4WLq9b78HjNL6dORahhlhHikNaeshj6h22mD3FQ==",
+      "dependencies": {
+        "@embroider/addon-shim": "^1.8.9",
+        "@embroider/macros": "^1.16.6",
+        "@glimmer/env": "^0.1.7",
+        "rsvp": "^4.8.5"
+      },
+      "engines": {
+        "node": "14.* || >= 16"
+      },
+      "peerDependencies": {
+        "@ember/test-helpers": "^2.6.0 || >= 3.0.0",
+        "@ember/test-waiters": ">= 3.0.1",
+        "ember-modifier": "^3.2.0 || >= 4.0.0",
+        "ember-source": "^3.28.0 || >= 4.0.0"
+      }
+    },
+    "node_modules/ember-sortable/node_modules/rsvp": {
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+      "engines": {
+        "node": "6.* || >= 7.*"
       }
     },
     "node_modules/ember-source": {

--- a/package.json
+++ b/package.json
@@ -100,7 +100,6 @@
     "ember-data-resources": "^5.0.0",
     "ember-data-table": "^2.1.0",
     "ember-data-types": "5.4.0-alpha.131",
-    "ember-drag-drop": "^1.0.0",
     "ember-feature-flags": "^6.0.0",
     "ember-fetch": "^8.1.2",
     "ember-intl": "^7.0.3",
@@ -172,6 +171,7 @@
   "dependencies": {
     "@curvenote/prosemirror-utils": "^1.0.5",
     "ember-resources": "^7.0.2",
+    "ember-sortable": "^5.2.3",
     "reactiveweb": "^1.3.0",
     "tracked-toolbox": "^2.0.0"
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,7 @@
   },
   "exclude": ["node_modules", "dist"],
   "glint": {
-    "environment": ["ember-loose", "ember-template-imports"]
+    "environment": ["ember-loose", "ember-template-imports"],
+    "checkStandaloneTemplates": false
   }
 }


### PR DESCRIPTION
### Overview
This PR includes the following changes:
- Replace `ember-drag-drop` by `ember-sortable`
- Some slight adjustments to the styling of the meeting agenda table
- Set the deprecated `EXTEND_PROTOTYPES` flag to `false`

### How to test/reproduce
- Start the app
- Ensure the meeting agenda table works as you'd expect + the changes are correctly persisted
- There should be no issues caused by disabling the `EXTEND_PROTOTYPES` flag 

### Challenges/uncertainties
I made some slight css changes to the meeting agenda table, so it might behave slightly different. This is to make the behaviour consistent with the behaviour on RB, and to better align the styles with how `ember-sortable` behaves.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
