### PR TITLE
feat: add ability to select default lang based on env var

### DIFF
--- a/.changeset/long-toes-burn.md
+++ b/.changeset/long-toes-burn.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Allow language based on process env in dev modew

--- a/config/environment.js
+++ b/config/environment.js
@@ -78,7 +78,7 @@ module.exports = function (environment) {
   if (environment === 'development') {
     require('dotenv').config();
     ENV.environmentName = 'LOCAL';
-    ENV.defaultLanguage = 'en-us';
+    ENV.defaultLanguage = process.env.DEFAULT_LANGUAGE ?? 'nl-be';
     ENV.manual.baseUrl =
       'https://abb-vlaanderen.gitbook.io/gelinkt-notuleren-handleiding/';
     ENV.manual.notuleren = '#notuleren';


### PR DESCRIPTION
### Overview
<!-- high level overview of changes (not just "implement ticket") + *why* + design document, special notes like ticket partially implemented etc. -->

Those of us who speak dutch should always run GN in dutch to catch typos and mistakes as early as possible, as dutch is the "official" front-facing language. 

This pr does 2 things:
- exposes the language select to the process environment
- sets the default dev language back to dutch

Because we use the `dotenv` library, devs can now easily add `DEFAULT_LANGUAGE=en-us` to their `.env` file to set-and-forget the language to english.

I've reverted the default back to dutch for those rare occasions we get a visiting reviewer like niels or others. The baseline review experience should be as close to prod as possible, which currently chooses dutch regardless of browser locale. 

I hope that's a decent compromise @lagartoverde @piemonkey 
##### connected issues and PRs:
<!-- links to connected jira tickets -->
<!-- Link to PRs that are related (and in what way) -->


### Setup
<!-- PR dependencies -->
<!-- override snippets -->

### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->



### Checks PR readiness

- [x] changelog
- [x] npm lint
- [x] no new deprecations
