### PR TITLE
GN-5228: fix selection issues when moving articles

### DIFF
--- a/.changeset/green-tips-allow.md
+++ b/.changeset/green-tips-allow.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Update `@lblod/ember-rdfa-editor` to version [10.11.2](https://github.com/lblod/ember-rdfa-editor/releases/tag/v10.11.2). This version fixes issues related to the preservation of selections.

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "@lblod/ember-acmidm-login": "^2.1.0",
         "@lblod/ember-environment-banner": "^0.6.0",
         "@lblod/ember-mock-login": "^0.10.0",
-        "@lblod/ember-rdfa-editor": "10.11.1",
+        "@lblod/ember-rdfa-editor": "10.11.1-dev.29b60e1d46269e45cac64dc08cc2b1162e52c340",
         "@lblod/ember-rdfa-editor-lblod-plugins": "26.4.0",
         "@lblod/template-uuid-instantiator": "^1.0.3",
         "@nullvoxpopuli/ember-composable-helpers": "^5.2.6",
@@ -7181,9 +7181,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor": {
-      "version": "10.11.1",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-10.11.1.tgz",
-      "integrity": "sha512-aVhimH5M9TTd6j7posAMmEOI3cXtMXpErBDjrtKbgPnQZLSRYeVzr6SQgJbnh09fFiXkKC/SxyqSsZSpu8/xIQ==",
+      "version": "10.11.1-dev.29b60e1d46269e45cac64dc08cc2b1162e52c340",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-10.11.1-dev.29b60e1d46269e45cac64dc08cc2b1162e52c340.tgz",
+      "integrity": "sha512-9N5OtiaLf72uNlqLkVahNGZx8d776PaO1fpYVyqApwbvgjeo1WtaX5vn2pqlbw3DYti/pkOaqYjnBR/77RzVgA==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.25.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "@lblod/ember-acmidm-login": "^2.1.0",
         "@lblod/ember-environment-banner": "^0.6.0",
         "@lblod/ember-mock-login": "^0.10.0",
-        "@lblod/ember-rdfa-editor": "10.11.1-dev.29b60e1d46269e45cac64dc08cc2b1162e52c340",
+        "@lblod/ember-rdfa-editor": "10.11.2",
         "@lblod/ember-rdfa-editor-lblod-plugins": "26.4.0",
         "@lblod/template-uuid-instantiator": "^1.0.3",
         "@nullvoxpopuli/ember-composable-helpers": "^5.2.6",
@@ -7181,9 +7181,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor": {
-      "version": "10.11.1-dev.29b60e1d46269e45cac64dc08cc2b1162e52c340",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-10.11.1-dev.29b60e1d46269e45cac64dc08cc2b1162e52c340.tgz",
-      "integrity": "sha512-9N5OtiaLf72uNlqLkVahNGZx8d776PaO1fpYVyqApwbvgjeo1WtaX5vn2pqlbw3DYti/pkOaqYjnBR/77RzVgA==",
+      "version": "10.11.2",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-10.11.2.tgz",
+      "integrity": "sha512-oEJhLW/8X2achrGU8X1uOxRVbu2akMvva5ttwnpF+0yU2yiEO5cN8lqpHklTrC+RBJAFu6u831vbUc02U0LTbA==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.25.2",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@lblod/ember-acmidm-login": "^2.1.0",
     "@lblod/ember-environment-banner": "^0.6.0",
     "@lblod/ember-mock-login": "^0.10.0",
-    "@lblod/ember-rdfa-editor": "10.11.1-dev.29b60e1d46269e45cac64dc08cc2b1162e52c340",
+    "@lblod/ember-rdfa-editor": "10.11.2",
     "@lblod/ember-rdfa-editor-lblod-plugins": "26.4.0",
     "@lblod/template-uuid-instantiator": "^1.0.3",
     "@nullvoxpopuli/ember-composable-helpers": "^5.2.6",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@lblod/ember-acmidm-login": "^2.1.0",
     "@lblod/ember-environment-banner": "^0.6.0",
     "@lblod/ember-mock-login": "^0.10.0",
-    "@lblod/ember-rdfa-editor": "10.11.1",
+    "@lblod/ember-rdfa-editor": "10.11.1-dev.29b60e1d46269e45cac64dc08cc2b1162e52c340",
     "@lblod/ember-rdfa-editor-lblod-plugins": "26.4.0",
     "@lblod/template-uuid-instantiator": "^1.0.3",
     "@nullvoxpopuli/ember-composable-helpers": "^5.2.6",


### PR DESCRIPTION
### Overview
This PR includes a (dev-commit) editor update which fixes issues regarding the preservation of selections when having the `defaultAttributeValueGeneration` and/or `listTrackingPlugin` plugins enabled.
This fix also ensures that moving articles containg lists (e.g. mobility measures) can be done without issues.

##### connected issues and PRs:
https://github.com/lblod/ember-rdfa-editor/pull/1247
[GN-5228](https://binnenland.atlassian.net/browse/GN-5228?atlOrigin=eyJpIjoiNTA5NzAyNWIyZGEwNDlmMjg0NDQ0M2U3NTZmZjcyNjYiLCJwIjoiaiJ9)


### How to test/reproduce
Check-out https://github.com/lblod/ember-rdfa-editor/pull/1247

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
