### PR TITLE
GN-5221: introduce application-wide `lang` query-param

### DIFF
--- a/.changeset/empty-pens-drum.md
+++ b/.changeset/empty-pens-drum.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': minor
+---
+
+Addition of an application-wide `lang` query parameter which controls the display language of the application. By default, the language of the application is set to `nl-BE`, regardless of the user navigator languages/system locale.

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -5,7 +5,11 @@ import { decentLocaleMatch } from '../utils/intl';
 
 const featureFlagRegex = /^feature\[(.+)\]$/;
 
-const DEFAULT_LOCALE = 'nl-BE';
+const DEFAULT_LOCALE =
+  !ENV.defaultLanguage || ENV.defaultLanguage.startsWith('{{')
+    ? 'nl-BE'
+    : ENV.defaultLanguage;
+
 export default class ApplicationRoute extends Route {
   @service currentSession;
   @service features;

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -5,6 +5,7 @@ import { decentLocaleMatch } from '../utils/intl';
 
 const featureFlagRegex = /^feature\[(.+)\]$/;
 
+const DEFAULT_LOCALE = 'nl-BE';
 export default class ApplicationRoute extends Route {
   @service currentSession;
   @service features;
@@ -12,17 +13,26 @@ export default class ApplicationRoute extends Route {
   @service plausible;
   @service intl;
 
+  queryParams = {
+    lang: {
+      refreshModel: true,
+    },
+  };
+
   async beforeModel(transition) {
-    const userLocales = decentLocaleMatch(
-      navigator.languages,
-      this.intl.locales,
-      'nl-BE',
-    );
-    this.intl.setLocale(userLocales);
     this.updateFeatureFlags(transition.to.queryParams);
     await this.startAnalytics();
     await this.session.setup();
     return this.loadCurrentSession();
+  }
+
+  model(params) {
+    const matchedLocales = decentLocaleMatch(
+      params.lang ? [params.lang] : [],
+      this.intl.locales,
+      DEFAULT_LOCALE,
+    );
+    this.intl.setLocale(matchedLocales);
   }
 
   async startAnalytics() {

--- a/config/environment.js
+++ b/config/environment.js
@@ -5,6 +5,7 @@ module.exports = function (environment) {
     environment,
     rootURL: '/',
     locationType: 'history',
+    defaultLanguage: '{{DEFAULT_LANGUAGE}}',
     regulatoryStatementEndpoint: '{{REGULATORY_STATEMENT_ENDPOINT}}',
     regulatoryStatementFileEndpoint: '{{REGULATORY_STATEMENT_FILE_ENDPOINT}}',
     mowRegistryEndpoint: '{{MOW_REGISTRY_ENDPOINT}}',
@@ -77,6 +78,7 @@ module.exports = function (environment) {
   if (environment === 'development') {
     require('dotenv').config();
     ENV.environmentName = 'LOCAL';
+    ENV.defaultLanguage = 'en-us';
     ENV.manual.baseUrl =
       'https://abb-vlaanderen.gitbook.io/gelinkt-notuleren-handleiding/';
     ENV.manual.notuleren = '#notuleren';


### PR DESCRIPTION
### Overview
This PR introduces an application-wide `lang` query parameter which controls the display language of the application. By default, the language of the application is set to `nl-BE`, regardless of the user navigator languages/system locale.

##### connected issues and PRs:
[GN-5221](https://binnenland.atlassian.net/browse/GN-5221?atlOrigin=eyJpIjoiZjgyZWMwNWE4Y2ZkNGY1Zjk1MDkzMzlmZGMwM2VkNzYiLCJwIjoiaiJ9)

### How to test/reproduce
- Start the app
- Ensure the display language is dutch
- Add a `lang` query-param with e.g. `en-US`/`en-UK`
- Ensure the display language is now english
- The language should be persisted across reloads and route transitions
- Setting an unsupported language results in a dutch display language

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
