### PR TITLE
make sure to sent cookies to the endpoint

### DIFF
--- a/.changeset/heavy-toys-count.md
+++ b/.changeset/heavy-toys-count.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Send cookies to endpoint for sparql queries

--- a/app/utils/sparql.ts
+++ b/app/utils/sparql.ts
@@ -43,7 +43,7 @@ export async function executeQuery<Binding = Record<string, RDF.Term>>({
   const response = await fetch(endpoint, {
     method: 'POST',
     mode: 'cors',
-    credentials: "same-origin",
+    credentials: 'same-origin',
     headers: {
       Accept: 'application/sparql-results+json',
       'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',

--- a/app/utils/sparql.ts
+++ b/app/utils/sparql.ts
@@ -43,6 +43,7 @@ export async function executeQuery<Binding = Record<string, RDF.Term>>({
   const response = await fetch(endpoint, {
     method: 'POST',
     mode: 'cors',
+    credentials: "same-origin",
     headers: {
       Accept: 'application/sparql-results+json',
       'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',


### PR DESCRIPTION
### Overview
Include cookies when doing a SPARQL request. This ensures the sparql wrapper can verify if there is an active session

##### connected issues and PRs:



### Setup


### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->



### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
