### PR TITLE
Correctly process prepublisher errors on the extracts

### DIFF
--- a/.changeset/five-teams-sort.md
+++ b/.changeset/five-teams-sort.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Correctly show prepublisher errors on the extract page

--- a/app/controllers/meetings/publish/uittreksels/show.js
+++ b/app/controllers/meetings/publish/uittreksels/show.js
@@ -204,7 +204,9 @@ export default class MeetingsPublishUittrekselsShowController extends Controller
       );
       if (!result.ok) {
         const json = await result.json();
-        const errors = json?.errors.map((error) => error.title).join('\n');
+        const errors = json?.errors
+          .map((error) => error.title || error)
+          .join('\n');
         throw errors;
       }
       // TODO if the prepublisher would be fully jsonAPI compliant, this would not be needed


### PR DESCRIPTION
### Overview
Fix the way errors from the prepublisher are shown in the extracts as they are now an array of objects.
I checked and the other pages just don't show any errors from the prepublisher but it requires more work to fix, I will create a ticket for that
##### connected issues and PRs:
GN-5649 kinda


### Setup
None

### How to test/reproduce
Maybe a little bit hard to test, but you will have to force a error from the prepublisher, or change the code of the prepublisher to throw an error and check that is correctly shown on the extracts page

### Challenges/uncertainties
None


### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
