### PR TITLE
POC of shacl-validation on save

### DIFF
--- a/app/controllers/agendapoints/edit.js
+++ b/app/controllers/agendapoints/edit.js
@@ -14,6 +14,115 @@ import { getActiveEditableNode } from '@lblod/ember-rdfa-editor/plugins/_private
 import SnippetInsertRdfaComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/snippet-plugin/snippet-insert-rdfa';
 import { fixArticleConnections } from '../../utils/fix-article-connections';
 import { modifier } from 'ember-modifier';
+import factory from '@rdfjs/dataset';
+import SHACLValidator from 'rdf-validate-shacl';
+import { Parser as ParserN3 } from 'n3';
+import { RdfaParser } from 'rdfa-streaming-parser';
+
+const besluitShape = `
+@prefix sh:      <http://www.w3.org/ns/shacl#> .
+@prefix qb:      <http://purl.org/linked-data/cube#> .
+@prefix lblodBesluit:	<http://lblod.data.gift/vocabularies/besluit/> .
+<https://data.vlaanderen.be/shacl/besluit-publicatie#BesluitShape>
+	a sh:NodeShape ;
+	sh:targetClass <http://data.vlaanderen.be/ns/besluit#Besluit> ;
+	sh:property [
+		sh:name "beschrijving" ;
+		sh:description "Een beknopte beschrijving van het besluit." ;
+		sh:path <http://data.europa.eu/eli/ontology#description> ;
+		sh:datatype <http://www.w3.org/2001/XMLSchema#string> ;
+        sh:minCount 0 ;
+		sh:maxCount 1 ;
+    sh:resultMessage "De besluit moet maximaal één beschrijving hebben"
+	] ;
+    sh:property [
+		sh:name "inhoud" ;
+		sh:description "De beschrijving van de beoogde rechtsgevolgen, het zogenaamde beschikkend gedeelte." ;
+		sh:path <http://www.w3.org/ns/prov#value> ;
+		sh:datatype <http://www.w3.org/2001/XMLSchema#string> ;
+		sh:minCount 1 ;
+		sh:maxCount 1 ;
+    sh:resultMessage "De beslissing moet een artikelcontainer hebben";
+	] ;
+	sh:property [
+		sh:name "citeeropschrift" ;
+		sh:description "De beknopte titel of officiële korte naam van een decreet, wet, besluit... Deze wordt officieel vastgelegd. Deze benaming wordt in de praktijk gebruikt om naar de rechtsgrond te verwijzen." ;
+		sh:path <http://data.europa.eu/eli/ontology#title_short> ;
+		sh:datatype <http://www.w3.org/2001/XMLSchema#string> ;
+        sh:minCount 0 ;
+		sh:maxCount 1 ;
+    sh:resultMessage "De beslissing mag niet meer dan één officiële titel hebben";
+	] ;
+    sh:property [
+		sh:name "titel" ;
+		sh:description "Titel van de legale verschijningsvorm." ;
+		sh:path <http://data.europa.eu/eli/ontology#title> ;
+		sh:datatype <http://www.w3.org/2001/XMLSchema#string> ;
+		sh:minCount 1 ;
+    sh:resultMessage "De besluit moet minstens één titel hebben";
+	] ;
+	sh:property [
+		sh:name "taal" ;
+		sh:description "De taal van de verschijningsvorm." ;
+		sh:path <http://data.europa.eu/eli/ontology#language> ;
+		sh:class <http://www.w3.org/2004/02/skos/core#Concept> ;
+		sh:minCount 1 ;
+		sh:maxCount 1 ;
+		qb:codeList <http://publications.europa.eu/mdr/authority/language/index.html> ;
+    sh:resultMessage "De besluit moet een geldige taal hebben"
+	] ;
+    sh:property [
+		sh:name "heeftDeel" ;
+		sh:description "Duidt een artikel aan van dit besluit." ;
+		sh:path <http://data.europa.eu/eli/ontology#has_part> ;
+		sh:class <http://data.vlaanderen.be/ns/besluit#Artikel> ;
+		sh:minCount 0 ;
+    sh:resultMessage "De artikelen moeten het juiste type hebben"
+	] ;
+    sh:property [
+		sh:name "citeert" ;
+		sh:description "Een citatie in de wettelijke tekst. Dit omvat zowel woordelijke citaten als citaten in verwijzingen." ;
+		sh:path <http://data.europa.eu/eli/ontology#cites> ;
+		sh:class <http://data.europa.eu/eli/ontology#LegalExpression> ;
+    sh:minCount 0 ;
+    sh:resultMessage "De citatie moeten het juiste type hebben"
+	] ;
+    sh:property [
+		sh:name "motivering" ;
+		sh:description "Beschrijving van de juridische en feitelijke motivering achter de beslissing die wordt uitgedrukt in het besluit." ;
+		sh:path <http://data.vlaanderen.be/ns/besluit#motivering> ;
+		sh:datatype <http://www.w3.org/1999/02/22-rdf-syntax-ns#langString> ;
+		sh:minCount 1 ;
+		sh:maxCount 1 ;
+    sh:resultMessage "De besluit moet één motivering hebben"
+	] ;
+	sh:property [
+		sh:name "publicatiedatum" ;
+		sh:description "De officiële publicatiedatum van het besluit." ;
+		sh:path <http://data.europa.eu/eli/ontology#date_publication> ;
+		sh:datatype <http://www.w3.org/2001/XMLSchema#date> ;
+    sh:minCount 0 ;
+		sh:maxCount 1 ;
+    sh:resultMessage "De besluit mag niet meer dan één publicatiedatum hebben"
+	] ;
+    sh:property [
+		sh:name "buitenwerkingtreding" ;
+		sh:description "De laatste dag waarop de regelgeving nog van kracht is." ;
+		sh:path <http://data.europa.eu/eli/ontology#date_no_longer_in_force> ;
+		sh:datatype <http://www.w3.org/2001/XMLSchema#date> ;
+        sh:minCount 0 ;
+		sh:maxCount 1 ;
+	] ;
+	sh:property [
+		sh:name "inwerkingtreding" ;
+		sh:description "De datum waarop de regelgeving van kracht wordt." ;
+		sh:path <http://data.europa.eu/eli/ontology#first_date_entry_in_force> ;
+		sh:datatype <http://www.w3.org/2001/XMLSchema#date> ;
+		sh:minCount 0 ;
+		sh:maxCount 1 ;
+	] ;
+	sh:closed false .
+  `;
 
 export default class AgendapointsEditController extends Controller {
   @service store;
@@ -178,6 +287,14 @@ export default class AgendapointsEditController extends Controller {
       const html = this.controller.htmlContent;
       const cleanedHtml = this.removeEmptyDivs(html);
 
+      const rdf = await htmlToRdf(cleanedHtml);
+      const shacl = await parse(besluitShape);
+      const validator = new SHACLValidator(shacl, {
+        allowNamedNodeInList: true,
+      });
+      const report = await validator.validate(rdf);
+      console.log(shaclReportToMessage(report));
+
       const editorDocument =
         await this.documentService.createEditorDocument.perform(
           this.editorDocument.title,
@@ -207,4 +324,61 @@ export default class AgendapointsEditController extends Controller {
 
     return parsedHtml.body.innerHTML;
   }
+}
+
+async function parse(triples) {
+  return new Promise((resolve, reject) => {
+    const parser = new ParserN3();
+    const dataset = factory.dataset();
+    parser.parse(triples, (error, quad) => {
+      if (error) {
+        console.warn(error);
+        reject(error);
+      } else if (quad) {
+        dataset.add(quad);
+      } else {
+        resolve(dataset);
+      }
+    });
+  });
+}
+
+function htmlToRdf(html) {
+  return new Promise((res, rej) => {
+    const myParser = new RdfaParser({ contentType: 'text/html' });
+    const dataset = factory.dataset();
+    myParser
+      .on('data', (data) => {
+        dataset.add(data);
+      })
+      .on('error', rej)
+      .on('end', () => res(dataset));
+    myParser.write(html);
+    myParser.end();
+  });
+}
+
+function shaclSeverityToString(severity) {
+  const uri = severity.value;
+  return uri.replace('http://www.w3.org/ns/shacl#', '');
+}
+
+export function shaclReportToMessage(report) {
+  let reportString = '\n';
+  for (const r of report.results) {
+    let description = '';
+    const shapeId = r.sourceShape.id;
+    for (let [_, quad] of r.dataset._quads) {
+      if (
+        quad._subject?.id === shapeId &&
+        quad._predicate?.id === 'http://www.w3.org/ns/shacl#resultMessage'
+      ) {
+        description = quad._object.id;
+        break;
+      }
+    }
+    const severity = shaclSeverityToString(r.severity);
+    reportString += `${severity} - ${description} - ${r.path.value} (${r.focusNode.value})\n`;
+  }
+  return reportString;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,11 @@
       "license": "MIT",
       "dependencies": {
         "@curvenote/prosemirror-utils": "^1.0.5",
+        "@rdfjs/dataset": "^2.0.2",
         "ember-sortable": "^5.2.3",
+        "n3": "^1.25.2",
+        "rdf-validate-shacl": "^0.6.2",
+        "rdfa-streaming-parser": "^3.0.2",
         "reactiveweb": "^1.3.0",
         "tracked-toolbox": "^2.0.0"
       },
@@ -7515,6 +7519,119 @@
         }
       }
     },
