### PR TITLE
Use regulatory notation for inserting traffic signals text for AR imports

### DIFF
--- a/.changeset/public-cloths-tan.md
+++ b/.changeset/public-cloths-tan.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': minor
+---
+
+Use regulatoryNotation text when inserting measures imported from AR designs

--- a/app/models/traffic-signal-concept.ts
+++ b/app/models/traffic-signal-concept.ts
@@ -6,5 +6,6 @@ export default class TrafficSignalConcept extends Model {
 
   @attr('string') declare uri: string;
   @attr('string') declare code: string;
+  @attr('string') declare regulatoryNotation?: string;
   @attr('string') declare type: string;
 }

--- a/app/services/ar-importer.ts
+++ b/app/services/ar-importer.ts
@@ -70,6 +70,7 @@ function convertSignals(signals: TrafficSignal[]) {
         code: trafficSignalConcept.code,
         uri: trafficSignalConcept.uri,
         type: trafficSignalConcept.type,
+        regulatoryNotation: trafficSignalConcept.regulatoryNotation,
         image: '',
       };
     }),


### PR DESCRIPTION
### Overview
<!-- high level overview of changes (not just "implement ticket") + *why* + design document, special notes like ticket partially implemented etc. -->

see linked pr

##### connected issues and PRs:
<!-- links to connected jira tickets -->
<!-- Link to PRs that are related (and in what way) -->

[GN-6052](https://binnenland.atlassian.net/browse/GN-6052)
https://github.com/lblod/vks-design-service/pull/14

### Setup
<!-- PR dependencies -->
<!-- override snippets -->


Setup vks as described in the pr there

### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

Make sure your GN setup is connecting to the right MOW endpoint
Make sure the AR-design you're testing with references signals that actually have special regulatory notation filled in in MOW registry you've configured for your VKS-design service.
Check if it inserts the correct text

### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->



### Checks PR readiness
- [x] changelog
- [x] npm lint
- [x] no new deprecations
