### PR TITLE
Actually use roadsigns table styling

### DIFF
--- a/.changeset/thin-spiders-brake.md
+++ b/.changeset/thin-spiders-brake.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Correctly style traffic measure insert modal

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -36,6 +36,7 @@
 @import 'structure-plugin';
 @import 'mandatee-table-plugin';
 @import 'document-validation';
+@import 'roadsign-regulation-table';
 
 // PROJECT COMPONENTS > @TODO: refactor in ember-appuniversum where possible
 @import 'project/c-app-chrome';


### PR DESCRIPTION
### Overview
While the padding on the table had been fixed, I realised the weird styling for roadsign templates in the traffic measure modal was caused by not actually using the stylesheet.

##### connected issues and PRs:
Related to https://binnenland.atlassian.net/browse/GN-5685

### Setup
N/A

### How to test/reproduce
Open the 'insert traffic measure' modal and notice that long templates no longer overflow onto the next row.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
