### PR TITLE
Fix delete button for agendapoints

### DIFF
--- a/.changeset/legal-teeth-nail.md
+++ b/.changeset/legal-teeth-nail.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Fix bug where 'move to trash' button was not displayed for agendapoints

--- a/app/components/agendapoint-edit.gts
+++ b/app/components/agendapoint-edit.gts
@@ -431,7 +431,8 @@ export default class AgendapointsEditController extends Component<AgendapointEdi
                 {{t 'agendapoint.copy-parts-link'}}
               </AuLink>
             {{/if}}
-            {{#if this.isNotAllowedToTrash.isResolved}}
+            {{! This has to be reversed as the result is a bool and reactiveweb incorrectly returns 'false' for 'isResolved' if the result is 'false' }}
+            {{#unless this.isNotAllowedToTrash.isPending}}
               <AuButton
                 {{on 'click' this.toggleDeleteModal}}
                 @skin='link'
@@ -442,7 +443,7 @@ export default class AgendapointsEditController extends Component<AgendapointEdi
                 <AuIcon @icon='bin' @alignment='left' />
                 {{t 'utils.delete'}}
               </AuButton>
-            {{/if}}
+            {{/unless}}
           </AuDropdown>
           <AuButton
             {{on 'click' (perform this.saveTask)}}


### PR DESCRIPTION
### Overview
It seems there's a bug in reactiveweb for boolean returns, where `isResolved` returns false if the promise has resolved to `false`. I've checked the rest of this codebase and it doesn't seem we're hitting this bug as we're not checking the resolved state when handling booleans.

##### connected issues and PRs:
Fixes https://binnenland.atlassian.net/browse/GN-6080
Submitted upstream patch: https://github.com/universal-ember/reactiveweb/pull/189

### Setup
N/A

### How to test/reproduce
Open an AP and the file options menu should include the delete/naar prullenmand button. It should be disabled or not depending on whether it has been attached to a meeting or not.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [x] changelog
- [x] npm lint
- [x] no new deprecations