+    "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/@rdfjs/namespace": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rdfjs/namespace/-/namespace-1.1.0.tgz",
+      "integrity": "sha512-utO5rtaOKxk8B90qzaQ0N+J5WrCI28DtfAY/zExCmXE7cOfC5uRI/oMKbLaVEPj2P7uArekt/T4IPATtj7Tjug==",
+      "dev": true,
+      "dependencies": {
+        "@rdfjs/data-model": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/@rdfjs/namespace/node_modules/@rdfjs/data-model": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-1.3.4.tgz",
+      "integrity": "sha512-iKzNcKvJotgbFDdti7GTQDCYmL7GsGldkYStiP0K8EYtN7deJu5t7U11rKTz+nR7RtesUggT+lriZ7BakFv8QQ==",
+      "dev": true,
+      "dependencies": {
+        "@rdfjs/types": ">=1.0.1"
+      },
+      "bin": {
+        "rdfjs-data-model-test": "bin/test.js"
+      }
+    },
+    "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/@rdfjs/term-set": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rdfjs/term-set/-/term-set-1.1.0.tgz",
+      "integrity": "sha512-QQ4yzVe1Rvae/GN9SnOhweHNpaxQtnAjeOVciP/yJ0Gfxtbphy2tM56ZsRLV04Qq5qMcSclZIe6irYyEzx/UwQ==",
+      "dev": true,
+      "dependencies": {
+        "@rdfjs/to-ntriples": "^2.0.0"
+      }
+    },
+    "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/@rdfjs/to-ntriples": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@rdfjs/to-ntriples/-/to-ntriples-2.0.0.tgz",
+      "integrity": "sha512-nDhpfhx6W6HKsy4HjyLp3H1nbrX1CiUCWhWQwKcYZX1s9GOjcoQTwY7GUUbVec0hzdJDQBR6gnjxtENBDt482Q==",
+      "dev": true
+    },
+    "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/clownface": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/clownface/-/clownface-1.5.1.tgz",
+      "integrity": "sha512-Ko8N/UFsnhEGmPlyE1bUFhbRhVgDbxqlIjcqxtLysc4dWaY0A7iCdg3savhAxs7Lheb7FCygIyRh7ADYZWVIng==",
+      "dev": true,
+      "dependencies": {
+        "@rdfjs/data-model": "^1.1.0",
+        "@rdfjs/namespace": "^1.0.0"
+      }
+    },
+    "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/clownface/node_modules/@rdfjs/data-model": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-1.3.4.tgz",
+      "integrity": "sha512-iKzNcKvJotgbFDdti7GTQDCYmL7GsGldkYStiP0K8EYtN7deJu5t7U11rKTz+nR7RtesUggT+lriZ7BakFv8QQ==",
+      "dev": true,
+      "dependencies": {
+        "@rdfjs/types": ">=1.0.1"
+      },
+      "bin": {
+        "rdfjs-data-model-test": "bin/test.js"
+      }
+    },
+    "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/rdf-validate-datatype": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/rdf-validate-datatype/-/rdf-validate-datatype-0.1.5.tgz",
+      "integrity": "sha512-gU+cD+AT1LpFwbemuEmTDjwLyFwJDiw21XHyIofKhFnEpXODjShBuxhgDGnZqW3qIEwu/vECjOecuD60e5ngiQ==",
+      "dev": true,
+      "dependencies": {
+        "@rdfjs/namespace": "^1.1.0",
+        "@rdfjs/to-ntriples": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.4"
+      }
+    },
+    "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/rdf-validate-shacl": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/rdf-validate-shacl/-/rdf-validate-shacl-0.4.5.tgz",
+      "integrity": "sha512-tGYnssuPzmsPua1dju4hEtGkT1zouvwzVTNrFhNiqj2aZFO5pQ7lvLd9Cv9H9vKAlpIdC/x0zL6btxG3PCss0w==",
+      "dev": true,
+      "dependencies": {
+        "@rdfjs/dataset": "^1.1.1",
+        "@rdfjs/namespace": "^1.0.0",
+        "@rdfjs/term-set": "^1.1.0",
+        "clownface": "^1.4.0",
+        "debug": "^4.3.2",
+        "rdf-literal": "^1.3.0",
+        "rdf-validate-datatype": "^0.1.5"
+      }
+    },
+    "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/rdf-validate-shacl/node_modules/@rdfjs/data-model": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-1.3.4.tgz",
+      "integrity": "sha512-iKzNcKvJotgbFDdti7GTQDCYmL7GsGldkYStiP0K8EYtN7deJu5t7U11rKTz+nR7RtesUggT+lriZ7BakFv8QQ==",
+      "dev": true,
+      "dependencies": {
+        "@rdfjs/types": ">=1.0.1"
+      },
+      "bin": {
+        "rdfjs-data-model-test": "bin/test.js"
+      }
+    },
+    "node_modules/@lblod/ember-rdfa-editor-lblod-plugins/node_modules/rdf-validate-shacl/node_modules/@rdfjs/dataset": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/dataset/-/dataset-1.1.1.tgz",
+      "integrity": "sha512-BNwCSvG0cz0srsG5esq6CQKJc1m8g/M0DZpLuiEp0MMpfwguXX7VeS8TCg4UUG3DV/DqEvhy83ZKSEjdsYseeA==",
+      "dev": true,
+      "dependencies": {
+        "@rdfjs/data-model": "^1.2.0"
+      },
+      "bin": {
+        "rdfjs-dataset-test": "bin/test.js"
+      }
+    },
     "node_modules/@lblod/ember-rdfa-editor/node_modules/@rdfjs/types": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
