### PR TITLE
feat(meeting-navigation): hide green checkmark icons

### DIFF
--- a/.changeset/hungry-owls-rule.md
+++ b/.changeset/hungry-owls-rule.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Meeting navigation card: do not display green checkmark icons when no issues are found

--- a/app/components/meeting-form.gts
+++ b/app/components/meeting-form.gts
@@ -1063,23 +1063,18 @@ const NavigationEntry: TOC<NavigationEntrySignature> = <template>
     <span>
       {{yield}}
     </span>
-    <WithTooltip
-      @tooltip={{if @ok @successMessage @warningMessage}}
-      @placement='bottom-start'
-    >
-      {{#if @ok}}
-        <AuBadge
-          class='meeting-validation-card__icon au-u-margin-tiny'
-          @skin='success'
-          @icon='check'
-        />
-      {{else}}
+    {{#unless @ok}}
+      <WithTooltip
+        @tooltip={{if @ok @successMessage @warningMessage}}
+        @placement='bottom-start'
+      >
         <AuBadge
           class='meeting-validation-card__icon au-u-margin-tiny'
           @skin='warning'
           @icon='alert-triangle'
         />
-      {{/if}}
-    </WithTooltip>
+      </WithTooltip>
+    {{/unless}}
+
   </AuLinkExternal>
 </template>;


### PR DESCRIPTION
### Overview
Meeting navigation:
this PR removes the green checkmark icons from sections where no problems were found/no validation has been implemented.

### How to test/reproduce
- Start the app
- Open a meeting
- Meeting sections that do not have any validation issues, no longer have a green checkmark displayed next to them

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
