### PR TITLE
Hide IV creation option behind a feature flag

### DIFF
--- a/.changeset/yellow-crabs-wash.md
+++ b/.changeset/yellow-crabs-wash.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': minor
+---
+
+Hide creation of IV meetings behind a feature flag

--- a/app/controllers/inbox/meetings.js
+++ b/app/controllers/inbox/meetings.js
@@ -13,6 +13,7 @@ export default class InboxMeetingsController extends Controller {
   @service store;
   @service currentSession;
   @service router;
+  @service features;
 
   sort = '-geplande-start';
   @tracked debounceTime = 2000;
@@ -28,7 +29,7 @@ export default class InboxMeetingsController extends Controller {
   };
 
   mayCreateInaugurationMeeting = trackedFunction(this, async () => {
-    if (this.readOnly) {
+    if (this.readOnly || !this.features.isEnabled('inauguration-meeting')) {
       return false;
     }
     const unitClass = await this.currentSession.group.classificatie;

--- a/app/templates/inbox/meetings.hbs
+++ b/app/templates/inbox/meetings.hbs
@@ -20,25 +20,29 @@
           {{#unless
             (or this.readOnly this.mayCreateInaugurationMeeting.isLoading)
           }}
-            <AuDropdown
-              @skin='primary'
-              @title={{t 'inbox.meetings.new.title'}}
-              @alignment='left'
-              @icon='chevron-down'
-              role='menu'
-            >
-              <AuLink @route='inbox.meetings.new' role='menuitem'>
-                {{t 'inbox.meetings.new.common-meeting.title'}}
-              </AuLink>
-              {{#if this.mayCreateInaugurationMeeting.value}}
+            {{#if this.mayCreateInaugurationMeeting.value}}
+              <AuDropdown
+                @skin='primary'
+                @title={{t 'inbox.meetings.new.title'}}
+                @alignment='left'
+                @icon='chevron-down'
+                role='menu'
+              >
+                <AuLink @route='inbox.meetings.new' role='menuitem'>
+                  {{t 'inbox.meetings.new.common-meeting.title'}}
+                </AuLink>
                 <AuLink
                   @route='inbox.meetings.new-inauguration'
                   role='menuitem'
                 >
                   {{t 'inbox.meetings.new.inauguration-meeting.title'}}
                 </AuLink>
-              {{/if}}
-            </AuDropdown>
+              </AuDropdown>
+            {{else}}
+              <AuLink @route='inbox.meetings.new' @skin='button' @icon='add'>
+                {{t 'inbox.meetings.new.common-meeting.title'}}
+              </AuLink>
+            {{/if}}
           {{/unless}}
         </Group>
       </AuToolbar>

--- a/config/environment.js
+++ b/config/environment.js
@@ -55,6 +55,7 @@ module.exports = function (environment) {
       'regulatory-statements': '{{GN_FEATURE_REGULATORY_STATEMENTS}}',
       'mandatee-table-editor': '{{GN_FEATURE_MANDATEE_TABLE_EDITOR}}',
       'citerra-poc': '{{GN_FEATURE_CITERRA_POC}}',
+      'inauguration-meeting': '{{GN_FEATURE_INAUGURATION_MEETING}}',
     },
     browserUpdate: {
       vs: { f: -3, c: -3 },
@@ -93,6 +94,7 @@ module.exports = function (environment) {
     ENV.featureFlags['prosemirror-dev-tools'] = true;
     ENV.featureFlags['mandatee-table-editor'] = true;
     ENV.featureFlags['citerra-poc'] = true;
+    ENV.featureFlags['inauguration-meeting'] = true;
     ENV.mowRegistryEndpoint =
       process.env.MOW_REGISTRY_SPARQL_ENDPOINT ??
       'https://dev.roadsigns.lblod.info/sparql';


### PR DESCRIPTION
### Overview
...

##### connected issues and PRs:
Jira ticket: https://binnenland.atlassian.net/browse/GN-5428

### Setup
N/A

### How to test/reproduce
With flag = false, get a 'create meeting' button, with flag = true, get a dropdown.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
