### PR TITLE
Remove standard-template service from new AP controller

### DIFF
--- a/.changeset/wicked-vans-unite.md
+++ b/.changeset/wicked-vans-unite.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': minor
+---
+
+Remove standard-template service from new agendapoint creation as the templates are now all coming from RB

--- a/app/components/document-creator/modal.gts
+++ b/app/components/document-creator/modal.gts
@@ -85,7 +85,7 @@ export default class DocumentCreatorModal extends Component<Sig> {
     await template.loadBody?.();
     const templateDecisionType =
       this.agendapointEditor.extractFromDocumentHeadlessly(
-        template.body,
+        template.body ?? '',
         (state) =>
           this.decisionTypes &&
           checkBesluitTypeInstance(state, this.decisionTypes),

--- a/app/components/document-creator/template-picker.gts
+++ b/app/components/document-creator/template-picker.gts
@@ -146,13 +146,9 @@ export default class TemplatePicker extends Component<Sig> {
   };
 
   isFavouriteTemplate = (template: PreviewableTemplate) =>
-    // TODO the standard templates don't have URIs, so treat them as permanent favourites. Remove
-    // this when moving these templates to RB
-    !template.original.uri ||
-    (this.currentSession.preferences?.favouriteTemplates?.includes(
+    this.currentSession.preferences?.favouriteTemplates?.includes(
       template.original.uri,
-    ) ??
-      false);
+    ) ?? false;
   toggleFavouriteTemplate = (template: PreviewableTemplate) => {
     const preferences = this.currentSession.preferences;
     if (!preferences || !preferences.favouriteTemplates) {

--- a/app/config/environment.d.ts
+++ b/app/config/environment.d.ts
@@ -1,0 +1,5 @@
+import type EnvFunc from '../../config/environment';
+
+export declare const Env: ReturnType<typeof EnvFunc>;
+export type Environment = typeof Env;
+export default Env;

--- a/app/controllers/inbox/agendapoints/new.js
+++ b/app/controllers/inbox/agendapoints/new.js
@@ -6,7 +6,6 @@ import { EDITOR_FOLDERS } from 'frontend-gelinkt-notuleren/config/constants';
 export default class InboxAgendapointsNewController extends Controller {
   @service router;
   @service plausible;
-  @service standardTemplate;
   @service templateFetcher;
   @service('editor/agendapoint') agendapointEditor;
 
@@ -34,28 +33,8 @@ export default class InboxAgendapointsNewController extends Controller {
       favourites,
       abortSignal,
     });
-    if (pagination.pageNumber === 0) {
-      const standardTemplatesPromise = this.standardTemplate.fetchTemplates
-        .perform()
-        .then((standardTemplates) => {
-          return this.standardTemplate.templatesForContext(standardTemplates, [
-            'http://data.vlaanderen.be/ns/besluit#BehandelingVanAgendapunt',
-          ]);
-        });
-      // TODO this means there are actually more results on the first page, but we plan to remove
-      // the 'standard' templates anyway
-      const [results, totalCount] = await Promise.all([
-        standardTemplatesPromise,
-        dynamicTemplatesPromise,
-      ]).then(([standard, [dynamic, dynamicCount]]) => [
-        standard.concat(dynamic),
-        dynamicCount + standard.length,
-      ]);
-      return { results, totalCount };
-    } else {
-      const [results, totalCount] = await dynamicTemplatesPromise;
-      return { results, totalCount };
-    }
+    const [results, totalCount] = await dynamicTemplatesPromise;
+    return { results, totalCount };
   };
 
   @action

--- a/app/services/document-service.ts
+++ b/app/services/document-service.ts
@@ -171,11 +171,11 @@ export default class DocumentService extends Service {
        */
       if (template.loadBody) {
         await template.loadBody();
-        const trimmedHtml = template.body.replace(/>\s+</g, '><');
+        const trimmedHtml = template.body?.replace(/>\s+</g, '><') ?? '';
         //If the template comes from RB we instantiate it with the new library
         return templateUuidInstantiator(trimmedHtml);
       } else {
-        const trimmedHtml = template.body.replace(/>\s+</g, '><');
+        const trimmedHtml = template.body?.replace(/>\s+</g, '><') ?? '';
         // If it's a built=in template, we apply both instantiate functions
         return instantiateUuids(templateUuidInstantiator(trimmedHtml));
       }

--- a/app/services/editor/agendapoint.ts
+++ b/app/services/editor/agendapoint.ts
@@ -80,8 +80,7 @@ import {
 import { highlight } from '@lblod/ember-rdfa-editor/plugins/highlight/marks/highlight';
 import { color } from '@lblod/ember-rdfa-editor/plugins/color/marks/color';
 
-// @ts-expect-error no types for this
-import ENV_OBJ from 'frontend-gelinkt-notuleren/config/environment';
+import ENV from 'frontend-gelinkt-notuleren/config/environment';
 import {
   regulatoryStatementNode,
   regulatoryStatementNodeView,
@@ -129,9 +128,6 @@ import type CurrentSessionService from 'frontend-gelinkt-notuleren/services/curr
 import configurationPerAdminUnit from '../../config/configuration-per-admin-unit';
 import type BestuurseenheidClassificatieCodeModel from 'frontend-gelinkt-notuleren/models/bestuurseenheid-classificatie-code';
 import type BestuurseenheidModel from 'frontend-gelinkt-notuleren/models/bestuurseenheid';
-
-// Type hack
-const ENV = ENV_OBJ as Record<string, string>;
 
 export default class AgendapointEditorService extends Service {
   @service declare intl: IntlService;


### PR DESCRIPTION
### Overview
Removes the hacky approach to including standard templates by moving those templates to RB.

Fixes the problems with favourites and standard templates by making them no longer relevant.

For now the standard template service still exists as it is used by the standard template plugin.

##### connected issues and PRs:
Part of [binnenland.atlassian.net/browse/GN-5418](https://binnenland.atlassian.net/browse/GN-5418)
Built on https://github.com/lblod/frontend-gelinkt-notuleren/pull/838
Requires https://github.com/lblod/app-reglementaire-bijlage/pull/94
Also Requires (for favourites) https://github.com/lblod/app-gelinkt-notuleren/pull/228

### Setup
For favourites to work, needs to be pointing to a GN [with the PR changes](https://github.com/lblod/app-gelinkt-notuleren/pull/228).
For standard templates to appear, needs to be pointing to [an RB with the moved templates](https://github.com/lblod/app-reglementaire-bijlage/pull/94)

### How to test/reproduce
The 'standard templates' should appear as normal templates, and all the functionality (e.g. favourites) should work as expected.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
