### PR TITLE
Fix issues related to decision article uri generation

### DIFF
--- a/.changeset/funny-roses-give.md
+++ b/.changeset/funny-roses-give.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Update `@lblod/ember-rdfa-editor-lblod-plugins` to version [26.4.1](https://github.com/lblod/ember-rdfa-editor-lblod-plugins/releases/tag/v26.4.1)

--- a/.changeset/honest-mice-travel.md
+++ b/.changeset/honest-mice-travel.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Ensure both the 'Insert traffic measure' and 'Insert article block' functionalities insert decision articles with correctly defined URIs (not placeholder URIs)

--- a/app/services/editor/agendapoint.js
+++ b/app/services/editor/agendapoint.js
@@ -172,7 +172,7 @@ export default class AgendapointEditorService extends Service {
       roadsignRegulation: {
         endpoint: ENV.mowRegistryEndpoint,
         imageBaseUrl: ENV.roadsignImageBaseUrl,
-        articleUriGenrator: articleUriGenerator,
+        articleUriGenerator,
       },
       besluitType: {
         endpoint: 'https://centrale-vindplaats.lblod.info/sparql',

--- a/app/services/editor/agendapoint.js
+++ b/app/services/editor/agendapoint.js
@@ -129,6 +129,8 @@ export default class AgendapointEditorService extends Service {
   get config() {
     const classificatie = this.currentSession.classificatie;
     const municipality = this.currentSession.group;
+    const articleUriGenerator = () =>
+      `http://data.lblod.info/artikels/${uuidv4()}`;
     return {
       date: {
         formats: [
@@ -170,6 +172,7 @@ export default class AgendapointEditorService extends Service {
       roadsignRegulation: {
         endpoint: ENV.mowRegistryEndpoint,
         imageBaseUrl: ENV.roadsignImageBaseUrl,
+        articleUriGenrator: articleUriGenerator,
       },
       besluitType: {
         endpoint: 'https://centrale-vindplaats.lblod.info/sparql',
@@ -216,7 +219,10 @@ export default class AgendapointEditorService extends Service {
         },
       },
       insertArticle: {
-        uriGenerator: () => `http://data.lblod.info/artikels/${uuidv4()}`,
+        uriGenerator: articleUriGenerator,
+      },
+      decisionPlugin: {
+        articleUriGenerator,
       },
       ...this.adminUnitConfig,
     };

--- a/app/templates/agendapoints/edit.hbs
+++ b/app/templates/agendapoints/edit.hbs
@@ -174,7 +174,10 @@
     </:sidebarCollapsible>
     <:sidebar>
       <this.StructureControlCard @controller={{this.controller}} />
-      <DecisionPlugin::DecisionPluginCard @controller={{this.controller}} />
+      <DecisionPlugin::DecisionPluginCard
+        @controller={{this.controller}}
+        @options={{this.config.decisionPlugin}}
+      />
       <CitationPlugin::CitationCard
         @controller={{this.controller}}
         @config={{this.config.citation}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "@lblod/ember-environment-banner": "^0.6.0",
         "@lblod/ember-mock-login": "^0.10.0",
         "@lblod/ember-rdfa-editor": "10.11.2",
-        "@lblod/ember-rdfa-editor-lblod-plugins": "26.4.0",
+        "@lblod/ember-rdfa-editor-lblod-plugins": "26.4.0-dev.f82b13a8fe713c47fb9002f9d1d7c7c75d9da643",
         "@lblod/template-uuid-instantiator": "^1.0.3",
         "@nullvoxpopuli/ember-composable-helpers": "^5.2.6",
         "@release-it-plugins/lerna-changelog": "^6.0.0",
@@ -7268,9 +7268,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor-lblod-plugins": {
-      "version": "26.4.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-26.4.0.tgz",
-      "integrity": "sha512-w1SWzGPDf+h1wgwXnBjhxLlqMtWJbgMBZlvyQPA1F+KTekw1fa/lnA7okdBjGFMeZV06C2j/zqFk2pOKt7xPdA==",
+      "version": "26.4.0-dev.f82b13a8fe713c47fb9002f9d1d7c7c75d9da643",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-26.4.0-dev.f82b13a8fe713c47fb9002f9d1d7c7c75d9da643.tgz",
+      "integrity": "sha512-R1TpylIu7KPS0R6k64LteeBPop2TBMd7ziqN5MiwMJOO4jIxyD2BGfnXCilwe6skP5t52BaFhBu3RapMZaNN1w==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.25.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "@lblod/ember-environment-banner": "^0.6.0",
         "@lblod/ember-mock-login": "^0.10.0",
         "@lblod/ember-rdfa-editor": "10.11.2",
-        "@lblod/ember-rdfa-editor-lblod-plugins": "26.4.0-dev.f82b13a8fe713c47fb9002f9d1d7c7c75d9da643",
+        "@lblod/ember-rdfa-editor-lblod-plugins": "26.4.1",
         "@lblod/template-uuid-instantiator": "^1.0.3",
         "@nullvoxpopuli/ember-composable-helpers": "^5.2.6",
         "@release-it-plugins/lerna-changelog": "^6.0.0",
@@ -7268,9 +7268,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor-lblod-plugins": {
-      "version": "26.4.0-dev.f82b13a8fe713c47fb9002f9d1d7c7c75d9da643",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-26.4.0-dev.f82b13a8fe713c47fb9002f9d1d7c7c75d9da643.tgz",
-      "integrity": "sha512-R1TpylIu7KPS0R6k64LteeBPop2TBMd7ziqN5MiwMJOO4jIxyD2BGfnXCilwe6skP5t52BaFhBu3RapMZaNN1w==",
+      "version": "26.4.1",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-26.4.1.tgz",
+      "integrity": "sha512-nleTLgojAPnRWGS3jKifMP3Pe8Olwceig9OwfSG7Obk5hMYoHO3WH0EbjBzoifGn08ui3XKFp6GNM0K2wNB3+g==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.25.2",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@lblod/ember-environment-banner": "^0.6.0",
     "@lblod/ember-mock-login": "^0.10.0",
     "@lblod/ember-rdfa-editor": "10.11.2",
-    "@lblod/ember-rdfa-editor-lblod-plugins": "26.4.0-dev.f82b13a8fe713c47fb9002f9d1d7c7c75d9da643",
+    "@lblod/ember-rdfa-editor-lblod-plugins": "26.4.1",
     "@lblod/template-uuid-instantiator": "^1.0.3",
     "@nullvoxpopuli/ember-composable-helpers": "^5.2.6",
     "@release-it-plugins/lerna-changelog": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@lblod/ember-environment-banner": "^0.6.0",
     "@lblod/ember-mock-login": "^0.10.0",
     "@lblod/ember-rdfa-editor": "10.11.2",
-    "@lblod/ember-rdfa-editor-lblod-plugins": "26.4.0",
+    "@lblod/ember-rdfa-editor-lblod-plugins": "26.4.0-dev.f82b13a8fe713c47fb9002f9d1d7c7c75d9da643",
     "@lblod/template-uuid-instantiator": "^1.0.3",
     "@nullvoxpopuli/ember-composable-helpers": "^5.2.6",
     "@release-it-plugins/lerna-changelog": "^6.0.0",


### PR DESCRIPTION
### Overview
This PR ensures that both the 'Insert traffic measure' and 'Insert article block' insert decision articles with correctly defined URIs (not placeholder URIs)

##### connected issues and PRs:
https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/533

### How to test/reproduce
- Start the app
- Open/create an empty decision (with type 'reglement')
- Insert an article block and mobility measure
- Ensure both inserted articles have correctly defined URIs

### Challenges/uncertainties
There's a typo in the config of roadsign-regulation plugin, will fix this in a PR on the editor-plugins...

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
