### PR TITLE
fix: increase page-size-limit of agendapoints rel on zitting model

### DIFF
--- a/.changeset/short-maps-tease.md
+++ b/.changeset/short-maps-tease.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Increase `defaultPageSize` limit to 100 for `agendapoints` relationship of `zitting` model

--- a/app/models/behandeling-van-agendapunt.ts
+++ b/app/models/behandeling-van-agendapunt.ts
@@ -60,20 +60,16 @@ export default class BehandelingVanAgendapunt extends Model {
   })
   declare besluiten: AsyncHasMany<BesluitModel>;
 
-  // @ts-expect-error add types for `defaultPageSize`
   @hasMany('mandataris', { inverse: null, defaultPageSize: 100, async: true })
   declare aanwezigen: AsyncHasMany<MandatarisModel>;
 
-  // @ts-expect-error add types for `defaultPageSize`
   @hasMany('mandataris', { inverse: null, defaultPageSize: 100, async: true })
   declare afwezigen: AsyncHasMany<MandatarisModel>;
 
-  // @ts-expect-error add types for `defaultPageSize`
   @hasMany('mandataris', { inverse: null, defaultPageSize: 100, async: true })
   declare nietToegekendeMandatarissen: AsyncHasMany<MandatarisModel>;
 
   // original queries did "fetch all" pagination loops
-  // @ts-expect-error add types for `defaultPageSize`
   @hasMany('stemming', {
     inverse: 'behandelingVanAgendapunt',
     defaultPageSize: 1000,
@@ -81,7 +77,6 @@ export default class BehandelingVanAgendapunt extends Model {
   })
   declare stemmingen: AsyncHasMany<StemmingModel>;
 
-  // @ts-expect-error add types for `defaultPageSize`
   @hasMany('custom-voting', {
     inverse: 'behandelingVanAgendapunt',
     defaultPageSize: 1000,

--- a/app/models/zitting.ts
+++ b/app/models/zitting.ts
@@ -33,18 +33,21 @@ export default class ZittingModel extends Model {
 
   @hasMany('agenda', { inverse: null, async: true })
   declare publicatieAgendas: AsyncHasMany<Agenda>;
-  @hasMany('agendapunt', { inverse: 'zitting', async: true, as: 'zitting' })
+
+  @hasMany('agendapunt', {
+    inverse: 'zitting',
+    defaultPageSize: 100,
+    async: true,
+    as: 'zitting',
+  })
   declare agendapunten: AsyncHasMany<Agendapunt>;
 
-  // @ts-expect-error add types for `defaultPageSize`
   @hasMany('mandataris', { inverse: null, defaultPageSize: 100, async: true })
   declare aanwezigenBijStart: AsyncHasMany<MandatarisModel>;
 
-  // @ts-expect-error add types for `defaultPageSize`
   @hasMany('mandataris', { inverse: null, defaultPageSize: 100, async: true })
   declare afwezigenBijStart: AsyncHasMany<MandatarisModel>;
 
-  // @ts-expect-error add types for `defaultPageSize`
   @hasMany('mandataris', { inverse: null, defaultPageSize: 100, async: true })
   declare nietToegekendeMandatarissen: AsyncHasMany<MandatarisModel>;
 

--- a/types/@ember-data/model.d.ts
+++ b/types/@ember-data/model.d.ts
@@ -1,0 +1,20 @@
+import '@ember-data/model';
+import type { NoNull } from '@ember-data/model/-private/belongs-to';
+import type { RelationshipDecorator } from '@ember-data/model/-private/belongs-to';
+import type { RelationshipOptions } from '@ember-data/model/-private/belongs-to';
+import type { TypeFromInstance } from '@warp-drive/core-types/record';
+
+type HasManyOptions = RelationshipOptions<T, boolean> & {
+  defaultPageSize?: number;
+};
+
+declare module '@ember-data/model' {
+  export function hasMany<T>(
+    type: TypeFromInstance<NoNull<T>>,
+    options: HasManyOptions,
+  ): RelationshipDecorator<T>;
+  export function hasMany(
+    type: string,
+    options: HasManyOptions,
+  ): RelationshipDecorator<unknown>;
+}


### PR DESCRIPTION
### Overview
This ensures that e.g. the meeting table-of-contents displays all agendapoints (up to a 100) of a meeting.
Also includes some type overrides for the `hasMany` function/decorator.

### How to test/reproduce
- Open a meeting with more than 20 ap's
- Ensure all ap's are displayed in the table-of-contents

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
