### PR TITLE
GN-5480: load editor styles before app styles

### DIFF
--- a/.changeset/friendly-dots-drop.md
+++ b/.changeset/friendly-dots-drop.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Styling: ensure editor styles are loaded before app styles

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -19,19 +19,10 @@
 // EMBER-APPUNIVERSUM
 @import '@appuniversum/ember-appuniversum/styles';
 
-// PROJECT COMPONENTS > @TODO: refactor in ember-appuniversum where possible
-@import 'project/c-app-chrome';
-@import 'project/c-meeting-chrome';
-@import 'project/c-rdfa-editor';
-@import 'project/c-onboarding';
-@import 'project/c-editor-preview';
-@import 'project/c-template';
-@import 'project/c-environment-banner';
-@import 'project/c-inauguration-meeting-synchronization';
-@import 'project/c-sortable';
+// EDITOR
+@import '@lblod/ember-rdfa-editor';
 
 // PLUGINS
-@import '@lblod/ember-rdfa-editor';
 @import 'citaten-plugin';
 @import 'date-plugin';
 @import 'variable-plugin';
@@ -44,6 +35,17 @@
 @import 'location-plugin';
 @import 'structure-plugin';
 @import 'mandatee-table-plugin';
+
+// PROJECT COMPONENTS > @TODO: refactor in ember-appuniversum where possible
+@import 'project/c-app-chrome';
+@import 'project/c-meeting-chrome';
+@import 'project/c-rdfa-editor';
+@import 'project/c-onboarding';
+@import 'project/c-editor-preview';
+@import 'project/c-template';
+@import 'project/c-environment-banner';
+@import 'project/c-inauguration-meeting-synchronization';
+@import 'project/c-sortable';
 
 // give treatment (behandeling) content and the copy-parts content the same style as other say-documents
 .c-template-content--treatment {


### PR DESCRIPTION
### Overview
This PR ensures that the editor styles are loaded before the app styles. This ensures that the app styles take priority over the styles of the appuniversum and editor packages.

##### connected issues and PRs:
[GN-5480](https://binnenland.atlassian.net/browse/GN-5480)

### How to test/reproduce
- Start the app
- Open a meeting page
- Ensure the styling of the meeting page is as expected
- Ensure the styles of an editor page have not changed

### Challenges/uncertainties
Unsure why we were loading the editor styles after the app styles, but this approach seems safer to me.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