@@ -8261,10 +8378,9 @@
       }
     },
     "node_modules/@rdfjs/data-model": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-2.0.2.tgz",
-      "integrity": "sha512-v5LRNkLRJazMCGU7VtEzhz5wKwz/IrOdJEKapCtd35HuFbQfeGpoJP6QOXGyFHhWwKmtG+UMlZzYFyNDVE1m6g==",
-      "dev": true,
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-2.1.0.tgz",
+      "integrity": "sha512-pnjwSqDCXxxJQPm3TyDaqoWynYYQBl1pZC7rIPhdck7RbcEVF8hIBg5vXXosUbNcW3qwyAEBtYGojoWRnxBPew==",
       "bin": {
         "rdfjs-data-model-test": "bin/test.js"
       }
@@ -8273,7 +8389,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@rdfjs/dataset/-/dataset-2.0.2.tgz",
       "integrity": "sha512-6YJx+5n5Uxzq9dd9I0GGcIo6eopZOPfcsAfxSGX5d+YBzDgVa1cbtEBFnaPyPKiQsOm4+Cr3nwypjpg02YKPlA==",
-      "dev": true,
       "bin": {
         "rdfjs-dataset-test": "bin/test.js"
       }
@@ -8281,8 +8396,7 @@
     "node_modules/@rdfjs/environment": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@rdfjs/environment/-/environment-1.0.0.tgz",
