### PR TITLE
Allow the user to clear the linked decision select

### DIFF
--- a/.changeset/polite-forks-watch.md
+++ b/.changeset/polite-forks-watch.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Allow the user to clear the linked decision select

--- a/app/components/document-creator/modal.gts
+++ b/app/components/document-creator/modal.gts
@@ -130,8 +130,10 @@ export default class DocumentCreatorModal extends Component<Sig> {
     }
   });
 
-  updateLinkedDecision = (linkedDecisionOption: updateLinkedDecisionArgs) => {
-    this.linkedDecisionUri = linkedDecisionOption.uri;
+  updateLinkedDecision = (
+    linkedDecisionOption: updateLinkedDecisionArgs | null,
+  ) => {
+    this.linkedDecisionUri = linkedDecisionOption?.uri;
   };
 
   <template>

--- a/app/components/document-information-modal.gts
+++ b/app/components/document-information-modal.gts
@@ -234,8 +234,10 @@ export default class DocumentInformationModal extends Component<Sig> {
     return this.topics.value || [];
   }
 
-  updateLinkedDecision = (linkedDecisionOption: updateLinkedDecisionArgs) => {
-    this.linkedDecisionUri = linkedDecisionOption.uri;
+  updateLinkedDecision = (
+    linkedDecisionOption: updateLinkedDecisionArgs | null,
+  ) => {
+    this.linkedDecisionUri = linkedDecisionOption?.uri;
     this.linkedDecisionChanged = true;
   };
 
@@ -280,22 +282,20 @@ export default class DocumentInformationModal extends Component<Sig> {
   }
 
   updateDocumentLinkedDecision() {
-    if (this.linkedDecisionUri) {
-      this.controller.doCommand((state, dispatch) => {
-        if (!dispatch) {
-          return false;
-        }
-        const { result, transaction } = setLinkedDecision(
-          state,
-          this.linkedDecisionUri as string,
-        );
-        if (result.every((ok) => ok)) {
-          dispatch(transaction);
-          return true;
-        }
+    this.controller.doCommand((state, dispatch) => {
+      if (!dispatch) {
         return false;
-      });
-    }
+      }
+      const { result, transaction } = setLinkedDecision(
+        state,
+        this.linkedDecisionUri,
+      );
+      if (result.every((ok) => ok)) {
+        dispatch(transaction);
+        return true;
+      }
+      return false;
+    });
   }
 
   getLinkedDecisionFromDocument = () => {

--- a/app/components/linked-decision-select.gts
+++ b/app/components/linked-decision-select.gts
@@ -137,6 +137,7 @@ export default class LinkedDecisionSelect extends Component<Sig> {
         @options={{this.publishedBesluits}}
         @selected={{this.selectedPublishedBesluit}}
         @onChange={{@updateLinkedDecision}}
+        @allowClear={{true}}
         as |publishedBesluit|
       >
         {{this.reglementTitle publishedBesluit.title}}

--- a/app/utils/setLinkedDecision.ts
+++ b/app/utils/setLinkedDecision.ts
@@ -16,7 +16,7 @@ import {
 
 export default function setLinkedDecision(
   initialState: EditorState,
-  linkedDecisionUri: string,
+  linkedDecisionUri?: string,
 ): TransactionCombinatorResult<boolean> {
   const transaction = initialState.tr;
   const resource = getCurrentBesluitURI(initialState);
@@ -38,15 +38,17 @@ export default function setLinkedDecision(
       },
     });
   });
-  monads.push(
-    addPropertyToNode({
-      resource,
-      property: {
-        predicate: ELI('consolidates').full,
-        object: sayDataFactory.namedNode(linkedDecisionUri),
-      },
-    }),
-  );
+  if (linkedDecisionUri) {
+    monads.push(
+      addPropertyToNode({
+        resource,
+        property: {
+          predicate: ELI('consolidates').full,
+          object: sayDataFactory.namedNode(linkedDecisionUri),
+        },
+      }),
+    );
+  }
   return transactionCombinator<boolean>(initialState)(monads);
 }
 


### PR DESCRIPTION
### Overview
Allow the user to clear the selection of the linked decision select on both the agendapoint creation and the document information modal

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-6108


### Setup
None

### How to test/reproduce
Create an agendapoint, check that you can select and then clear a linked decision. Then go to an agendapoint and verify you can add and the clear the linked decision. Important also verify that you can remove a linked decision from an already saved document, and it indeed removes the triple

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
