### PR TITLE
CIT-41: configure new versions of rdfa-tools

### DIFF
--- a/app/components/rdfa-editor-container.gts
+++ b/app/components/rdfa-editor-container.gts
@@ -18,9 +18,16 @@ import EditorContainer from '@lblod/ember-rdfa-editor/components/editor-containe
 import Editor from '@lblod/ember-rdfa-editor/components/editor';
 import Sidebar from '@lblod/ember-rdfa-editor/components/sidebar';
 import ResponsiveToolbar from '@lblod/ember-rdfa-editor/components/responsive-toolbar';
+
+import NodeControlsCard from '@lblod/ember-rdfa-editor/components/_private/node-controls/card';
+import DocImportedResourceEditorCard from '@lblod/ember-rdfa-editor/components/_private/doc-imported-resource-editor/card';
+import ImportedResourceLinkerCard from '@lblod/ember-rdfa-editor/components/_private/imported-resource-linker/card';
+import ExternalTripleEditorCard from '@lblod/ember-rdfa-editor/components/_private/external-triple-editor/card';
+import RelationshipEditorCard from '@lblod/ember-rdfa-editor/components/_private/relationship-editor/card';
+import { documentConfig } from '@lblod/ember-rdfa-editor/components/_private/relationship-editor/configs';
 import AttributeEditor from '@lblod/ember-rdfa-editor/components/_private/attribute-editor';
-import RdfaEditor from '@lblod/ember-rdfa-editor/components/_private/rdfa-editor';
 import DebugInfo from '@lblod/ember-rdfa-editor/components/_private/debug-info';