-      "integrity": "sha512-+S5YjSvfoQR5r7YQCRCCVHvIEyrWia7FJv2gqM3s5EDfotoAQmFeBagApa9c/eQFi5EiNhmBECE5nB8LIxTaHg==",
-      "dev": true
+      "integrity": "sha512-+S5YjSvfoQR5r7YQCRCCVHvIEyrWia7FJv2gqM3s5EDfotoAQmFeBagApa9c/eQFi5EiNhmBECE5nB8LIxTaHg=="
     },
     "node_modules/@rdfjs/fetch-lite": {
       "version": "3.2.3",
@@ -8370,7 +8484,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@rdfjs/namespace/-/namespace-2.0.1.tgz",
       "integrity": "sha512-U85NWVGnL3gWvOZ4eXwUcv3/bom7PAcutSBQqmVWvOaslPy+kDzAJCH1WYBLpdQd4yMmJ+bpJcDl9rcHtXeixg==",
-      "dev": true,
       "dependencies": {
         "@rdfjs/data-model": "^2.0.1"
       }
@@ -8610,7 +8723,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@rdfjs/term-map/-/term-map-2.0.2.tgz",
       "integrity": "sha512-EJ2FmmdEUsSR/tU1nrizRLWzH24YzhuvesrbUWxC3Fs0ilYNdtTbg0RaFJDUnJF3HkbNBQe8Zrt/uvU/hcKnHg==",
-      "dev": true,
       "dependencies": {
         "@rdfjs/to-ntriples": "^3.0.1"
       }
@@ -8619,7 +8731,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@rdfjs/term-set/-/term-set-2.0.3.tgz",
       "integrity": "sha512-DyXrKWEx+mtAFUZVU7bc3Va6/KZ8PsIp0RVdyWT9jfDgI/HCvNisZaBtAcm+SYTC45o+7WLkbudkk1bfaKVB0A==",
-      "dev": true,
       "dependencies": {
         "@rdfjs/to-ntriples": "^3.0.1"
       }
@@ -8627,8 +8738,7 @@
     "node_modules/@rdfjs/to-ntriples": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@rdfjs/to-ntriples/-/to-ntriples-3.0.1.tgz",
-      "integrity": "sha512-gjoPAvh4j7AbGMjcDn/8R4cW+d/FPtbfbMM0uQXkyfBFtNUW2iVgrqsgJ65roLc54Y9A2TTFaeeTGSvY9a0HCQ==",
-      "dev": true
+      "integrity": "sha512-gjoPAvh4j7AbGMjcDn/8R4cW+d/FPtbfbMM0uQXkyfBFtNUW2iVgrqsgJ65roLc54Y9A2TTFaeeTGSvY9a0HCQ=="
     },
     "node_modules/@rdfjs/traverser": {
       "version": "0.1.4",
@@ -8654,7 +8764,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-2.0.1.tgz",
       "integrity": "sha512-uyAzpugX7KekAXAHq26m3JlUIZJOC0uSBhpnefGV5i15bevDyyejoB7I+9MKeUrzXD8OOUI3+4FeV1wwQr5ihA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -8806,6 +8915,18 @@
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
       "dev": true
+    },
+    "node_modules/@tpluscode/rdf-ns-builders": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tpluscode/rdf-ns-builders/-/rdf-ns-builders-4.3.0.tgz",
+      "integrity": "sha512-x3uh9mYwAU+PrALaDKhVjml1TCCWWduo6J8rybd9SMEEAoooXq1MYb13MRputjRT/kYaFyCND7LMobzhxZ/+bg==",
+      "dependencies": {
+        "@rdfjs/data-model": "^2",
+        "@rdfjs/namespace": "^2",
+        "@rdfjs/types": "*",
+        "@types/rdfjs__namespace": "^2.0.2",
+        "@zazuko/prefixes": "^2.0.1"
+      }
     },
     "node_modules/@tsconfig/ember": {
       "version": "3.0.9",
@@ -9094,6 +9215,14 @@
       "dependencies": {
         "@rdfjs/types": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/rdfjs__namespace": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__namespace/-/rdfjs__namespace-2.0.10.tgz",
+      "integrity": "sha512-xoVzEIOxcpyteEmzaj94MSBbrBFs+vqv05joMhzLEiPRwsBBDnhkdBCaaDxR1Tf7wOW0kB2R1IYe4C3vEBFPgA==",
+      "dependencies": {
+        "@rdfjs/types": "*"
       }
     },
     "node_modules/@types/rdfjs__parser-n3": {
@@ -9424,6 +9553,14 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@vocabulary/sh": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@vocabulary/sh/-/sh-1.1.6.tgz",
+      "integrity": "sha512-8IfAQoKh57THz8LA2+n1jaY/VC2XaqMNSsJgzBKSSrj20y5PSMAawb6dMsxoLxqDIPBDs1TFRl/9CijUnwbBUA==",
+      "peerDependencies": {
+        "@rdfjs/types": "^2.0.0"
+      }
+    },
     "node_modules/@warp-drive-types/core-types": {
       "version": "5.4.0-alpha.150",
       "resolved": "https://registry.npmjs.org/@warp-drive-types/core-types/-/core-types-5.4.0-alpha.150.tgz",
@@ -9692,6 +9829,11 @@
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
     },
+    "node_modules/@zazuko/prefixes": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@zazuko/prefixes/-/prefixes-2.4.0.tgz",
+      "integrity": "sha512-bd53k5XgFKWR56sofHeAcIbv8o0m2HsJlbHaHbrMufUCdgiZsCLvZn84Vh1dhcsyBHOD0EIo9AD4pNWDQLVRaw=="
+    },
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -9702,7 +9844,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dev": true,
       "dependencies": {
         "event-target-shim": "^5.0.0"
       },
