### PR TITLE
fix(intl): fix internationalization of unassigned-mandatees-banner component

### DIFF
--- a/.changeset/tiny-waves-wash.md
+++ b/.changeset/tiny-waves-wash.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Add internationalization to title of `UnassignedMandateesBanner` component

--- a/app/components/participation-list.gts
+++ b/app/components/participation-list.gts
@@ -238,7 +238,7 @@ class UnassignedMandateesBanner extends Component<UnassignedMandateesBannerSigna
     {{#if this.shouldShow}}
       <AuAlert
         ...attributes
-        @title='Warning'
+        @title={{t 'participation-list.unassigned-mandatees-warning.title'}}
         @skin='warning'
         @size='small'
         @icon='alert-triangle'

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -532,6 +532,7 @@ participation-list:
   open-modal-button: Manage attendees at the start of the session
   period-start: 'period'
   unassigned-mandatees-warning:
+    title: Warning
     first-line: 'The following mandatees have not yet been assigned as either attendee or absentee:'
     second-line: Please assign these mandatees as either attendee or absentee.
 

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -541,6 +541,7 @@ participation-list:
   open-modal-button: Beheer aanwezigen bij start van de zitting
   period-start: 'periode'
   unassigned-mandatees-warning:
+    title: Waarschuwing
     first-line: 'De hieronder vermelde mandatarissen zijn nog niet toegewezen als zijnde aanwezig of afwezig: '
     second-line: Gelieve deze mandatarissen toe te wijzen als aanwezig of afwezig.
 


### PR DESCRIPTION
### Overview
This PR simply converts the non-translated title to a translated one.