### PR TITLE
Missing translation in document information modal

### DIFF
--- a/.changeset/dirty-clowns-stick.md
+++ b/.changeset/dirty-clowns-stick.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Missing translation in document information modal

--- a/app/components/document-information-modal.gts
+++ b/app/components/document-information-modal.gts
@@ -338,7 +338,7 @@ export default class DocumentInformationModal extends Component<Sig> {
   <template>
     <div {{this.updateDataModifier}}>
       <AuModal
-        @title='Edit document information'
+        @title={{t 'document-information-modal.modal-title'}}
         @overflow={{true}}
         @modalOpen={{true}}
         @closeModal={{@closeModal}}

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -961,6 +961,7 @@ ar-importer:
     warning-un-included-signal-concept: Signal {signal} is not included in the measure {measure} but it is used in this design
 document-information-modal:
   button-title: Document information
+  modal-title: Edit document information
   document-title: Document title
   decision-topic: Decision topic
   save: Save

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -968,6 +968,7 @@ ar-importer:
 
 document-information-modal:
   button-title: Documentinformatie bewerken
+  modal-title: Documentinformatie bewerken
   document-title: Titel document
   decision-topic: Besluitondwerp
   save: Opslaan


### PR DESCRIPTION
### Overview
Noticed a missing translation in the document information modal during the demo

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-5974


### Setup
None

### How to test/reproduce
Notice the translation error is fixed

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
