### PR TITLE
Prevent concurrent extract signing using Tasks

### DIFF
--- a/.changeset/deep-insects-lick.md
+++ b/.changeset/deep-insects-lick.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': minor
+---
+
+Prevent issues with concurrent signing of extracts

--- a/app/controllers/meetings/publish/uittreksels/show.ts
+++ b/app/controllers/meetings/publish/uittreksels/show.ts
@@ -158,25 +158,36 @@ export default class MeetingsPublishUittrekselsShowController extends Controller
     this.closeSigningModal();
     try {
       this.error = null;
-      if (!this.versionedTreatment) {
-        this._versionedTreatment =
-          this.store.createRecord<VersionedBehandeling>(
-            'versioned-behandeling',
-            {
-              zitting: this.meeting,
-              content: this.model.extractPreview,
-              behandeling: this.treatment,
-            },
-          );
-      }
-      await this.versionedTreatment?.save();
-      const signature = this.store.createRecord<SignedResource>(
-        'signed-resource',
-        {
-          versionedBehandeling: this.versionedTreatment,
-        },
+      const taskId = await this.muTask.fetchTaskifiedEndpoint(
+        `/signing/uittreksel/sign/${this.meeting.id}/${this.treatment.id}`,
+        { method: 'POST' },
       );
-      await signature?.save();
+      const taskResult = await this.muTask.waitForMuTaskTask.perform(taskId);
+      let signature: SignedResource | undefined;
+      if (taskResult?.data.payload) {
+        // @ts-expect-error Strangely the types don't have the (valid) override that doesn't include
+        // a data type
+        this.store.pushPayload(taskResult.data.payload);
+        const createdData = taskResult?.data.payload?.['data'];
+        const createdId =
+          createdData &&
+          typeof createdData === 'object' &&
+          'id' in createdData &&
+          (createdData?.['id'] as string);
+        signature = !createdId
+          ? undefined
+          : await this.store.findRecord<SignedResource>(
+              'signed-resource',
+              createdId,
+            );
+      } else {
+        console.error(
+          'Task did not contain created Signed Resource, searching for one instead',
+        );
+        throw new Error(
+          'Unable to recover from lack of Signed Resource from Task.',
+        );
+      }
       const log = this.store.createRecord<PublishingLog>('publishing-log', {
         action: 'sign',
         user: this.currentSession.user,
@@ -208,6 +219,7 @@ export default class MeetingsPublishUittrekselsShowController extends Controller
     // so it is still in the signedResources array.
     // we could reload the model here, but then we're reloading twice in one call, which seems unnecessary
     if (this.signatureCount === 1 && this.versionedTreatment) {
+      // versionedTreatment should always be set as we always reload after signing
       this.versionedTreatment.deleted = true;
       await this.versionedTreatment.save();
     }

--- a/app/controllers/meetings/publish/uittreksels/show.ts
+++ b/app/controllers/meetings/publish/uittreksels/show.ts
@@ -184,8 +184,20 @@ export default class MeetingsPublishUittrekselsShowController extends Controller
         console.error(
           'Task did not contain created Signed Resource, searching for one instead',
         );
+        const signatures = await this.store.query<SignedResource>(
+          'signed-resource',
+          {
+            'filter[versioned-behandeling][zitting][:id:]': this.meeting.id,
+            'filter[gebruiker][:id:]': this.currentSession.user?.id,
+            'filter[:or:][deleted]': false,
+            'filter[:or:][:has-no:deleted]': 'yes',
+          },
+        );
+        signature = signatures[0];
+      }
+      if (!signature) {
         throw new Error(
-          'Unable to recover from lack of Signed Resource from Task.',
+          'Unable to find signature that should have been created',
         );
       }
       const log = this.store.createRecord<PublishingLog>('publishing-log', {
@@ -196,6 +208,9 @@ export default class MeetingsPublishUittrekselsShowController extends Controller
         zitting: this.meeting,
       });
       await log.save();
+      // This is needed to get the versioned behandeling. We could add this to the response from the
+      // Task status endpoint, but this requires correctly assembling a jsonAPI compatible response
+      // including it. It was not done yet as the refresh likely sidesteps other concurrency problems.
       await this.refreshRoute();
     } catch (e) {
       this.error = e;

--- a/app/controllers/meetings/publish/uittreksels/show.ts
+++ b/app/controllers/meetings/publish/uittreksels/show.ts
@@ -15,12 +15,14 @@ import type MeetingsPublishUittrekselsShowRoute from 'frontend-gelinkt-notuleren
 import type SignedResource from 'frontend-gelinkt-notuleren/models/signed-resource';
 import type PublishingLog from 'frontend-gelinkt-notuleren/models/publishing-log';
 import type MuTaskService from 'frontend-gelinkt-notuleren/services/mu-task';
+import type VersionedBehandeling from 'frontend-gelinkt-notuleren/models/versioned-behandeling';
 
 export default class MeetingsPublishUittrekselsShowController extends Controller {
   publicationBaseUrl = ENV.publication.baseUrl;
   @tracked error: Option<unknown>;
   @tracked signingModalOpen = false;
   @tracked publishingModalOpen = false;
+  @tracked _versionedTreatment: VersionedBehandeling | null = null;
   @service declare publish: PublishService;
   @service declare router: RouterService;
   @service declare intl: IntlService;
@@ -38,7 +40,7 @@ export default class MeetingsPublishUittrekselsShowController extends Controller
   }
 
   get versionedTreatment() {
-    return this.model.versionedTreatment;
+    return this.model.versionedTreatment ?? this._versionedTreatment;
   }
 
   get meeting() {
@@ -122,7 +124,7 @@ export default class MeetingsPublishUittrekselsShowController extends Controller
 
   get previewDocument() {
     return {
-      body: this.model.versionedTreatment?.content,
+      body: this.model.extractPreview,
       signedId: this.meeting.get('id'),
     };
   }
@@ -156,7 +158,18 @@ export default class MeetingsPublishUittrekselsShowController extends Controller
     this.closeSigningModal();
     try {
       this.error = null;
-      await this.versionedTreatment.save();
+      if (!this.versionedTreatment) {
+        this._versionedTreatment =
+          this.store.createRecord<VersionedBehandeling>(
+            'versioned-behandeling',
+            {
+              zitting: this.meeting,
+              content: this.model.extractPreview,
+              behandeling: this.treatment,
+            },
+          );
+      }
+      await this.versionedTreatment?.save();
       const signature = this.store.createRecord<SignedResource>(
         'signed-resource',
         {
@@ -194,7 +207,7 @@ export default class MeetingsPublishUittrekselsShowController extends Controller
     // at this point, the signature is marked as deleted but the model has not yet reloaded,
     // so it is still in the signedResources array.
     // we could reload the model here, but then we're reloading twice in one call, which seems unnecessary
-    if (this.signatureCount === 1) {
+    if (this.signatureCount === 1 && this.versionedTreatment) {
       this.versionedTreatment.deleted = true;
       await this.versionedTreatment.save();
     }

--- a/app/routes/meetings/publish/uittreksels/show.ts
+++ b/app/routes/meetings/publish/uittreksels/show.ts
@@ -5,7 +5,6 @@ import type BehandelingVanAgendapunt from 'frontend-gelinkt-notuleren/models/beh
 import type ExtractPreview from 'frontend-gelinkt-notuleren/models/extract-preview';
 import type SignedResource from 'frontend-gelinkt-notuleren/models/signed-resource';
 import type VersionedBehandelingModel from 'frontend-gelinkt-notuleren/models/versioned-behandeling';
-import PublishedResourceModel from 'frontend-gelinkt-notuleren/models/published-resource';
 import type ZittingModel from 'frontend-gelinkt-notuleren/models/zitting';
 
 export default class MeetingsPublishUittrekselsShowRoute extends Route {
@@ -29,6 +28,7 @@ export default class MeetingsPublishUittrekselsShowRoute extends Route {
           'filter[behandeling][:id:]': treatment.id,
           'filter[:or:][deleted]': false,
           'filter[:or:][:has-no:deleted]': 'yes',
+          include: ['publishedResource'],
         },
       );
     const versionedTreatment = versionedTreatments[0];
@@ -54,8 +54,7 @@ export default class MeetingsPublishUittrekselsShowRoute extends Route {
         validationErrors: extractPreview.validationErrors,
       };
     } else {
-      // because the signedResources endpoint IS jsonAPI compliant,
-      // we could have used the relationship here, but the extra filtering
+      // We could have used the relationship here, but the extra filtering
       // needed prevents that
       const signedResources = await this.store.query<SignedResource>(
         'signed-resource',
@@ -64,20 +63,13 @@ export default class MeetingsPublishUittrekselsShowRoute extends Route {
           'filter[:or:][deleted]': false,
           'filter[:or:][:has-no:deleted]': 'yes',
           sort: 'created-on',
+          include: ['gebruiker'],
         },
       );
       if (signedResources.length > 2) {
         throw new Error('More than 2 undeleted signatures found');
       }
-      // we can't use the relationship here because the published-resource is not
-      // created with a jsonAPI compliant endpoint. This means ED is not aware when we create it,
-      // causing ED to cache too aggressively. With query, we bypass the cache.
-      const publishedResource = await this.store.query<PublishedResourceModel>(
-        'published-resource',
-        {
-          'filter[versioned-behandeling][:id:]': versionedTreatment.id,
-        },
-      );
+      const publishedResource = await versionedTreatment.publishedResource;
       return {
         treatment,
         agendapoint,
@@ -85,7 +77,7 @@ export default class MeetingsPublishUittrekselsShowRoute extends Route {
         extractPreview: versionedTreatment.content,
         meeting,
         signedResources: signedResources.slice(),
-        publishedResource: publishedResource[0],
+        publishedResource,
         // if a versionedTreatment exists, that means some signature or publication
         // has happened, which means that there are no errors, so we can safely do this
         validationErrors: [],

--- a/app/routes/meetings/publish/uittreksels/show.ts
+++ b/app/routes/meetings/publish/uittreksels/show.ts
@@ -34,6 +34,8 @@ export default class MeetingsPublishUittrekselsShowRoute extends Route {
     const versionedTreatment = versionedTreatments[0];
 
     if (!versionedTreatment) {
+      // We don't set the `html` attribute here, but the save goes to the prepublisher, not
+      // resources, and this populates this for us
       const extractPreview = this.store.createRecord<ExtractPreview>(
         'extract-preview',
         {
@@ -41,24 +43,14 @@ export default class MeetingsPublishUittrekselsShowRoute extends Route {
         },
       );
       await extractPreview.save();
-      const newVersionedTreatment =
-        this.store.createRecord<VersionedBehandelingModel>(
-          'versioned-behandeling',
-          {
-            zitting: meeting,
-            content: extractPreview.html,
-            behandeling: treatment,
-          },
-        );
-      const signedResources: SignedResource[] = [];
-      const publishedResource = await newVersionedTreatment.publishedResource;
       return {
         treatment,
         agendapoint,
-        versionedTreatment: newVersionedTreatment,
+        versionedTreatment: null,
+        extractPreview: extractPreview.html,
         meeting,
-        signedResources,
-        publishedResource,
+        signedResources: [] as SignedResource[],
+        publishedResource: null,
         validationErrors: extractPreview.validationErrors,
       };
     } else {
@@ -90,6 +82,7 @@ export default class MeetingsPublishUittrekselsShowRoute extends Route {
         treatment,
         agendapoint,
         versionedTreatment,
+        extractPreview: versionedTreatment.content,
         meeting,
         signedResources: signedResources.slice(),
         publishedResource: publishedResource[0],

--- a/app/services/mu-task.ts
+++ b/app/services/mu-task.ts
@@ -1,6 +1,7 @@
 import Service from '@ember/service';
 import { task, timeout } from 'ember-concurrency';
 import { type Option } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
+import type { ObjectValue } from '@warp-drive/core-types/json/raw';
 
 const TASK_ENDPOINT = '/publication-tasks';
 export const TASK_STATUS_FAILURE =
@@ -12,7 +13,7 @@ export const TASK_STATUS_SUCCESS =
 export const TASK_STATUS_RUNNING =
   'http://lblod.data.gift/besluit-publicatie-melding-statuses/ongoing';
 
-type TaskBody = { data: { id: string; status: string } };
+type TaskBody = { data: { id: string; status: string; payload?: ObjectValue } };
 
 export default class MuTaskService extends Service {
   fetchMuTask(taskId: string) {


### PR DESCRIPTION
### Overview
Use the new locking tasks to prevent concurrent signing from causing issues. Moves the creation of versioned behandeling to the server, so only one is created.

Uses the new Task created resources to push a Signed Resource into the Ember Data store and prevent caching problems.

##### connected issues and PRs:
Part of https://binnenland.atlassian.net/browse/GN-6092
Needs https://github.com/lblod/notulen-prepublish-service/pull/132

### Setup
Needs to be run against the prepublisher service in the linked PR.

### How to test/reproduce
Try to sign extracts simultaneously with 2 different users. Also try deleting and re-signing, as well as signatures with 2 users done sequentially. Ideally check that the data in the triplestore is correct, at least that only one versioned behandeling is created when signing concurrently.

### Challenges/uncertainties
All the JSON:api confusion.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
