### PR TITLE
Add own deps to autoimport reload

### DIFF
--- a/.changeset/mean-jars-sit.md
+++ b/.changeset/mean-jars-sit.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+add our own deps to watchdeps

--- a/app/components/agendapoint-edit.gts
+++ b/app/components/agendapoint-edit.gts
@@ -506,7 +506,6 @@ export default class AgendapointsEditController extends Component<AgendapointEdi
             </div>
           </:toolbar>
           <:sidebarCollapsible as |container|>
-            {{! @glint-expect-error for some reason @label is required although it has a sensible default }}
             <InsertArticleComponent
               @controller={{container.controller}}
               @options={{this.config.insertArticle}}

--- a/app/components/regulatory-statement-edit-citerra.gts
+++ b/app/components/regulatory-statement-edit-citerra.gts
@@ -937,7 +937,6 @@ export default class RegulatoryStatementEditCiterra extends Component<Regulatory
           <TemplateCommentInsert @controller={{container.controller}} />
           <LocationInsert
             @controller={{container.controller}}
-            {{! @glint-expect-error Option vs undefined }}
             @defaultMunicipality={{get this.defaultMunicipality 'naam'}}
             @config={{this.config.location}}
           />

--- a/app/components/regulatory-statement-edit.gts
+++ b/app/components/regulatory-statement-edit.gts
@@ -659,7 +659,6 @@ export default class RegulatoryStatementEdit extends Component<RegulatoryStateme
           <TemplateCommentInsert @controller={{container.controller}} />
           <LocationInsert
             @controller={{container.controller}}
-            {{! @glint-expect-error Option vs undefined }}
             @defaultMunicipality={{get this.defaultMunicipality 'naam'}}
             @config={{this.config.location}}
           />

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -5,6 +5,13 @@ const envIsProduction = process.env.EMBER_ENV === 'production';
 
 module.exports = function (defaults) {
   let app = new EmberApp(defaults, {
+    autoImport: {
+      watchDependencies: [
+        '@lblod/ember-rdfa-editor',
+        '@lblod/ember-rdfa-editor-lblod-plugins',
+        '@appuniversum/ember-appuniversum',
+      ],
+    },
     'ember-cli-babel': {
       includePolyfill: false,
       enableTypeScriptTransform: true,


### PR DESCRIPTION

### Overview
<!-- high level overview of changes (not just "implement ticket") + *why* + design document, special notes like ticket partially implemented etc. -->

Should make it so that when the node_modules content of these deps changes, the devServer will rebuild.

- **chore: add our deps to autoImport watchdependencies**
- **docs: add changeset**
##### connected issues and PRs:
<!-- links to connected jira tickets -->
<!-- Link to PRs that are related (and in what way) -->


### Setup
<!-- PR dependencies -->
<!-- override snippets -->

### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->



### Checks PR readiness
- [x] changelog
