### PR TITLE
Don't crash if a RS document container has no current version

### DIFF
--- a/.changeset/major-clocks-think.md
+++ b/.changeset/major-clocks-think.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Fix crash when a regulatory statement does not have a current version

--- a/app/routes/inbox/regulatory-statements.js
+++ b/app/routes/inbox/regulatory-statements.js
@@ -35,7 +35,12 @@ export default class InboxRegulatoryStatementsRoute extends Route {
     if (params.filter) {
       options['filter[current-version][title]'] = params.filter;
     }
-    return this.store.query('document-container', options);
+    const containers = await this.store.query('document-container', options);
+    // If the saving process is interupted, it's possible to have no `currentVersion`. We don't have
+    // a good way to handle this, so just hide them from the list to avoid crashes.
+    return containers.filter((container) =>
+      container.currentVersion.get('status'),
+    );
   }
   @action
   loading(transition) {


### PR DESCRIPTION
### Overview
Fixes the crash seen for Holsbeek on QA. Preventative fixes ~~should follow later~~ in a separate PR.

##### connected issues and PRs:
Jira ticket: https://binnenland.atlassian.net/browse/GN-6079
PR for prevention steps: https://github.com/lblod/frontend-gelinkt-notuleren/pull/915

### Setup
Either load a recent (after 14/04) QA backup or generate your own broken RS document containers:
- Create a RS based on the 'RPR - rechtspositieregeling 2026' template, this is a very large document and takes some time to create.
- After starting the creation, navigate away from the page by clicking back or refreshing
- The document-container should have been created, as well as the editor-document, but they are only linked as a revision, not as `currentVersion`.

### How to test/reproduce
Instead of the RS list page crashing from this broken data, it is now just ignored, so does not appear in the list.

### Challenges/uncertainties
Difficulties in preventing this happening have been moved to another PR.

### Checks PR readiness
- [x] changelog
- [x] npm lint
- [x] no new deprecations
