### PR TITLE
Update `@lblod/ember-rdfa-editor-lblod-plugins` to version 26.5.0

### DIFF
--- a/.changeset/nasty-zebras-rhyme.md
+++ b/.changeset/nasty-zebras-rhyme.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Update `@lblod/ember-rdfa-editor-lblod-plugins` to version [26.5.0](https://github.com/lblod/ember-rdfa-editor-lblod-plugins/releases/tag/v26.5.0)

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "@lblod/ember-environment-banner": "^0.6.0",
         "@lblod/ember-mock-login": "^0.10.0",
         "@lblod/ember-rdfa-editor": "10.11.2",
-        "@lblod/ember-rdfa-editor-lblod-plugins": "26.4.1",
+        "@lblod/ember-rdfa-editor-lblod-plugins": "26.5.0",
         "@lblod/template-uuid-instantiator": "^1.0.3",
         "@nullvoxpopuli/ember-composable-helpers": "^5.2.6",
         "@release-it-plugins/lerna-changelog": "^6.0.0",
@@ -7245,9 +7245,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor-lblod-plugins": {
-      "version": "26.4.1",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-26.4.1.tgz",
-      "integrity": "sha512-nleTLgojAPnRWGS3jKifMP3Pe8Olwceig9OwfSG7Obk5hMYoHO3WH0EbjBzoifGn08ui3XKFp6GNM0K2wNB3+g==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-26.5.0.tgz",
+      "integrity": "sha512-DsegI5wBzol1pxlbDaJvxUz2VNlt5pnRnATQeytoVbLOvbOUP+n9/iigIb1kT/5hg18nH42WteAb7hvTtIDTqg==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.25.2",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@lblod/ember-environment-banner": "^0.6.0",
     "@lblod/ember-mock-login": "^0.10.0",
     "@lblod/ember-rdfa-editor": "10.11.2",
-    "@lblod/ember-rdfa-editor-lblod-plugins": "26.4.1",
+    "@lblod/ember-rdfa-editor-lblod-plugins": "26.5.0",
     "@lblod/template-uuid-instantiator": "^1.0.3",
     "@nullvoxpopuli/ember-composable-helpers": "^5.2.6",
     "@release-it-plugins/lerna-changelog": "^6.0.0",


### PR DESCRIPTION
### Overview
Updates `@lblod/ember-rdfa-editor-lblod-plugins` to version [26.5.0](https://github.com/lblod/ember-rdfa-editor-lblod-plugins/releases/tag/v26.5.0)

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