@@ -11214,7 +11355,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -13553,7 +13693,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -14533,37 +14672,13 @@
       }
     },
     "node_modules/clownface": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/clownface/-/clownface-1.5.1.tgz",
-      "integrity": "sha512-Ko8N/UFsnhEGmPlyE1bUFhbRhVgDbxqlIjcqxtLysc4dWaY0A7iCdg3savhAxs7Lheb7FCygIyRh7ADYZWVIng==",
-      "dev": true,
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/clownface/-/clownface-2.0.3.tgz",
+      "integrity": "sha512-E76TBJ7CgU9+/5paSAvuNdMO+fzFThnvRVtidosktYppYkXM8V7tid8Ezzo8S1OmoWxKUam3yfkZlfCid4OiJQ==",
       "dependencies": {
-        "@rdfjs/data-model": "^1.1.0",
-        "@rdfjs/namespace": "^1.0.0"
-      }
-    },
-    "node_modules/clownface/node_modules/@rdfjs/data-model": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-1.3.4.tgz",
-      "integrity": "sha512-iKzNcKvJotgbFDdti7GTQDCYmL7GsGldkYStiP0K8EYtN7deJu5t7U11rKTz+nR7RtesUggT+lriZ7BakFv8QQ==",
-      "dev": true,
-      "dependencies": {
-        "@rdfjs/types": ">=1.0.1"
-      },
-      "bin": {
-        "rdfjs-data-model-test": "bin/test.js"
-      }
-    },
-    "node_modules/clownface/node_modules/@rdfjs/namespace": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@rdfjs/namespace/-/namespace-1.1.0.tgz",
-      "integrity": "sha512-utO5rtaOKxk8B90qzaQ0N+J5WrCI28DtfAY/zExCmXE7cOfC5uRI/oMKbLaVEPj2P7uArekt/T4IPATtj7Tjug==",
-      "dev": true,
-      "dependencies": {
-        "@rdfjs/data-model": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=6"
+        "@rdfjs/data-model": "^2.0.1",
+        "@rdfjs/environment": "0 - 1",
+        "@rdfjs/namespace": "^2.0.0"
       }
     },
     "node_modules/codemirror": {
@@ -16211,6 +16326,30 @@
       "resolved": "https://registry.npmjs.org/dom-element-descriptors/-/dom-element-descriptors-0.5.1.tgz",
       "integrity": "sha512-DLayMRQ+yJaziF4JJX1FMjwjdr7wdTr1y9XvZ+NfHELfOMcYDnCHneAYXAS4FT1gLILh4V0juMZohhH1N5FsoQ=="
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/domain-browser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
@@ -16221,11 +16360,49 @@
         "npm": ">=1.2"
       }
     },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
     "node_modules/dompurify": {
       "version": "3.1.6",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.6.tgz",
       "integrity": "sha512-cTOAhc36AalkjtBpfG6O8JimdTMWNXjiePT2xQH/ppBGi/4uIpmj8eKyIkMJErXWARyINV/sB38yf8JCLF5pbQ==",
       "dev": true
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
     },
     "node_modules/dot-case": {
       "version": "3.0.4",
@@ -32792,7 +32969,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -35167,6 +35343,35 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/htmlparser2": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/http-cache-semantics": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
@@ -35336,7 +35541,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -35369,9 +35573,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.6.tgz",
-      "integrity": "sha512-Ju0+lEMyzMVZarkTn/gqRpdqd5dOPaz1mCZ0SH3JV6iFw81PldE/PEB1hWVEA288HPt4WXW8O7AWxB10M+03QQ==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
+      "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==",
       "dev": true
     },
     "node_modules/import-fresh": {
@@ -39072,13 +39276,11 @@
       }
     },
     "node_modules/n3": {
-      "version": "1.17.4",
-      "resolved": "https://registry.npmjs.org/n3/-/n3-1.17.4.tgz",
-      "integrity": "sha512-G5RR9PKLJXQU1uDJ2cZq+zp23V5XruqWhAGlCpF2/8kLiPbqEKOXDXgOLuoMqFwdxO/oBE2h4KNGQUp0aQ0OLA==",
-      "dev": true,
+      "version": "1.25.2",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-1.25.2.tgz",
+      "integrity": "sha512-ZBPnAgOw4sze/hnyoydNA5Ts9wbwiG+BXssTkdBKD6IkQZcg1IfQdo5AMU9JhsIu/RGtRD1QD0gphEhk/6ZnWA==",
       "dependencies": {
         "buffer": "^6.0.3",
-        "queue-microtask": "^1.1.2",
         "readable-stream": "^4.0.0"
       },
       "engines": {
@@ -39089,7 +39291,6 @@
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
       "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
-      "dev": true,
       "dependencies": {
         "abort-controller": "^3.0.0",
         "buffer": "^6.0.3",
@@ -39304,6 +39505,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true
+    },
+    "node_modules/node-libs-browser/node_modules/path-browserify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
+      "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
       "dev": true
     },
     "node_modules/node-libs-browser/node_modules/punycode": {
@@ -43100,12 +43307,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/path-browserify": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
-      "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
-      "dev": true
-    },
     "node_modules/path-dirname": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
@@ -43697,7 +43898,6 @@
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -44343,9 +44543,29 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.2.tgz",
       "integrity": "sha512-TfQD63Lokabd09ES1jAtKK8AA6rkr9rwyUBGo6olOt1CE0Um36CUQIqytyf0am2ouBPR0l7SaHxCiMcPGHkt1A==",
-      "dev": true,
       "dependencies": {
         "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/rdf-dataset-ext": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/rdf-dataset-ext/-/rdf-dataset-ext-1.1.0.tgz",
+      "integrity": "sha512-CH85RfRKN9aSlbju8T7aM8hgCSWMBsh2eh/tGxUUtWMN+waxi6iFDt8/r4PAEmKaEA82guimZJ4ISbmJ2rvWQg==",
+      "deprecated": "rdf-dataset-ext is deprecated. Switching to rdf-ext is recommended.",
+      "dependencies": {
+        "rdf-canonize": "^3.0.0",
+        "readable-stream": "3 - 4"
+      }
+    },
+    "node_modules/rdf-dataset-ext/node_modules/rdf-canonize": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-3.4.0.tgz",
+      "integrity": "sha512-fUeWjrkOO0t1rg7B2fdyDTvngj+9RlUyL92vOdiB7c0FPguWVsniIMjEtHH+meLBO9rzkUlUzBVXgWrjI8P9LA==",
+      "dependencies": {
+        "setimmediate": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/rdf-ext": {
@@ -44395,120 +44615,88 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/rdf-literal/-/rdf-literal-1.3.2.tgz",
       "integrity": "sha512-79Stlu3sXy0kq9/decHFLf3xNPuY6sfhFPhd/diWErgaFr0Ekyg38Vh9bnVcqDYu48CFRi0t+hrFii49n92Hbw==",
-      "dev": true,
       "dependencies": {
         "@rdfjs/types": "*",
         "rdf-data-factory": "^1.1.0"
       }
     },
     "node_modules/rdf-validate-datatype": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/rdf-validate-datatype/-/rdf-validate-datatype-0.1.5.tgz",
-      "integrity": "sha512-gU+cD+AT1LpFwbemuEmTDjwLyFwJDiw21XHyIofKhFnEpXODjShBuxhgDGnZqW3qIEwu/vECjOecuD60e5ngiQ==",
-      "dev": true,
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/rdf-validate-datatype/-/rdf-validate-datatype-0.2.1.tgz",
+      "integrity": "sha512-DpREnmoWDxC80KyslZeBPLQb3ztyeiOolT4uCl58tCju2KHJu4j5vonmVVdEJh2Mpad5UY57v6sSM/hfSTFGKQ==",
       "dependencies": {
-        "@rdfjs/namespace": "^1.1.0",
-        "@rdfjs/to-ntriples": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.4"
+        "@rdfjs/term-map": "^2.0.0",
+        "@tpluscode/rdf-ns-builders": "3 - 4"
       }
-    },
-    "node_modules/rdf-validate-datatype/node_modules/@rdfjs/data-model": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-1.3.4.tgz",
-      "integrity": "sha512-iKzNcKvJotgbFDdti7GTQDCYmL7GsGldkYStiP0K8EYtN7deJu5t7U11rKTz+nR7RtesUggT+lriZ7BakFv8QQ==",
-      "dev": true,
-      "dependencies": {
-        "@rdfjs/types": ">=1.0.1"
-      },
-      "bin": {
-        "rdfjs-data-model-test": "bin/test.js"
-      }
-    },
-    "node_modules/rdf-validate-datatype/node_modules/@rdfjs/namespace": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@rdfjs/namespace/-/namespace-1.1.0.tgz",
-      "integrity": "sha512-utO5rtaOKxk8B90qzaQ0N+J5WrCI28DtfAY/zExCmXE7cOfC5uRI/oMKbLaVEPj2P7uArekt/T4IPATtj7Tjug==",
-      "dev": true,
-      "dependencies": {
-        "@rdfjs/data-model": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/rdf-validate-datatype/node_modules/@rdfjs/to-ntriples": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@rdfjs/to-ntriples/-/to-ntriples-2.0.0.tgz",
-      "integrity": "sha512-nDhpfhx6W6HKsy4HjyLp3H1nbrX1CiUCWhWQwKcYZX1s9GOjcoQTwY7GUUbVec0hzdJDQBR6gnjxtENBDt482Q==",
-      "dev": true
     },
     "node_modules/rdf-validate-shacl": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/rdf-validate-shacl/-/rdf-validate-shacl-0.4.5.tgz",