+
 import type {
   NodeViewConstructor,
   Plugin,
@@ -79,8 +86,13 @@ export default class RdfaEditorContainerComponent extends Component<Sig> {
   @service declare features: Features;
   @tracked controller?: SayController;
   @tracked ready = false;
+
+  NodeControlsCard = NodeControlsCard;
+  DocImportedResourceEditorCard = DocImportedResourceEditorCard;
+  ImportedResourceLinkerCard = ImportedResourceLinkerCard;
+  ExternalTripleEditorCard = ExternalTripleEditorCard;
+  RelationshipEditorCard = RelationshipEditorCard;
   AttributeEditor = AttributeEditor;
-  RdfaEditor = RdfaEditor;
   DebugInfo = DebugInfo;
 
   /**
@@ -171,6 +183,10 @@ export default class RdfaEditorContainerComponent extends Component<Sig> {
     return attrString;
   }
 
+  get optionGeneratorConfig() {
+    return this.controller && documentConfig(this.controller);
+  }
+
   <template>
     {{#if @busy}}
       <AuBodyContainer>
@@ -217,16 +233,12 @@ export default class RdfaEditorContainerComponent extends Component<Sig> {
               {{#if this.controller}}
                 <ResponsiveToolbar>
                   <:main as |Tb|>
-                    {{! @glint-expect-error insufficient types for ResponsiveToolbar }}
                     <Tb.Group>
                       <ToolbarHistory @controller={{this.controller}} />
                     </Tb.Group>
-                    {{! @glint-expect-error insufficient types for ResponsiveToolbar }}
                     <Tb.Group>
                       <ToolbarStyling @controller={{this.controller}} />
-                      {{! @glint-expect-error no arg types }}
                       <TextStyleSubscript @controller={{this.controller}} />
-                      {{! @glint-expect-error no arg types }}
                       <TextStyleSuperscript @controller={{this.controller}} />
                       <TextStyleHighlight
                         @controller={{this.controller}}
@@ -237,25 +249,20 @@ export default class RdfaEditorContainerComponent extends Component<Sig> {
                         @defaultColor='#000000'
                       />
                     </Tb.Group>
-                    {{! @glint-expect-error insufficient types for ResponsiveToolbar }}
                     <Tb.Group>
                       <ToolbarList @controller={{this.controller}} />
                       <IndentationMenu @controller={{this.controller}} />
                     </Tb.Group>
-                    {{! @glint-expect-error insufficient types for ResponsiveToolbar }}
                     <Tb.Group>
                       <LinkMenu @controller={{this.controller}} />
                       <ImageInsertMenu @controller={{this.controller}} />
                     </Tb.Group>
-                    {{! @glint-expect-error insufficient types for ResponsiveToolbar }}
                     <Tb.Group>
                       <TableMenu @controller={{this.controller}} />
                     </Tb.Group>
-                    {{! @glint-expect-error insufficient types for ResponsiveToolbar }}
                     <Tb.Group>
                       <HeadingMenu @controller={{this.controller}} />
                     </Tb.Group>
-                    {{! @glint-expect-error insufficient types for ResponsiveToolbar }}
                     <Tb.Group>
                       <AlignmentMenu @controller={{this.controller}} />
                     </Tb.Group>
@@ -263,7 +270,6 @@ export default class RdfaEditorContainerComponent extends Component<Sig> {
                     <Tb.Spacer />
                   </:main>
                   <:side as |Tb|>
-                    {{! @glint-expect-error insufficient types for ResponsiveToolbar }}
                     <Tb.Group>
                       {{yield to='toolbar'}}
                     </Tb.Group>
@@ -292,17 +298,38 @@ export default class RdfaEditorContainerComponent extends Component<Sig> {
                   {{/if}}
                   {{yield to='sidebar'}}
                   {{#if @shouldEditRdfa}}
-                    {{#if this.activeNode}}
-                      <this.RdfaEditor
-                        @node={{this.activeNode}}
-                        @controller={{this.controller}}
-                      />
-                      <this.AttributeEditor
-                        @node={{this.activeNode}}
-                        @controller={{this.controller}}
-                      />
-                      <this.DebugInfo @node={{this.activeNode}} />
-                    {{/if}}
+                    <div
+                      class='au-u-flex au-u-flex--column au-u-flex--spaced-tiny'
+                    >
+                      {{#if this.activeNode}}
+                        <NodeControlsCard
+                          @node={{this.activeNode}}
+                          @controller={{this.controller}}
+                        />
+                        <RelationshipEditorCard
+                          @node={{this.activeNode}}
+                          @controller={{this.controller}}
+                          @optionGeneratorConfig={{this.optionGeneratorConfig}}
+                        />
+                        <DocImportedResourceEditorCard
+                          @controller={{this.controller}}
+                          @optionGeneratorConfig={{this.optionGeneratorConfig}}
+                        />
+                        <ImportedResourceLinkerCard
+                          @node={{this.activeNode}}
+                          @controller={{this.controller}}
+                        />
+                        <ExternalTripleEditorCard
+                          @node={{this.activeNode}}
+                          @controller={{this.controller}}
+                        />
+                        <DebugInfo @node={{this.activeNode}} />
+                        <AttributeEditor
+                          @node={{this.activeNode}}
+                          @controller={{this.controller}}
+                        />
+                      {{/if}}
+                    </div>
                   {{/if}}
                 </Sidebar>
               {{/if}}

--- a/app/components/regulatory-statement-edit-citerra.gts
+++ b/app/components/regulatory-statement-edit-citerra.gts
@@ -68,6 +68,7 @@ import { code_block } from '@lblod/ember-rdfa-editor/plugins/code';
 import { image, imageView } from '@lblod/ember-rdfa-editor/plugins/image';
 import {
   PNode,
+  ProsePlugin,
   SayController,
   Schema,
   type NodeViewConstructor,
@@ -84,7 +85,7 @@ import { color } from '@lblod/ember-rdfa-editor/plugins/color/marks/color';
 import { undo } from '@lblod/ember-rdfa-editor/plugins/history';
 import { getActiveEditableNode } from '@lblod/ember-rdfa-editor/plugins/_private/editable-node';
 import VisualiserCard from '@lblod/ember-rdfa-editor/components/_private/rdfa-visualiser/visualiser-card';
-import LinkRdfaNodeButton from '@lblod/ember-rdfa-editor/components/_private/link-rdfa-node-poc/button';
+import CreateRelationshipButton from '@lblod/ember-rdfa-editor/components/_private/relationship-editor/create-button';
 import type { Option } from '@lblod/ember-rdfa-editor/utils/_private/option';
 import FormattingToggle from '@lblod/ember-rdfa-editor/components/plugins/formatting/formatting-toggle';
 import {
@@ -163,7 +164,7 @@ import {
   OCMW,
 } from 'frontend-gelinkt-notuleren/utils/bestuurseenheid-classificatie-codes';
 import { RDFA_VISUALIZER_CONFIG } from 'frontend-gelinkt-notuleren/utils/citerra-poc/visualizer';
-import { BACKLINK_EDITOR_CONFIG } from 'frontend-gelinkt-notuleren/utils/citerra-poc/backlink-editor';
+import { relationshipEditorConfig } from 'frontend-gelinkt-notuleren/utils/citerra-poc/relationship-editor';
 import type Store from 'frontend-gelinkt-notuleren/services/store';
 import type DocumentService from 'frontend-gelinkt-notuleren/services/document-service';
 import type CurrentSessionService from 'frontend-gelinkt-notuleren/services/current-session';
@@ -276,7 +277,7 @@ export default class RegulatoryStatementEditCiterra extends Component<Regulatory
     };
   }
 
-  get plugins() {
+  get plugins(): ProsePlugin[] {
     return [
       ...tablePlugins,
       tableKeymap,
@@ -473,7 +474,10 @@ export default class RegulatoryStatementEditCiterra extends Component<Regulatory
    * CITERRA POC
    */
   visualizerConfig = RDFA_VISUALIZER_CONFIG;
-  backlinkEditorConfig = BACKLINK_EDITOR_CONFIG;
+
+  get backlinkEditorConfig() {
+    return this.controller && relationshipEditorConfig(this.controller);
+  }
 
   @action
   insertThing(thing: string) {
@@ -819,14 +823,10 @@ export default class RegulatoryStatementEditCiterra extends Component<Regulatory
         <:sidebarCollapsible>
           {{#if this.controller}}
             {{#if this.activeNode}}
-              <LinkRdfaNodeButton
+              <CreateRelationshipButton
                 @controller={{this.controller}}
                 @node={{this.activeNode}}
-                @predicateOptionGenerator={{this.backlinkEditorConfig.predicateOptionGenerator}}
-                @subjectOptionGenerator={{this.backlinkEditorConfig.subjectOptionGenerator
-                  this.controller
-                }}
-                @objectOptionGenerator={{this.backlinkEditorConfig.objectOptionGenerator}}
+                @optionGeneratorConfig={{this.backlinkEditorConfig}}
               />
             {{/if}}
             <ArticleStructureCard
@@ -902,7 +902,6 @@ export default class RegulatoryStatementEditCiterra extends Component<Regulatory
             {{#if this.activeNode}}
               <VisualiserCard
                 @controller={{this.controller}}
-                @node={{this.activeNode}}
                 @config={{this.visualizerConfig}}
               />
             {{/if}}

--- a/app/controllers/agendapoints/edit.ts
+++ b/app/controllers/agendapoints/edit.ts
@@ -31,11 +31,6 @@ import ConceptModel from 'frontend-gelinkt-notuleren/models/concept';
 import BehandelingVanAgendapunt from 'frontend-gelinkt-notuleren/models/behandeling-van-agendapunt';
 import { unwrap } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
 
-import VisualiserCard from '@lblod/ember-rdfa-editor/components/_private/rdfa-visualiser/visualiser-card';
-import LinkRdfaNodeButton from '@lblod/ember-rdfa-editor/components/_private/link-rdfa-node-poc/button';
-import { RDFA_VISUALIZER_CONFIG } from 'frontend-gelinkt-notuleren/utils/citerra-poc/visualizer';
-import { BACKLINK_EDITOR_CONFIG } from 'frontend-gelinkt-notuleren/utils/citerra-poc/backlink-editor';
-
 export default class AgendapointsEditController extends Controller {
   @service declare store: StoreService;
   @service declare router: RouterService;
@@ -236,12 +231,4 @@ export default class AgendapointsEditController extends Controller {
 
     return parsedHtml.body.innerHTML;
   }
-
-  /**
-   * CITERRA POC
-   */
-  VisualiserCard = VisualiserCard;
-  LinkRdfaNodeButton = LinkRdfaNodeButton;
-  visualizerConfig = RDFA_VISUALIZER_CONFIG;
-  backlinkEditorConfig = BACKLINK_EDITOR_CONFIG;
 }

--- a/app/templates/agendapoints/edit.hbs
+++ b/app/templates/agendapoints/edit.hbs
@@ -114,16 +114,6 @@
       <Plugins::Formatting::FormattingToggle @controller={{this.controller}} />
     </:toolbar>
     <:sidebarCollapsible>
-      {{#if (feature-flag 'citerra-poc')}}
-        <this.LinkRdfaNodeButton
-          @controller={{this.controller}}
-          @node={{this.activeNode}}
-          @predicateOptionGenerator={{this.backlinkEditorConfig.predicateOptionGenerator}}
-          @subjectOptionGenerator={{this.backlinkEditorConfig.subjectOptionGenerator
-            this.controller
-          }}
-        />
-      {{/if}}
       <this.InsertArticle
         @controller={{this.controller}}
         @options={{this.config.insertArticle}}
@@ -182,13 +172,6 @@
       {{/if}}
     </:sidebarCollapsible>
     <:sidebar>
-      {{#if (feature-flag 'citerra-poc')}}
-        <this.VisualiserCard
-          @controller={{this.controller}}
-          @node={{this.activeNode}}
-          @config={{this.visualizerConfig}}
-        />
-      {{/if}}
       <this.StructureControlCard @controller={{this.controller}} />
       <DecisionPlugin::DecisionPluginCard
         @controller={{this.controller}}

--- a/app/utils/citerra-poc/relationship-editor.ts
+++ b/app/utils/citerra-poc/relationship-editor.ts
@@ -8,9 +8,11 @@ import { unwrap } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
 import type {
   PredicateOption,
   PredicateOptionGenerator,
-  TargetOptionGenerator,
+  ObjectOptionGenerator,
+  SubjectOptionGenerator,
   TermOption,
-} from '@lblod/ember-rdfa-editor/components/_private/link-rdfa-node-poc/modal';
+  OptionGeneratorConfig,
+} from '@lblod/ember-rdfa-editor/components/_private/relationship-editor/types';
 import {
   isRdfaAttrs,
   type RdfaResourceAttrs,
@@ -75,7 +77,7 @@ const SUBJECT_OPTION_MATCHERS: SubjectOptionMatcher[] = [
 
 const subjectOptionGenerator = (
   controller: SayController,
-): TargetOptionGenerator => {
+): SubjectOptionGenerator => {
   return ({ searchString = '' } = {}) => {
     const subjectMapping = rdfaInfoPluginKey.getState(
       controller.mainEditorState,
@@ -109,7 +111,7 @@ const subjectOptionGenerator = (
   };
 };
 
-const objectOptionGenerator: TargetOptionGenerator = ({
+const objectOptionGenerator: ObjectOptionGenerator = ({
   searchString = '',
 } = {}) => {
   // FIXME We should add object options but I don't know what we should expect
@@ -122,8 +124,10 @@ const objectOptionGenerator: TargetOptionGenerator = ({
   );
 };
 
-export const BACKLINK_EDITOR_CONFIG = {
-  predicateOptionGenerator,
-  subjectOptionGenerator,
-  objectOptionGenerator,
-};
+export const relationshipEditorConfig: (
+  controller: SayController,
+) => OptionGeneratorConfig = (controller) => ({
+  predicates: predicateOptionGenerator,
+  subjects: subjectOptionGenerator(controller),
+  objects: objectOptionGenerator,
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "@lblod/ember-acmidm-login": "^2.1.0",
         "@lblod/ember-environment-banner": "^0.6.0",
         "@lblod/ember-mock-login": "^0.10.0",
-        "@lblod/ember-rdfa-editor": "12.6.1",
+        "@lblod/ember-rdfa-editor": "12.6.1-dev.3e6971c608af91f07636dabcf30128718c1e734b",
         "@lblod/ember-rdfa-editor-lblod-plugins": "31.0.3",
         "@lblod/template-uuid-instantiator": "^1.0.3",
         "@nullvoxpopuli/ember-composable-helpers": "^5.2.6",
@@ -7372,9 +7372,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor": {
-      "version": "12.6.1",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-12.6.1.tgz",
-      "integrity": "sha512-i/CHo1A1wZbvEdNKMBXjPuWE4YyjJUaM7EblkkEQDFfJZC6IBcDuv4IpBwhIRGv6ntZ/UV+BkSQLKR1wjQ6wgQ==",
+      "version": "12.6.1-dev.3e6971c608af91f07636dabcf30128718c1e734b",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-12.6.1-dev.3e6971c608af91f07636dabcf30128718c1e734b.tgz",
+      "integrity": "sha512-9Lz2M4UGDoJbSkdlIyVNmCLZWDdWlZ9zbT9EUlXkNJZ6reYoHwmaj9cXOXcL0zrrrH4doP7gH8uc6PUt8kimVw==",
       "dev": true,
       "dependencies": {
         "@codemirror/commands": "^6.6.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@lblod/ember-acmidm-login": "^2.1.0",
     "@lblod/ember-environment-banner": "^0.6.0",
     "@lblod/ember-mock-login": "^0.10.0",
-    "@lblod/ember-rdfa-editor": "12.6.1",
+    "@lblod/ember-rdfa-editor": "12.6.1-dev.3e6971c608af91f07636dabcf30128718c1e734b",
     "@lblod/ember-rdfa-editor-lblod-plugins": "31.0.3",
     "@lblod/template-uuid-instantiator": "^1.0.3",
     "@nullvoxpopuli/ember-composable-helpers": "^5.2.6",


### PR DESCRIPTION
### Overview
This PR configures the new versions of the rdfa-tools (implemented in https://github.com/lblod/ember-rdfa-editor/pull/1310).
This PR can be used to e.g. test the imported-resource linker tool (which cannot be easily tested in the editor test-app)

##### connected issues and PRs:
[CIT-41](https://binnenland.atlassian.net/browse/CIT-41?atlOrigin=eyJpIjoiZDUzZmZhNGJhZTczNDVlMmJlODI3Y2Y0NzQ0ZjY4ZjIiLCJwIjoiaiJ9)
https://github.com/lblod/ember-rdfa-editor/pull/1310

### How to test/reproduce
- Start the app
- Enable the `@shouldEditRdfa` argument for all editor instances
- Open an agendapoint. Ensure all rdfa-tools show up and behave as expected
- Open a regulatory statement (with or without citerra enabled). Ensure the rdfa-tools work correctly, the rdfa-visualizer is correctly shown, and the 'Add relationship' button works.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [ ] changelog
- [x] npm lint
- [x] no new deprecations
