### PR TITLE
add contextual actions for place descriptions

### DIFF
--- a/.changeset/goofy-buckets-raise.md
+++ b/.changeset/goofy-buckets-raise.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Add contextual actions for place descriptions

--- a/app/components/agendapoint-edit.gts
+++ b/app/components/agendapoint-edit.gts
@@ -68,6 +68,10 @@ import ArImporterSidebarWidget from 'frontend-gelinkt-notuleren/components/edito
 import RegulatoryStatementsSidebarInsert from 'frontend-gelinkt-notuleren/components/editor-plugins/regulatory-statements/sidebar-insert';
 import type ZittingModel from 'frontend-gelinkt-notuleren/models/zitting';
 import DocumentInformationModal from 'frontend-gelinkt-notuleren/components/document-information-modal';
+import type {
+  GetContextualActionGroups,
+  GetContextualActions,
+} from '@lblod/ember-rdfa-editor/plugins/contextual-actions';
 
 interface AgendapointEditSig {
   Args: {
@@ -97,6 +101,8 @@ export default class AgendapointsEditController extends Component<AgendapointEdi
 
   @tracked schema?: Schema;
   @tracked plugins?: ProsePlugin[];
+  @tracked contextualActionGetters?: GetContextualActions;
+  @tracked contextualActionGroupGetters?: GetContextualActionGroups;
   @tracked editorSetup = false;
 
   get config() {
@@ -158,11 +164,17 @@ export default class AgendapointsEditController extends Component<AgendapointEdi
   });
 
   setSchemaAndPlugins = modifier(() => {
-    const { schema, plugins } =
-      this.agendapointEditor.getSchemaAndPlugins(false);
+    const {
+      schema,
+      plugins,
+      contextualActionGetters,
+      contextualActionGroupGetters,
+    } = this.agendapointEditor.getSchemaAndPlugins(false);
     this.schema = schema;
     this.plugins = plugins;
     this.editorSetup = true;
+    this.contextualActionGetters = contextualActionGetters;
+    this.contextualActionGroupGetters = contextualActionGroupGetters;
     return () => {
       this.editorSetup = false;
     };
@@ -530,6 +542,8 @@ export default class AgendapointsEditController extends Component<AgendapointEdi
           @nodeViews={{this.nodeViews}}
           @plugins={{this.plugins}}
           @shouldEditRdfa={{false}}
+          @contextualActionGetters={{this.contextualActionGetters}}
+          @contextualActionGroupGetters={{this.contextualActionGroupGetters}}
         >
           <:sidebarCollapsible as |container|>
             <InsertArticleComponent

--- a/app/components/rdfa-editor-container.gts
+++ b/app/components/rdfa-editor-container.gts
@@ -73,6 +73,11 @@ import type {
   PredicateOptionGeneratorArgs,
   TargetOptionGeneratorArgs,
 } from '@lblod/ember-rdfa-editor/components/_private/relationship-editor/types';
+import ContextualActionsContainer from '@lblod/ember-rdfa-editor/components/plugins/contextual-actions/container';
+import type {
+  GetContextualActionGroups,
+  GetContextualActions,
+} from '@lblod/ember-rdfa-editor/plugins/contextual-actions';
 
 interface Sig {
   Args: {
@@ -90,6 +95,8 @@ interface Sig {
     busyText?: string;
     shouldEditRdfa?: boolean;
     property?: string;
+    contextualActionGetters?: GetContextualActions;
+    contextualActionGroupGetters?: GetContextualActionGroups;
   };
   Blocks: {
     toolbar: [{ controller: SayController }];
@@ -225,6 +232,14 @@ export default class RdfaEditorContainerComponent extends Component<Sig> {
     predicates: this.predicateOptionGeneratorTask.perform.bind(this),
     objects: this.objectOptionGeneratorTask.perform.bind(this),
   };
+
+  get contextualActionGetters() {
+    return this.args.contextualActionGetters ?? [];
+  }
+
+  get contextualActionGroupGetters() {
+    return this.args.contextualActionGroupGetters ?? [];
+  }
 
   <template>
     <AuBodyContainer
@@ -379,6 +394,13 @@ export default class RdfaEditorContainerComponent extends Component<Sig> {
               @rdfaEditorInit={{this.rdfaEditorInit}}
               @notificationToaster={{false}}
             />
+            {{#if this.controller}}
+              <ContextualActionsContainer
+                @controller={{this.controller}}
+                @getActions={{this.contextualActionGetters}}
+                @getGroups={{this.contextualActionGroupGetters}}
+              />
+            {{/if}}
           </:default>
           <:sidebarRight as |container|>
             <Sidebar as |Sidebar|>

--- a/app/components/regulatory-statement-edit.gts
+++ b/app/components/regulatory-statement-edit.gts
@@ -641,7 +641,6 @@ export default class RegulatoryStatementEdit extends Component<RegulatoryStateme
         @nodeViews={{this.nodeViews}}
         @plugins={{this.plugins}}
         @shouldEditRdfa={{false}}
-        {{!@glint-ignore  TODO FIX THIS1}}
         @contextualActionGetters={{this.contextualActionGetters}}
         @contextualActionGroupGetters={{this.contextualActionGroupGetters}}
       >

--- a/app/components/regulatory-statement-edit.gts
+++ b/app/components/regulatory-statement-edit.gts
@@ -172,6 +172,11 @@ import RdfaEditorContainer from 'frontend-gelinkt-notuleren/components/rdfa-edit
 import ConfirmRouteLeave from 'frontend-gelinkt-notuleren/components/confirm-route-leave';
 import humanFriendlyDate from 'frontend-gelinkt-notuleren/helpers/human-friendly-date';
 import AuModal from '@appuniversum/ember-appuniversum/components/au-modal';
+import { locationModalsPlugin } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/location-plugin';
+import {
+  getContextualActionGroups as locationActionsGroups,
+  getContextualActions as locationActions,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/location-plugin/contextual-actions';
 
 interface RegulatoryStatementEditSig {
   Args: {
@@ -196,6 +201,8 @@ export default class RegulatoryStatementEdit extends Component<RegulatoryStateme
   html?: string;
   title?: string;
 
+  contextualActionGetters = [locationActions()];
+  contextualActionGroupGetters = [locationActionsGroups()];
   schema = new Schema({
     nodes: {
       doc: docWithConfig({
@@ -295,6 +302,7 @@ export default class RegulatoryStatementEdit extends Component<RegulatoryStateme
       // @ts-expect-error emberApplication should accept undefined as getOwner may return it
       emberApplication({ application: getOwner(this) }),
       variableAutofillerPlugin(this.config.autofilledVariable),
+      locationModalsPlugin(),
     ];
   }
 
@@ -633,6 +641,9 @@ export default class RegulatoryStatementEdit extends Component<RegulatoryStateme
         @nodeViews={{this.nodeViews}}
         @plugins={{this.plugins}}
         @shouldEditRdfa={{false}}
+        {{!@glint-ignore  TODO FIX THIS1}}
+        @contextualActionGetters={{this.contextualActionGetters}}
+        @contextualActionGroupGetters={{this.contextualActionGroupGetters}}
       >
         <:toolbar as |container|>
           <div class='au-u-margin-right-small'>

--- a/app/services/editor/agendapoint.ts
+++ b/app/services/editor/agendapoint.ts
@@ -165,6 +165,11 @@ import type {
   GetContextualActionGroups,
   GetContextualActions,
 } from '@lblod/ember-rdfa-editor/plugins/contextual-actions';
+import { locationModalsPlugin } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/location-plugin';
+import {
+  getContextualActionGroups as locationActionsGroups,
+  getContextualActions as locationActions,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/location-plugin/contextual-actions';
 
 const removeBlankNodes: ModelMigrationGenerator = (attrs) => {
   if (
@@ -197,8 +202,14 @@ export default class AgendapointEditorService extends Service {
     };
   }
 
-  contextualActionGetters = [placeDescriptionActions(this.locationOptions)];
-  contextualActionGroupGetters = [placeDescriptionActionGroups()];
+  contextualActionGetters = [
+    placeDescriptionActions(this.locationOptions),
+    locationActions(),
+  ];
+  contextualActionGroupGetters = [
+    placeDescriptionActionGroups(),
+    locationActionsGroups(),
+  ];
 
   get config() {
     const classificatie = this.currentSession
@@ -534,6 +545,7 @@ export default class AgendapointEditorService extends Service {
         intl: this.intl,
         getGroups: this.contextualActionGroupGetters,
       }),
+      locationModalsPlugin(),
     ];
 
     // The autofiller plugin messes with the headless editor by appending a transaction just

--- a/app/services/editor/agendapoint.ts
+++ b/app/services/editor/agendapoint.ts
@@ -156,6 +156,15 @@ import {
   type ModelMigration,
   type ModelMigrationGenerator,
 } from '@lblod/ember-rdfa-editor/core/rdfa-types';
+import { slashCommandsPlugin } from '@lblod/ember-rdfa-editor/plugins/slash-commands/index';
+import {
+  getContextualActionGroups as placeDescriptionActionGroups,
+  getContextualActions as placeDescriptionActions,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/contextual-actions';
+import type {
+  GetContextualActionGroups,
+  GetContextualActions,
+} from '@lblod/ember-rdfa-editor/plugins/contextual-actions';
 
 const removeBlankNodes: ModelMigrationGenerator = (attrs) => {
   if (
@@ -179,6 +188,17 @@ const removeBlankNodes: ModelMigrationGenerator = (attrs) => {
 export default class AgendapointEditorService extends Service {
   @service declare intl: IntlService;
   @service declare currentSession: CurrentSessionService;
+
+  get locationOptions() {
+    return {
+      endpoint: ENV.fallbackCodelistEndpoint,
+      zonalLocationCodelistUri: ENV.zonalLocationCodelistUri,
+      nonZonalLocationCodelistUri: ENV.nonZonalLocationCodelistUri,
+    };
+  }
+
+  contextualActionGetters = [placeDescriptionActions(this.locationOptions)];
+  contextualActionGroupGetters = [placeDescriptionActionGroups()];
 
   get config() {
     const classificatie = this.currentSession
@@ -433,6 +453,8 @@ export default class AgendapointEditorService extends Service {
   getSchemaAndPlugins(isHeadless: boolean): {
     schema: Schema;
     plugins: ProsePlugin[];
+    contextualActionGroupGetters: GetContextualActionGroups;
+    contextualActionGetters: GetContextualActions;
   } {
     const schema = new Schema({
       nodes: {
@@ -508,6 +530,10 @@ export default class AgendapointEditorService extends Service {
       documentValidationPlugin(this.config.documentValidation),
 
       emberApplication({ application: unwrap(getOwner(this)) }),
+      slashCommandsPlugin({
+        intl: this.intl,
+        getGroups: this.contextualActionGroupGetters,
+      }),
     ];
 
     // The autofiller plugin messes with the headless editor by appending a transaction just
@@ -517,7 +543,12 @@ export default class AgendapointEditorService extends Service {
       plugins.push(variableAutofillerPlugin(this.config.autofilledVariable));
     }
 
-    return { schema, plugins };
+    return {
+      schema,
+      plugins,
+      contextualActionGetters: this.contextualActionGetters,
+      contextualActionGroupGetters: this.contextualActionGroupGetters,
+    };
   }
 
   getState = (html: string) => {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@lblod/ember-environment-banner": "^0.6.0",
     "@lblod/ember-mock-login": "^0.14.0",
     "@lblod/ember-rdfa-editor": "catalog:",
-    "@lblod/ember-rdfa-editor-lblod-plugins": "35.6.0",
+    "@lblod/ember-rdfa-editor-lblod-plugins": "36.0.0-dev.8c895e4420d8957c6d1e99a0b86eb59e321c6233",
     "@lblod/template-uuid-instantiator": "^1.0.3",
     "@nullvoxpopuli/ember-composable-helpers": "catalog:",
     "@rdfjs/types": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@lblod/ember-environment-banner": "^0.6.0",
     "@lblod/ember-mock-login": "^0.14.0",
     "@lblod/ember-rdfa-editor": "catalog:",
-    "@lblod/ember-rdfa-editor-lblod-plugins": "37.0.0",
+    "@lblod/ember-rdfa-editor-lblod-plugins": "37.0.3",
     "@lblod/template-uuid-instantiator": "^1.0.3",
     "@nullvoxpopuli/ember-composable-helpers": "catalog:",
     "@rdfjs/types": "^2.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -296,8 +296,8 @@ importers:
         specifier: 13.7.1
         version: 13.7.1(a2cb0244dd9131bc305eb5466e43e69d)
       '@lblod/ember-rdfa-editor-lblod-plugins':
-        specifier: 35.6.0
-        version: 35.6.0(cc9eba76ea7044317ac64d65100624bd)
+        specifier: 36.0.0-dev.8c895e4420d8957c6d1e99a0b86eb59e321c6233
+        version: 36.0.0-dev.8c895e4420d8957c6d1e99a0b86eb59e321c6233(cc9eba76ea7044317ac64d65100624bd)
       '@lblod/template-uuid-instantiator':
         specifier: ^1.0.3
         version: 1.0.3
@@ -2069,8 +2069,8 @@ packages:
       ember-simple-auth: '>= 6.0.0'
       ember-source: '>= 4.0.0'
 
-  '@lblod/ember-rdfa-editor-lblod-plugins@35.6.0':
-    resolution: {integrity: sha512-ht46KN9jLAD7jmBDPX9ktiITrPnCtHwcLQt9BSpLc8qT5dU4gST/xwAMf9CZPP8kShddpYohNXSTf7XbNLNuIA==}
+  '@lblod/ember-rdfa-editor-lblod-plugins@36.0.0-dev.8c895e4420d8957c6d1e99a0b86eb59e321c6233':
+    resolution: {integrity: sha512-NYie3/ljnL/2bWql/20mYH52Oks72lPpISdSNd3ph3Qfj5s2yRFLwBKI9dqPVUZONdCkSkdhBFB5Dgk93z5cUQ==}
     engines: {node: '>= 18'}
     peerDependencies:
       '@appuniversum/ember-appuniversum': ^3.12.0
@@ -12606,7 +12606,7 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  '@lblod/ember-rdfa-editor-lblod-plugins@35.6.0(cc9eba76ea7044317ac64d65100624bd)':
+  '@lblod/ember-rdfa-editor-lblod-plugins@36.0.0-dev.8c895e4420d8957c6d1e99a0b86eb59e321c6233(cc9eba76ea7044317ac64d65100624bd)':
     dependencies:
       '@appuniversum/ember-appuniversum': 3.19.0(@ember/test-helpers@3.3.1(@babel/core@7.29.0)(@glint/template@1.7.7)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.106.2(postcss@8.5.14)))(webpack@5.106.2(postcss@8.5.14)))(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.106.2(postcss@8.5.14)))(eslint@9.39.4(jiti@2.6.1))(miragejs@0.1.48)(tracked-built-ins@4.1.2(@babel/core@7.29.0))(webpack@5.106.2(postcss@8.5.14))
       '@babel/core': 7.29.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -296,8 +296,8 @@ importers:
         specifier: 13.8.0
         version: 13.8.0(a2cb0244dd9131bc305eb5466e43e69d)
       '@lblod/ember-rdfa-editor-lblod-plugins':
-        specifier: 37.0.0
-        version: 37.0.0(3795a36643b13148804a93c61eb8d9bb)
+        specifier: 37.0.3
+        version: 37.0.3(3795a36643b13148804a93c61eb8d9bb)
       '@lblod/template-uuid-instantiator':
         specifier: ^1.0.3
         version: 1.0.3
@@ -2069,8 +2069,8 @@ packages:
       ember-simple-auth: '>= 6.0.0'
       ember-source: '>= 4.0.0'
 
-  '@lblod/ember-rdfa-editor-lblod-plugins@37.0.0':
-    resolution: {integrity: sha512-JM080GX101LJL/tHlns5/WFfgfpEBtgplusYjz06EvrRgle3gb8enseyPW2XutC7yjz5ZZQMsa2HmtMehaQF2A==}
+  '@lblod/ember-rdfa-editor-lblod-plugins@37.0.3':
+    resolution: {integrity: sha512-WvTO9XWS3iYKTkbAApGkWgCLzFsmSaVw+IKA6Cb1+2/DfZbiX8ABcNdylaHllFo4um5Ob0ek2pjybCBpEB4r9A==}
     engines: {node: '>= 18'}
     peerDependencies:
       '@appuniversum/ember-appuniversum': ^3.12.0
@@ -12615,7 +12615,7 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  '@lblod/ember-rdfa-editor-lblod-plugins@37.0.0(3795a36643b13148804a93c61eb8d9bb)':
+  '@lblod/ember-rdfa-editor-lblod-plugins@37.0.3(3795a36643b13148804a93c61eb8d9bb)':
     dependencies:
       '@appuniversum/ember-appuniversum': 3.19.0(@ember/test-helpers@3.3.1(@babel/core@7.29.0)(@glint/template@1.7.7)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.106.2(postcss@8.5.14)))(webpack@5.106.2(postcss@8.5.14)))(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.106.2(postcss@8.5.14)))(eslint@9.39.4(jiti@2.6.1))(miragejs@0.1.48)(tracked-built-ins@4.1.2(@babel/core@7.29.0))(webpack@5.106.2(postcss@8.5.14))
       '@babel/core': 7.29.0


### PR DESCRIPTION
##### connected issues and PRs:
Implements
https://binnenland.atlassian.net/browse/GN-6016
and https://binnenland.atlassian.net/browse/GN-6051 for GN


### How to test/reproduce
Both the slash commands and the floating plus should be available in place descriptions. The place descriptions should be a block rdfa node instead of an inline node.


### Checks PR readiness
- [x] changelog
- [x] npm lint