-      "integrity": "sha512-tGYnssuPzmsPua1dju4hEtGkT1zouvwzVTNrFhNiqj2aZFO5pQ7lvLd9Cv9H9vKAlpIdC/x0zL6btxG3PCss0w==",
-      "dev": true,
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rdf-validate-shacl/-/rdf-validate-shacl-0.6.2.tgz",
+      "integrity": "sha512-X2kThB9jADSNgSkMwpJ4GMjRdcsFZRO1tay/kfohintMNRHR0qNQc1icNAeeVGcV2fRZQccdzYDepJd1fDSMrw==",
       "dependencies": {
-        "@rdfjs/dataset": "^1.1.1",
-        "@rdfjs/namespace": "^1.0.0",
-        "@rdfjs/term-set": "^1.1.0",
-        "clownface": "^1.4.0",
+        "@rdfjs/data-model": "^2",
+        "@rdfjs/dataset": "^2",
+        "@rdfjs/environment": "^1",
+        "@rdfjs/namespace": "^2.0.0",
+        "@rdfjs/term-set": "^2.0.1",
+        "@rdfjs/types": "^1.1.0",
+        "@vocabulary/sh": "^1.1.5",
+        "clownface": "^2.0.0",
         "debug": "^4.3.2",
-        "rdf-literal": "^1.3.0",
-        "rdf-validate-datatype": "^0.1.5"
+        "rdf-dataset-ext": "^1.1.0",
+        "rdf-literal": "^1.3.2",
+        "rdf-validate-datatype": "^0.2.0"
       }
     },
