### PR TITLE
Feat/validate decision presence

### DIFF
--- a/.changeset/orange-months-beg.md
+++ b/.changeset/orange-months-beg.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Validate decision presence in treatment

--- a/app/components/behandeling-van-agendapunt.gts
+++ b/app/components/behandeling-van-agendapunt.gts
@@ -41,6 +41,7 @@ import TreatmentVoting from './treatment/voting';
 import TreatmentVotingEdit from './treatment/voting/edit';
 import type { AgendapointTreatmentValidationResult } from 'frontend-gelinkt-notuleren/services/meeting';
 import type { ParticipationInfo } from './participation-list/modal';
+import WithTooltip from './with-tooltip';
 type Signature = {
   Args: {
     meeting: ZittingModel;
@@ -496,6 +497,7 @@ export default class BehandelingVanAgendapuntComponent extends Component<Signatu
       @title={{t 'behandeling-van-agendapunten.content-title'}}
     >
       <:body>
+
         {{#if this.attachments}}
           {{#if this.editable}}
             <AuPill
@@ -521,19 +523,38 @@ export default class BehandelingVanAgendapuntComponent extends Component<Signatu
       </:body>
 
       <:button>
-        {{#if (and this.editable @behandeling.documentContainer)}}
-          <AuLink
-            @route='agendapoints.edit'
-            @model={{@behandeling.documentContainer.id}}
-            @query={{hash returnToMeeting=@meeting.id}}
-            @skin='button-secondary'
-            @icon='pencil'
-            @iconAlignment='left'
-            class='au-u-hide-on-print'
-          >
-            {{t 'generic.edit'}}
-          </AuLink>
-        {{/if}}
+        <div class='au-u-flex au-u-flex--vertical-center au-u-flex--spaced'>
+          {{#unless @validationResult.decisionPresent}}
+            <WithTooltip
+              @tooltip={{t
+                'behandeling-van-agendapunten.no-decision-present-explanation'
+                email='gelinktnotuleren@vlaanderen.be'
+              }}
+              @placement='bottom-start'
+            >
+              <AuPill
+                @skin='warning'
+                @icon='alert-triangle'
+                @iconAlignment='left'
+              >
+                {{t 'behandeling-van-agendapunten.no-decision-present'}}
+              </AuPill>
+            </WithTooltip>
+          {{/unless}}
+          {{#if (and this.editable @behandeling.documentContainer)}}
+            <AuLink
+              @route='agendapoints.edit'
+              @model={{@behandeling.documentContainer.id}}
+              @query={{hash returnToMeeting=@meeting.id}}
+              @skin='button-secondary'
+              @icon='pencil'
+              @iconAlignment='left'
+              class='au-u-hide-on-print'
+            >
+              {{t 'generic.edit'}}
+            </AuLink>
+          {{/if}}
+        </div>
       </:button>
     </MeetingSubSection>
   </template>

--- a/app/services/meeting.ts
+++ b/app/services/meeting.ts
@@ -1,5 +1,6 @@
 import Service from '@ember/service';
 import { unwrap } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
+import { sayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
 import BehandelingVanAgendapunt from 'frontend-gelinkt-notuleren/models/behandeling-van-agendapunt';
 import type MandatarisModel from 'frontend-gelinkt-notuleren/models/mandataris';
 import ZittingModel from 'frontend-gelinkt-notuleren/models/zitting';
@@ -139,11 +140,13 @@ export default class MeetingService extends Service {
     if (!documentContainer) return false;
     const document = await documentContainer.currentVersion;
     if (!document) return false;
-    const triples = await htmlToRdf(document.content);
+    const triples = await htmlToRdf(document.content as string);
     const matches = triples.match(
       undefined,
-      'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
-      'http://data.vlaanderen.be/ns/besluit#Besluit',
+      sayDataFactory.namedNode(
+        'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
+      ),
+      sayDataFactory.namedNode('http://data.vlaanderen.be/ns/besluit#Besluit'),
     );
     return matches.size > 0;
   }

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -773,4 +773,5 @@ div[typeof='besluitpublicatie:Documentonderdeel'] {
 
 .gn-tooltip {
   z-index: 2;
+  max-width: 800px;
 }

--- a/app/utils/htmlToRdf.js
+++ b/app/utils/htmlToRdf.js
@@ -1,0 +1,17 @@
+import { RdfaParser } from 'rdfa-streaming-parser';
+import factory from '@rdfjs/dataset';
+
+export default function htmlToRdf(html) {
+  return new Promise((res, rej) => {
+    const myParser = new RdfaParser({ contentType: 'text/html' });
+    const dataset = factory.dataset();
+    myParser
+      .on('data', (data) => {
+        dataset.add(data);
+      })
+      .on('error', rej)
+      .on('end', () => res(dataset));
+    myParser.write(html);
+    myParser.end();
+  });
+}

--- a/app/utils/htmlToRdf.ts
+++ b/app/utils/htmlToRdf.ts
@@ -1,12 +1,13 @@
 import { RdfaParser } from 'rdfa-streaming-parser';
 import factory from '@rdfjs/dataset';
+import type { Quad, DatasetCore } from '@rdfjs/types';
 
-export default function htmlToRdf(html) {
+export default function htmlToRdf(html: string): Promise<DatasetCore<Quad>> {
   return new Promise((res, rej) => {
     const myParser = new RdfaParser({ contentType: 'text/html' });
     const dataset = factory.dataset();
     myParser
-      .on('data', (data) => {
+      .on('data', (data: Quad) => {
         dataset.add(data);
       })
       .on('error', rej)

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "license": "MIT",
       "dependencies": {
         "@curvenote/prosemirror-utils": "^1.0.5",
+        "@rdfjs/dataset": "^2.0.2",
         "ember-sortable": "^5.2.3",
+        "rdfa-streaming-parser": "^3.0.2",
         "reactiveweb": "^1.3.0",
         "tracked-toolbox": "^2.0.0"
       },
@@ -8280,7 +8282,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@rdfjs/dataset/-/dataset-2.0.2.tgz",
       "integrity": "sha512-6YJx+5n5Uxzq9dd9I0GGcIo6eopZOPfcsAfxSGX5d+YBzDgVa1cbtEBFnaPyPKiQsOm4+Cr3nwypjpg02YKPlA==",
-      "dev": true,
       "bin": {
         "rdfjs-dataset-test": "bin/test.js"
       }
@@ -8661,7 +8662,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-2.0.1.tgz",
       "integrity": "sha512-uyAzpugX7KekAXAHq26m3JlUIZJOC0uSBhpnefGV5i15bevDyyejoB7I+9MKeUrzXD8OOUI3+4FeV1wwQr5ihA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -9715,7 +9715,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dev": true,
       "dependencies": {
         "event-target-shim": "^5.0.0"
       },
@@ -11257,7 +11256,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -13596,7 +13594,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -16254,6 +16251,30 @@
       "resolved": "https://registry.npmjs.org/dom-element-descriptors/-/dom-element-descriptors-0.5.1.tgz",
       "integrity": "sha512-DLayMRQ+yJaziF4JJX1FMjwjdr7wdTr1y9XvZ+NfHELfOMcYDnCHneAYXAS4FT1gLILh4V0juMZohhH1N5FsoQ=="
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/domain-browser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
@@ -16264,11 +16285,49 @@
         "npm": ">=1.2"
       }
     },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
     "node_modules/dompurify": {
       "version": "3.1.6",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.6.tgz",
       "integrity": "sha512-cTOAhc36AalkjtBpfG6O8JimdTMWNXjiePT2xQH/ppBGi/4uIpmj8eKyIkMJErXWARyINV/sB38yf8JCLF5pbQ==",
       "dev": true
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
     },
     "node_modules/dot-case": {
       "version": "3.0.4",
@@ -32870,7 +32929,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -35245,6 +35303,35 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/htmlparser2": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/http-cache-semantics": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
@@ -35414,7 +35501,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -43775,7 +43861,6 @@
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -44588,6 +44673,48 @@
       "integrity": "sha512-nDhpfhx6W6HKsy4HjyLp3H1nbrX1CiUCWhWQwKcYZX1s9GOjcoQTwY7GUUbVec0hzdJDQBR6gnjxtENBDt482Q==",
       "dev": true
     },
+    "node_modules/rdfa-streaming-parser": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rdfa-streaming-parser/-/rdfa-streaming-parser-3.0.2.tgz",
+      "integrity": "sha512-1MEkALT5PYjucVo6lNHXd9DbkgW0hSfPOJOs/TpUFe9zoZvkoreKcGIFnMFkbMmYTNLCiGFo/74LviIUnWLkIw==",
+      "dependencies": {
+        "htmlparser2": "^9.0.0",
+        "rdf-data-factory": "^2.0.0",
+        "readable-stream": "^4.0.0",
+        "relative-to-absolute-iri": "^1.0.2"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/rdfa-streaming-parser/node_modules/rdf-data-factory": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-2.0.2.tgz",
+      "integrity": "sha512-WzPoYHwQYWvIP9k+7IBLY1b4nIDitzAK4mA37WumAF/Cjvu/KOtYJH9IPZnUTWNSd5K2+pq4vrcE9WZC4sRHhg==",
+      "dependencies": {
+        "@rdfjs/types": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/rdfa-streaming-parser/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/rdfxml-streaming-parser": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/rdfxml-streaming-parser/-/rdfxml-streaming-parser-2.4.0.tgz",
@@ -44979,8 +45106,7 @@
     "node_modules/relative-to-absolute-iri": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/relative-to-absolute-iri/-/relative-to-absolute-iri-1.0.7.tgz",
-      "integrity": "sha512-Xjyl4HmIzg2jzK/Un2gELqbcE8Fxy85A/aLSHE6PE/3+OGsFwmKVA1vRyGaz6vLWSqLDMHA+5rjD/xbibSQN1Q==",
-      "dev": true
+      "integrity": "sha512-Xjyl4HmIzg2jzK/Un2gELqbcE8Fxy85A/aLSHE6PE/3+OGsFwmKVA1vRyGaz6vLWSqLDMHA+5rjD/xbibSQN1Q=="
     },
     "node_modules/release-it": {
       "version": "16.3.0",
@@ -47692,7 +47818,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "@release-it-plugins/lerna-changelog": "^6.0.0",
         "@tsconfig/ember": "^3.0.9",
         "@types/eslint__js": "^8.42.3",
+        "@types/rdfjs__dataset": "^2.0.7",
         "@types/rsvp": "^4.0.9",
         "@types/uuid": "^10.0.0",
         "@warp-drive-types/core-types": "5.4.0-alpha.150",
@@ -9091,6 +9092,15 @@
         "@rdfjs/types": "*",
         "@types/clownface": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/rdfjs__dataset": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__dataset/-/rdfjs__dataset-2.0.7.tgz",
+      "integrity": "sha512-+GaYIL9C7N1N0HyH+obU4IXuL7DX+fXuf827aUQ2Vx2UghO47+OTxo2v3seEQj/1YHoHBfQFk5Y4P6Q7Ht4Hqw==",
+      "dev": true,
+      "dependencies": {
+        "@rdfjs/types": "*"
       }
     },
     "node_modules/@types/rdfjs__environment": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@release-it-plugins/lerna-changelog": "^6.0.0",
     "@tsconfig/ember": "^3.0.9",
     "@types/eslint__js": "^8.42.3",
+    "@types/rdfjs__dataset": "^2.0.7",
     "@types/rsvp": "^4.0.9",
     "@types/uuid": "^10.0.0",
     "@warp-drive-types/core-types": "5.4.0-alpha.150",

--- a/package.json
+++ b/package.json
@@ -186,7 +186,9 @@
   },
   "dependencies": {
     "@curvenote/prosemirror-utils": "^1.0.5",
+    "@rdfjs/dataset": "^2.0.2",
     "ember-sortable": "^5.2.3",
+    "rdfa-streaming-parser": "^3.0.2",
     "reactiveweb": "^1.3.0",
     "tracked-toolbox": "^2.0.0"
   },

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -85,6 +85,8 @@ behandeling-van-agendapunten:
   edit-document: 'Edit document'
   sync-warning: Data possibly overwritten by synchronization
   add-custom-voting: Add custom voting
+  no-decision-present: No decision present
+  no-decision-present-explanation: This agenda item does not contain a decision, and will not be included in the decision list publication. If that is not what you expected, please verify the agenda-item contents or contact support at {email}
 
 contact:
   about: What is your message about?

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -450,10 +450,13 @@ meeting-toc-card:
         success: The intro of this meeting is correctly filled in
     treatments:
       label: Treatments
+      validation:
+        success: The treatments below were completed correctly
+        warning: A few problems were found in the following treatments
     treatment:
       validation:
-        success: The attendance of this treatment is correctly filled in
-        warning: A few problems were found in the attendance section of this treatment
+        success: This treatment is correctly filled in
+        warning: A few problems were found in this treatment
     outro:
       label: Meeting outro
       validation:

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -85,6 +85,8 @@ behandeling-van-agendapunten:
   edit-document: 'Bewerk document'
   sync-warning: Gegevens mogelijks overschreven door synchronisatie
   add-custom-voting: Aangepaste stemming toevoegen
+  no-decision-present: Geen besluit aanwezig
+  no-decision-present-explanation: Dit agendapunt bevat geen besluit en zal niet worden opgenomen in de publicatie van de besluitenlijst. Als dit niet is wat u verwachtte, controleer dan de inhoud van het agendapunt of neem contact op met support op {email}
 
 contact:
   about: Waar gaat uw bericht over?

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -456,12 +456,12 @@ meeting-toc-card:
     treatments:
       label: Behandelingen
       validation:
-        success: De aanwezigheid van de onderstaande behandeling werd correct ingevuld
-        warning: Er werden enkele problemen aangetroffen bij de aanwezigheid van onderstaande behandelingen
+        success: De onderstaande behandelingen werd correct ingevuld
+        warning: Er werden enkele problemen aangetroffen bij onderstaande behandelingen
     treatment:
       validation:
-        success: Deze aanwezigheid van deze behandeling is correct ingevuld
-        warning: Er werden enkele problemen aangetroffen bij de aanwezigheid van deze behandeling
+        success: Deze behandeling is correct ingevuld
+        warning: Er werden enkele problemen aangetroffen bij deze behandeling
     outro:
       label: Einde van de zitting
       validation:


### PR DESCRIPTION
### Overview
Validate decision presence in treatment. In this we convert the treatment to triples, which is a good thing since we will want to apply a shacl shape to that dataset at some point

##### connected issues and PRs:
GN-5563


### Setup
None

### How to test/reproduce
Check that if you add an agendapoint without a decision it show you a validation warning in the UI

### Challenges/uncertainties
Check the dutch translations



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
