### PR TITLE
citerra: include additional `mobiliteit:Zone` rdf-type on locations

### DIFF
--- a/app/components/regulatory-statement-edit-citerra.gts
+++ b/app/components/regulatory-statement-edit-citerra.gts
@@ -175,6 +175,7 @@ import DownloadDocument from 'frontend-gelinkt-notuleren/components/download-doc
 import RdfaEditorContainer from 'frontend-gelinkt-notuleren/components/rdfa-editor-container';
 import ConfirmRouteLeave from 'frontend-gelinkt-notuleren/components/confirm-route-leave';
 import humanFriendlyDate from 'frontend-gelinkt-notuleren/helpers/human-friendly-date';
+import { sayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
 
 interface RegulatoryStatementEditSig {
   Args: {
@@ -368,6 +369,11 @@ export default class RegulatoryStatementEditCiterra extends Component<Regulatory
           SAY('Subsection'),
           SAY('Section'),
           SAY('Chapter'),
+        ],
+        additionalRDFTypes: [
+          sayDataFactory.namedNode(
+            'https://data.vlaanderen.be/ns/mobiliteit#Zone',
+          ),
         ],
       },
       lmb: {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@lblod/ember-environment-banner": "^0.6.0",
     "@lblod/ember-mock-login": "^0.10.0",
     "@lblod/ember-rdfa-editor": "12.10.2",
-    "@lblod/ember-rdfa-editor-lblod-plugins": "32.2.0",
+    "@lblod/ember-rdfa-editor-lblod-plugins": "32.2.0-dev.4703977bcd18e3a08bc1713654b5767a73a0a791",
     "@lblod/template-uuid-instantiator": "^1.0.3",
     "@nullvoxpopuli/ember-composable-helpers": "^5.2.6",
     "@rdfjs/types": "^2.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,8 +137,8 @@ importers:
         specifier: 12.10.2
         version: 12.10.2(yoadtbtun6ib6qcdgxl7h75szu)
       '@lblod/ember-rdfa-editor-lblod-plugins':
-        specifier: 32.2.0
-        version: 32.2.0(oz5tle6fa3wwtkdosmcx4i4vue)
+        specifier: 32.2.0-dev.4703977bcd18e3a08bc1713654b5767a73a0a791
+        version: 32.2.0-dev.4703977bcd18e3a08bc1713654b5767a73a0a791(oz5tle6fa3wwtkdosmcx4i4vue)
       '@lblod/template-uuid-instantiator':
         specifier: ^1.0.3
         version: 1.0.3
@@ -1677,8 +1677,8 @@ packages:
       ember-simple-auth: ^6.0.0
       ember-source: '>= 4.0.0'
 
-  '@lblod/ember-rdfa-editor-lblod-plugins@32.2.0':
-    resolution: {integrity: sha512-X/fVgptJcdwuBByyhc3bn7g5Ad+boCMqhxm2H95uTUq4N9qdvm8LjjiwH9urkLksaY1BKUUe7a6EnLkhOgmJgg==}
+  '@lblod/ember-rdfa-editor-lblod-plugins@32.2.0-dev.4703977bcd18e3a08bc1713654b5767a73a0a791':
+    resolution: {integrity: sha512-3GK5xzfQetInuTdkqflGmar6OZIQi7v5gMB1JDriR/LS6sEKX1cRRYxzx7KMutvZ+45Jt1euG9fnAz1zDzC8JA==}
     engines: {node: '>= 18'}
     peerDependencies:
       '@appuniversum/ember-appuniversum': ^3.5.0
@@ -11133,7 +11133,7 @@ snapshots:
       - supports-color
       - webpack
 
-  '@lblod/ember-rdfa-editor-lblod-plugins@32.2.0(oz5tle6fa3wwtkdosmcx4i4vue)':
+  '@lblod/ember-rdfa-editor-lblod-plugins@32.2.0-dev.4703977bcd18e3a08bc1713654b5767a73a0a791(oz5tle6fa3wwtkdosmcx4i4vue)':
     dependencies:
       '@appuniversum/ember-appuniversum': 3.12.0(ozthojvnolfd3umnnunjuqt6ri)
       '@babel/core': 7.26.10


### PR DESCRIPTION
### Overview
This (draft) PR updates to the changes included in https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/583 and includes the `mobiliteit:Zone` rdf-type on locations on the citerra page.

##### connected issues and PRs:
https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/583

### How to test/reproduce
- Start the app
- Open a regulatory statement with citerra enabled
- Insert a location
- Export the document to html + check that the additional `mobiliteit:Zone` rdf-type is included on the location

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