-    "node_modules/rdf-validate-shacl/node_modules/@rdfjs/data-model": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-1.3.4.tgz",
-      "integrity": "sha512-iKzNcKvJotgbFDdti7GTQDCYmL7GsGldkYStiP0K8EYtN7deJu5t7U11rKTz+nR7RtesUggT+lriZ7BakFv8QQ==",
-      "dev": true,
+    "node_modules/rdf-validate-shacl/node_modules/@rdfjs/types": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
+      "integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
       "dependencies": {
-        "@rdfjs/types": ">=1.0.1"
+        "@types/node": "*"
+      }
+    },
+    "node_modules/rdfa-streaming-parser": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rdfa-streaming-parser/-/rdfa-streaming-parser-3.0.2.tgz",
+      "integrity": "sha512-1MEkALT5PYjucVo6lNHXd9DbkgW0hSfPOJOs/TpUFe9zoZvkoreKcGIFnMFkbMmYTNLCiGFo/74LviIUnWLkIw==",
+      "dependencies": {
+        "htmlparser2": "^9.0.0",
+        "rdf-data-factory": "^2.0.0",
+        "readable-stream": "^4.0.0",
+        "relative-to-absolute-iri": "^1.0.2"
       },
-      "bin": {
-        "rdfjs-data-model-test": "bin/test.js"
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
       }
     },
