### PR TITLE
Use in element to fix rb copy parts

### DIFF
--- a/.changeset/cold-toes-happen.md
+++ b/.changeset/cold-toes-happen.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Fix rb copy parts in ember 5

--- a/app/components/copy-parts/section.gjs
+++ b/app/components/copy-parts/section.gjs
@@ -6,6 +6,14 @@ import { inject as service } from '@ember/service';
 import { concat } from '@ember/helper';
 import update from 'frontend-gelinkt-notuleren/utils/copy-parts-update';
 
+function htmlSafer(text) {
+  return htmlSafe(text);
+}
+
+function getDestinationElement(content) {
+  return document.getElementById(content.replaceId);
+}
+
 export default class Section extends Component {
   @service intl;
   @trackedReset({
@@ -17,7 +25,6 @@ export default class Section extends Component {
     this.args.section.level + 1,
     this.intl,
   );
-
   <template>
     <div class='gn-meeting-copy--section-container'>
       <div class='gn-meeting-copy--structure'>
@@ -25,14 +32,12 @@ export default class Section extends Component {
           {{@section.label}}
         </div>
         <div class='gn-meeting-copy--structure-content'>
-          {{#each this.content as |content|}}
-            {{#if content.isSection}}
+          {{htmlSafe this.content.html}}
+
+          {{#each this.content.sections as |content|}}
+            {{#in-element (getDestinationElement content)}}
               <Section @section={{content}} />
-            {{else}}
-
-              {{htmlSafe content}}
-
-            {{/if}}
+            {{/in-element}}
           {{/each}}
         </div>
       </div>

--- a/app/components/copy-parts/section.gjs
+++ b/app/components/copy-parts/section.gjs
@@ -6,10 +6,6 @@ import { inject as service } from '@ember/service';
 import { concat } from '@ember/helper';
 import update from 'frontend-gelinkt-notuleren/utils/copy-parts-update';
 
-function htmlSafer(text) {
-  return htmlSafe(text);
-}
-
 function getDestinationElement(content) {
   return document.getElementById(content.replaceId);
 }

--- a/app/components/rb-copy-parts.gjs
+++ b/app/components/rb-copy-parts.gjs
@@ -5,6 +5,10 @@ import Section from './copy-parts/section';
 import { inject as service } from '@ember/service';
 import update from 'frontend-gelinkt-notuleren/utils/copy-parts-update';
 
+function getDestinationElement(content) {
+  return document.getElementById(content.replaceId);
+}
+
 export default class DecisionCopyParts extends Component {
   @service intl;
   @trackedReset({
@@ -16,14 +20,11 @@ export default class DecisionCopyParts extends Component {
   <template>
     <div class='au-o-flow--small au-u-3-5'>
       <div class='gn-meeting-copy--section-container'>
-        {{#each this.content as |content|}}
-          {{#if content.isSection}}
+        {{htmlSafe this.content.html}}
+        {{#each this.content.sections as |content|}}
+          {{#in-element (getDestinationElement content)}}
             <Section @section={{content}} />
-          {{else}}
-            <div class='gn-meeting-copy--structure-content'>
-              {{htmlSafe content}}
-            </div>
-          {{/if}}
+          {{/in-element}}
         {{/each}}
       </div>
     </div>

--- a/app/controllers/regulatory-statements/copy.js
+++ b/app/controllers/regulatory-statements/copy.js
@@ -1,0 +1,11 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+
+import { copyStringToClipboard } from 'frontend-gelinkt-notuleren/utils/copy-string-to-clipboard';
+
+export default class RegulatoryAttachmentsCopyController extends Controller {
+  @action
+  async copyToClipboard(text) {
+    await copyStringToClipboard({ html: text });
+  }
+}

--- a/app/templates/regulatory-statements/edit.hbs
+++ b/app/templates/regulatory-statements/edit.hbs
@@ -95,7 +95,7 @@
         role='menuitem'
       >
         <AuIcon @icon='copy' @alignment='left' />
-        {{t 'agendapoint.copy-parts-link'}}
+        {{t 'regulatory-statements.copy-parts-link'}}
       </AuLink>
     </AuDropdown>
     <AuButton

--- a/app/templates/regulatory-statements/edit.hbs
+++ b/app/templates/regulatory-statements/edit.hbs
@@ -95,7 +95,7 @@
         role='menuitem'
       >
         <AuIcon @icon='copy' @alignment='left' />
-        {{t 'regulatory-statements.copy-parts-link'}}
+        {{t 'regulatory-statement.copy-parts-link'}}
       </AuLink>
     </AuDropdown>
     <AuButton

--- a/app/utils/copy-parts-update.js
+++ b/app/utils/copy-parts-update.js
@@ -61,6 +61,5 @@ export default function update(sectionContent, level, intl) {
   let outerHTML = parsed.firstElementChild.outerHTML;
   outerHTML = outerHTML.replace('<html><head></head><body>', '');
   outerHTML = outerHTML.replace('</body></html>', '');
-  const outerHTMLSplited = outerHTML.split('say-rb-copy-replace-by');
   return { html: outerHTML, sections: mappedSections };
 }

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -618,6 +618,7 @@ required-field:
 regulatory-statement:
   page-title: Regulatory statement
   history: History
+  copy-parts-link: Copy regulatory statement parts
 
 signature-confirmation:
   modal-title: 'Confirm signing of '

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -622,6 +622,7 @@ required-field:
 regulatory-statement:
   page-title: Reglementaire bijlage
   history: Historiek
+  copy-parts-link: Kopieer reglementaire bijlage en onderdelen
 
 signature-confirmation:
   modal-title: 'Bevestig ondertekenen van '


### PR DESCRIPTION
### Overview
Rb copy parts was working by accident on ember 4 and upgrading to ember 5 uncovered that some asumptions I made were plain wrong. This PR fixes all the faulty logic and also a missing translation I discovered on the demo

##### connected issues and PRs:
Didn't find it will link later


### Setup
None

### How to test/reproduce
Check that rb still works as expected in ember 5

### Challenges/uncertainties
none



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