-    "node_modules/rdf-validate-shacl/node_modules/@rdfjs/dataset": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@rdfjs/dataset/-/dataset-1.1.1.tgz",
-      "integrity": "sha512-BNwCSvG0cz0srsG5esq6CQKJc1m8g/M0DZpLuiEp0MMpfwguXX7VeS8TCg4UUG3DV/DqEvhy83ZKSEjdsYseeA==",
-      "dev": true,
+    "node_modules/rdfa-streaming-parser/node_modules/rdf-data-factory": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-2.0.2.tgz",
+      "integrity": "sha512-WzPoYHwQYWvIP9k+7IBLY1b4nIDitzAK4mA37WumAF/Cjvu/KOtYJH9IPZnUTWNSd5K2+pq4vrcE9WZC4sRHhg==",
       "dependencies": {
-        "@rdfjs/data-model": "^1.2.0"
+        "@rdfjs/types": "^2.0.0"
       },
-      "bin": {
-        "rdfjs-dataset-test": "bin/test.js"
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
       }
     },
-    "node_modules/rdf-validate-shacl/node_modules/@rdfjs/namespace": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@rdfjs/namespace/-/namespace-1.1.0.tgz",
-      "integrity": "sha512-utO5rtaOKxk8B90qzaQ0N+J5WrCI28DtfAY/zExCmXE7cOfC5uRI/oMKbLaVEPj2P7uArekt/T4IPATtj7Tjug==",
-      "dev": true,
+    "node_modules/rdfa-streaming-parser/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
       "dependencies": {
-        "@rdfjs/data-model": "^1.1.0"
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
-    },
-    "node_modules/rdf-validate-shacl/node_modules/@rdfjs/term-set": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@rdfjs/term-set/-/term-set-1.1.0.tgz",
-      "integrity": "sha512-QQ4yzVe1Rvae/GN9SnOhweHNpaxQtnAjeOVciP/yJ0Gfxtbphy2tM56ZsRLV04Qq5qMcSclZIe6irYyEzx/UwQ==",
-      "dev": true,
-      "dependencies": {
-        "@rdfjs/to-ntriples": "^2.0.0"
-      }
-    },
-    "node_modules/rdf-validate-shacl/node_modules/@rdfjs/to-ntriples": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@rdfjs/to-ntriples/-/to-ntriples-2.0.0.tgz",
-      "integrity": "sha512-nDhpfhx6W6HKsy4HjyLp3H1nbrX1CiUCWhWQwKcYZX1s9GOjcoQTwY7GUUbVec0hzdJDQBR6gnjxtENBDt482Q==",
-      "dev": true
     },
     "node_modules/rdfxml-streaming-parser": {
       "version": "2.4.0",
@@ -44673,7 +44861,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -44901,8 +45088,7 @@
     "node_modules/relative-to-absolute-iri": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/relative-to-absolute-iri/-/relative-to-absolute-iri-1.0.7.tgz",
-      "integrity": "sha512-Xjyl4HmIzg2jzK/Un2gELqbcE8Fxy85A/aLSHE6PE/3+OGsFwmKVA1vRyGaz6vLWSqLDMHA+5rjD/xbibSQN1Q==",
-      "dev": true
+      "integrity": "sha512-Xjyl4HmIzg2jzK/Un2gELqbcE8Fxy85A/aLSHE6PE/3+OGsFwmKVA1vRyGaz6vLWSqLDMHA+5rjD/xbibSQN1Q=="
     },
     "node_modules/release-it": {
       "version": "16.3.0",
@@ -46680,8 +46866,7 @@
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-      "dev": true
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -47614,7 +47799,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -184,7 +184,11 @@
   },
   "dependencies": {
     "@curvenote/prosemirror-utils": "^1.0.5",
+    "@rdfjs/dataset": "^2.0.2",
     "ember-sortable": "^5.2.3",
+    "n3": "^1.25.2",
+    "rdf-validate-shacl": "^0.6.2",
+    "rdfa-streaming-parser": "^3.0.2",
     "reactiveweb": "^1.3.0",
     "tracked-toolbox": "^2.0.0"
   },


### PR DESCRIPTION
### Overview
POC of how we can validate shacl shapes in the frontend, still unknown if this is going to be here or in a editor plugin.
But basically we get a shape (in the near future I will update this PR so the shape is pulled from https://github.com/lblod/lib-decision-shapes) and then run the validation against the triples extracted from our own document. We get the violations that shacl detects and generate a report. The shape will contain the sh:resultMessage property with the error message expected to show to the user.
The code is pretty simple and pretty similar to what we already have in the tests of the notulen-prepublish-service, most of the work is on getting a shape that can be a standard on besluit validation.
This POC can also be used to validate other publications as the notulen, decision list or agenda for which we already have shapes in the linked library

##### connected issues and PRs:
CIT-27

### Setup
None

### How to test/reproduce
Create an agendapoint that doesn't have all the parts of a besluit and notice that you get a report with the failing cases in the console

### Challenges/uncertainties
Explained above



### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
