### PR TITLE
GN-6139: Implement insert options for AR-design insert

### DIFF
--- a/.changeset/pretty-schools-grow.md
+++ b/.changeset/pretty-schools-grow.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': minor
+---
+
+Add insertion options to the AR importer

--- a/app/components/editor-plugins/ar-importer/common-types.ts
+++ b/app/components/editor-plugins/ar-importer/common-types.ts
@@ -1,13 +1,16 @@
 import type { PNode } from '@lblod/ember-rdfa-editor';
 import type ArDesign from 'frontend-gelinkt-notuleren/models/ar-design';
+import type { ArticleInsertPosition } from 'frontend-gelinkt-notuleren/utils/article-insert-position';
 
 export type ArticlePosition = { node: PNode; pos: number };
 
-type InsertPosition = 'first' | 'last' | ArticlePosition;
-export type InsertPositionOption = { label: string; value: InsertPosition };
+export type InsertPositionOption = {
+  label: string;
+  value: ArticleInsertPosition;
+};
 
 export type ArInsertFunc = (
   arDesign: ArDesign,
-  pos: ArticlePosition | null,
+  insertPosition: ArticleInsertPosition,
   skipWarnings?: boolean,
 ) => void;

--- a/app/components/editor-plugins/ar-importer/common-types.ts
+++ b/app/components/editor-plugins/ar-importer/common-types.ts
@@ -1,0 +1,13 @@
+import type { PNode } from '@lblod/ember-rdfa-editor';
+import type ArDesign from 'frontend-gelinkt-notuleren/models/ar-design';
+
+export type ArticlePosition = { node: PNode; pos: number };
+
+type InsertPosition = 'first' | 'last' | ArticlePosition;
+export type InsertPositionOption = { label: string; value: InsertPosition };
+
+export type ArInsertFunc = (
+  arDesign: ArDesign,
+  pos: ArticlePosition | null,
+  skipWarnings?: boolean,
+) => void;

--- a/app/components/editor-plugins/ar-importer/insert-controls.gts
+++ b/app/components/editor-plugins/ar-importer/insert-controls.gts
@@ -1,0 +1,126 @@
+import { fn } from '@ember/helper';
+import { tracked } from '@glimmer/tracking';
+import { on } from '@ember/modifier';
+import AuButton from '@appuniversum/ember-appuniversum/components/au-button';
+import { PlusIcon } from '@appuniversum/ember-appuniversum/components/icons/plus';
+import type { TOC } from '@ember/component/template-only';
+import type ArDesign from 'frontend-gelinkt-notuleren/models/ar-design';
+import t from 'ember-intl/helpers/t';
+import PowerSelect, {
+  type Select,
+} from 'ember-power-select/components/power-select';
+import Component from '@glimmer/component';
+import { service } from '@ember/service';
+import type IntlService from 'ember-intl/services/intl';
+import type {
+  ArInsertFunc,
+  ArticlePosition,
+  InsertPositionOption,
+} from './common-types';
+
+const InsertButton: TOC<{
+  Args: {
+    arDesign: ArDesign;
+    insertLoading?: boolean;
+    onInsertAr: ArInsertFunc;
+    insertPos: ArticlePosition | null;
+  };
+}> = <template>
+  <AuButton
+    @icon={{PlusIcon}}
+    @loading={{@insertLoading}}
+    @loadingMessage={{t 'application.loading'}}
+    {{on 'click' (fn @onInsertAr @arDesign @insertPos true)}}
+  >{{t 'ar-importer.controls.insert'}}</AuButton>
+</template>;
+
+const InsertPositionSelector: TOC<{
+  Args: {
+    options: InsertPositionOption[];
+    selected: InsertPositionOption | null;
+    onChange: (
+      selected: InsertPositionOption,
+      select: Select,
+      event?: Event,
+    ) => void;
+  };
+}> = <template>
+  <PowerSelect
+    class='au-u-1-5'
+    @allowClear={{false}}
+    @onChange={{@onChange}}
+    @selected={{@selected}}
+    @options={{@options}}
+    as |option|
+  >{{option.label}}</PowerSelect>
+</template>;
+
+export interface ArInsertControlArgs {
+  arDesign: ArDesign;
+  onInsertAr: ArInsertFunc;
+  insertLoading?: boolean;
+  articles: ArticlePosition[];
+}
+type Sig = {
+  Args: ArInsertControlArgs;
+};
+
+export class InsertControls extends Component<Sig> {
+  @tracked _selected: InsertPositionOption | null = null;
+  @service declare intl: IntlService;
+
+  get beforeFirst(): InsertPositionOption {
+    return {
+      value: 'first',
+      label: this.intl.t('ar-importer.controls.first'),
+    };
+  }
+  get afterLast(): InsertPositionOption {
+    return { value: 'last', label: this.intl.t('ar-importer.controls.last') };
+  }
+
+  get articleOptions(): InsertPositionOption[] {
+    return this.args.articles.map((articlePos, i) => ({
+      value: articlePos,
+      label: this.intl.t('ar-importer.controls.after-article-x', {
+        articleNumber: i + 1,
+      }),
+    }));
+  }
+
+  get options(): InsertPositionOption[] {
+    return [this.afterLast, this.beforeFirst, ...this.articleOptions];
+  }
+
+  get selected(): InsertPositionOption {
+    return this._selected ?? this.afterLast;
+  }
+
+  setSelected = (val: InsertPositionOption | null) => {
+    this._selected = val;
+  };
+
+  get insertPos(): ArticlePosition | null {
+    if (this.selected.value === 'last' || this.args.articles.length == 0) {
+      return null;
+    } else if (this.selected.value === 'first') {
+      return this.args.articles[0] ?? null;
+    } else {
+      return this.selected.value;
+    }
+  }
+
+  <template>
+    <InsertPositionSelector
+      @options={{this.options}}
+      @selected={{this.selected}}
+      @onChange={{this.setSelected}}
+    />
+    <InsertButton
+      @arDesign={{@arDesign}}
+      @onInsertAr={{@onInsertAr}}
+      @insertLoading={{@insertLoading}}
+      @insertPos={{this.insertPos}}
+    />
+  </template>
+}

--- a/app/components/editor-plugins/ar-importer/insert-controls.gts
+++ b/app/components/editor-plugins/ar-importer/insert-controls.gts
@@ -51,10 +51,9 @@ const InsertPositionSelector: TOC<{
     ) => void;
   };
 }> = <template>
-  <AuLabel
-    class='ar-importer-insert-controls__label'
-    for='ar-importer-position-selector'
-  >{{t 'ar-importer.controls.select-position'}}:</AuLabel>
+  <AuLabel for='ar-importer-position-selector'>{{t
+      'ar-importer.controls.select-position'
+    }}:</AuLabel>
   <div class='ar-importer-insert-controls__selector'>
     <PowerSelect
       id='ar-importer-position-selector'

--- a/app/components/editor-plugins/ar-importer/insert-controls.gts
+++ b/app/components/editor-plugins/ar-importer/insert-controls.gts
@@ -17,20 +17,25 @@ import type {
   ArticlePosition,
   InsertPositionOption,
 } from './common-types';
+import {
+  afterLastArticle,
+  ArticleInsertPosition,
+  beforeFirstArticle,
+} from 'frontend-gelinkt-notuleren/utils/article-insert-position';
 
 const InsertButton: TOC<{
   Args: {
     arDesign: ArDesign;
     insertLoading?: boolean;
     onInsertAr: ArInsertFunc;
-    insertPos: ArticlePosition | null;
+    insertPosition: ArticleInsertPosition;
   };
 }> = <template>
   <AuButton
     @icon={{PlusIcon}}
     @loading={{@insertLoading}}
     @loadingMessage={{t 'application.loading'}}
-    {{on 'click' (fn @onInsertAr @arDesign @insertPos true)}}
+    {{on 'click' (fn @onInsertAr @arDesign @insertPosition true)}}
   >{{t 'ar-importer.controls.insert'}}</AuButton>
 </template>;
 
@@ -71,17 +76,20 @@ export class InsertControls extends Component<Sig> {
 
   get beforeFirst(): InsertPositionOption {
     return {
-      value: 'first',
+      value: beforeFirstArticle,
       label: this.intl.t('ar-importer.controls.first'),
     };
   }
   get afterLast(): InsertPositionOption {
-    return { value: 'last', label: this.intl.t('ar-importer.controls.last') };
+    return {
+      value: afterLastArticle,
+      label: this.intl.t('ar-importer.controls.last'),
+    };
   }
 
   get articleOptions(): InsertPositionOption[] {
-    return this.args.articles.map((articlePos, i) => ({
-      value: articlePos,
+    return this.args.articles.map((_, i) => ({
+      value: new ArticleInsertPosition(i),
       label: this.intl.t('ar-importer.controls.after-article-x', {
         articleNumber: i + 1,
       }),
@@ -100,16 +108,6 @@ export class InsertControls extends Component<Sig> {
     this._selected = val;
   };
 
-  get insertPos(): ArticlePosition | null {
-    if (this.selected.value === 'last' || this.args.articles.length == 0) {
-      return null;
-    } else if (this.selected.value === 'first') {
-      return this.args.articles[0] ?? null;
-    } else {
-      return this.selected.value;
-    }
-  }
-
   <template>
     <InsertPositionSelector
       @options={{this.options}}
@@ -120,7 +118,7 @@ export class InsertControls extends Component<Sig> {
       @arDesign={{@arDesign}}
       @onInsertAr={{@onInsertAr}}
       @insertLoading={{@insertLoading}}
-      @insertPos={{this.insertPos}}
+      @insertPosition={{this.selected.value}}
     />
   </template>
 }

--- a/app/components/editor-plugins/ar-importer/insert-controls.gts
+++ b/app/components/editor-plugins/ar-importer/insert-controls.gts
@@ -2,6 +2,7 @@ import { fn } from '@ember/helper';
 import { tracked } from '@glimmer/tracking';
 import { on } from '@ember/modifier';
 import AuButton from '@appuniversum/ember-appuniversum/components/au-button';
+import AuLabel from '@appuniversum/ember-appuniversum/components/au-label';
 import { PlusIcon } from '@appuniversum/ember-appuniversum/components/icons/plus';
 import type { TOC } from '@ember/component/template-only';
 import type ArDesign from 'frontend-gelinkt-notuleren/models/ar-design';
@@ -50,14 +51,20 @@ const InsertPositionSelector: TOC<{
     ) => void;
   };
 }> = <template>
-  <PowerSelect
-    class='au-u-1-5'
-    @allowClear={{false}}
-    @onChange={{@onChange}}
-    @selected={{@selected}}
-    @options={{@options}}
-    as |option|
-  >{{option.label}}</PowerSelect>
+  <AuLabel
+    class='ar-importer-insert-controls__label'
+    for='ar-importer-position-selector'
+  >{{t 'ar-importer.controls.select-position'}}:</AuLabel>
+  <div class='ar-importer-insert-controls__selector'>
+    <PowerSelect
+      id='ar-importer-position-selector'
+      @allowClear={{false}}
+      @onChange={{@onChange}}
+      @selected={{@selected}}
+      @options={{@options}}
+      as |option|
+    >{{option.label}}</PowerSelect>
+  </div>
 </template>;
 
 export interface ArInsertControlArgs {
@@ -109,16 +116,18 @@ export class InsertControls extends Component<Sig> {
   };
 
   <template>
-    <InsertPositionSelector
-      @options={{this.options}}
-      @selected={{this.selected}}
-      @onChange={{this.setSelected}}
-    />
-    <InsertButton
-      @arDesign={{@arDesign}}
-      @onInsertAr={{@onInsertAr}}
-      @insertLoading={{@insertLoading}}
-      @insertPosition={{this.selected.value}}
-    />
+    <div class='ar-importer-insert-controls'>
+      <InsertPositionSelector
+        @options={{this.options}}
+        @selected={{this.selected}}
+        @onChange={{this.setSelected}}
+      />
+      <InsertButton
+        @arDesign={{@arDesign}}
+        @onInsertAr={{@onInsertAr}}
+        @insertLoading={{@insertLoading}}
+        @insertPosition={{this.selected.value}}
+      />
+    </div>
   </template>
 }

--- a/app/components/editor-plugins/ar-importer/overview.gts
+++ b/app/components/editor-plugins/ar-importer/overview.gts
@@ -23,6 +23,7 @@ import { eq } from 'ember-truth-helpers';
 import { trackedFunction } from 'reactiveweb/function';
 import type EditorDocumentModel from 'frontend-gelinkt-notuleren/models/editor-document';
 import type { ArInsertFunc } from './common-types';
+import { afterLastArticle } from 'frontend-gelinkt-notuleren/utils/article-insert-position';
 
 export type ArDesignOverviewSignature = {
   Element: AuMainContainerSignature['Element'];
@@ -128,7 +129,10 @@ export default class ArDesignOverview extends Component<ArDesignOverviewSignatur
                   @disabled={{this.disabled}}
                   @loading={{eq @insertingDesign.id arDesign.id}}
                   @loadingMessage={{t 'application.loading'}}
-                  {{on 'click' (fn @onInsertAr arDesign null false)}}
+                  {{on
+                    'click'
+                    (fn @onInsertAr arDesign afterLastArticle false)
+                  }}
                 >{{t 'ar-importer.overview.table.actions.insert'}}</AuButton>
               </AuButtonGroup>
             </td>

--- a/app/components/editor-plugins/ar-importer/overview.gts
+++ b/app/components/editor-plugins/ar-importer/overview.gts
@@ -22,6 +22,7 @@ import type { ArDesignOverviewSortField, DesignInfo } from './widget-contents';
 import { eq } from 'ember-truth-helpers';
 import { trackedFunction } from 'reactiveweb/function';
 import type EditorDocumentModel from 'frontend-gelinkt-notuleren/models/editor-document';
+import type { ArInsertFunc } from './common-types';
 
 export type ArDesignOverviewSignature = {
   Element: AuMainContainerSignature['Element'];
@@ -29,7 +30,7 @@ export type ArDesignOverviewSignature = {
     arDesigns?: DesignInfo | null;
     loading?: boolean;
     onShowPreview: (arDesign: ArDesign) => void;
-    onInsertAr: (arDesign: ArDesign, skipWarnings?: boolean) => void;
+    onInsertAr: ArInsertFunc;
     insertingDesign?: ArDesign | null;
     nameFilter?: string;
     setNameFilter: (event: Event) => unknown;
@@ -127,7 +128,7 @@ export default class ArDesignOverview extends Component<ArDesignOverviewSignatur
                   @disabled={{this.disabled}}
                   @loading={{eq @insertingDesign.id arDesign.id}}
                   @loadingMessage={{t 'application.loading'}}
-                  {{on 'click' (fn @onInsertAr arDesign false)}}
+                  {{on 'click' (fn @onInsertAr arDesign null false)}}
                 >{{t 'ar-importer.overview.table.actions.insert'}}</AuButton>
               </AuButtonGroup>
             </td>

--- a/app/components/editor-plugins/ar-importer/overview.gts
+++ b/app/components/editor-plugins/ar-importer/overview.gts
@@ -4,7 +4,6 @@ import type { AuMainContainerSignature } from '@appuniversum/ember-appuniversum/
 import ReactiveTable from 'frontend-gelinkt-notuleren/components/common/reactive-table';
 import AuButtonGroup from '@appuniversum/ember-appuniversum/components/au-button-group';
 import AuButton from '@appuniversum/ember-appuniversum/components/au-button';
-import { PlusIcon } from '@appuniversum/ember-appuniversum/components/icons/plus';
 import { VisibleIcon } from '@appuniversum/ember-appuniversum/components/icons/visible';
 import AuFormRow from '@appuniversum/ember-appuniversum/components/au-form-row';
 import AuLabel from '@appuniversum/ember-appuniversum/components/au-label';
@@ -19,11 +18,9 @@ import type ArDesign from 'frontend-gelinkt-notuleren/models/ar-design';
 import { on } from '@ember/modifier';
 import t from 'ember-intl/helpers/t';
 import type { ArDesignOverviewSortField, DesignInfo } from './widget-contents';
-import { eq } from 'ember-truth-helpers';
 import { trackedFunction } from 'reactiveweb/function';
 import type EditorDocumentModel from 'frontend-gelinkt-notuleren/models/editor-document';
-import type { ArInsertFunc } from './common-types';
-import { afterLastArticle } from 'frontend-gelinkt-notuleren/utils/article-insert-position';
+import type { TOC } from '@ember/component/template-only';
 
 export type ArDesignOverviewSignature = {
   Element: AuMainContainerSignature['Element'];
@@ -31,8 +28,6 @@ export type ArDesignOverviewSignature = {
     arDesigns?: DesignInfo | null;
     loading?: boolean;
     onShowPreview: (arDesign: ArDesign) => void;
-    onInsertAr: ArInsertFunc;
-    insertingDesign?: ArDesign | null;
     nameFilter?: string;
     setNameFilter: (event: Event) => unknown;
     resetFilters: () => unknown;
@@ -44,104 +39,87 @@ export type ArDesignOverviewSignature = {
   };
 };
 
-export default class ArDesignOverview extends Component<ArDesignOverviewSignature> {
-  get disabled() {
-    return Boolean(this.args.insertingDesign);
-  }
-  <template>
-    <div class='ar-importer-overview' ...attributes>
-      <div class='ar-importer-overview__sidebar'>
-        <AuHeading @level='2' @skin='3'>{{t
-            'ar-importer.overview.filters.title'
-          }}</AuHeading>
-        <form class='ar-importer-overview__form'>
-          <AuFormRow>
-            {{#let (uuidv4) as |id|}}
-              <AuLabel class='ar-importer-overview__form__label' for={{id}}>
-                {{t 'ar-importer.overview.filters.name.label'}}
-              </AuLabel>
-              <AuInput
-                id={{id}}
-                @disabled={{this.disabled}}
-                @width='block'
-                value={{@nameFilter}}
-                {{on 'input' @setNameFilter}}
-              />
-            {{/let}}
-          </AuFormRow>
-          <AuButton
-            class='ar-importer-overview__reset-filters-button'
-            @skin='naked'
-            @size='large'
-            @disabled={{this.disabled}}
-            @icon={{CrossIcon}}
-            {{on 'click' @resetFilters}}
-          >{{t 'ar-importer.overview.filters.reset'}}</AuButton>
-        </form>
-      </div>
-      <div class='ar-importer-overview__content'>
-        <ReactiveTable
-          @content={{@arDesigns.designs}}
-          @isLoading={{@loading}}
-          @page={{@pageNumber}}
-          @pageSize={{@pageSize}}
-          @onPageChange={{@updatePageNumber}}
-          @onSortChange={{@updateSort}}
-          @sort={{@sort}}
-          @noDataMessage={{t 'ar-importer.overview.table.no-data'}}
-          @hidePagination={{false}}
-        >
-          <:header as |header|>
-            <header.Sortable
-              @field=':no-case:name'
-              @label={{t 'ar-importer.overview.table.headers.name'}}
+const ArDesignOverview: TOC<ArDesignOverviewSignature> = <template>
+  <div class='ar-importer-overview' ...attributes>
+    <div class='ar-importer-overview__sidebar'>
+      <AuHeading @level='2' @skin='3'>{{t
+          'ar-importer.overview.filters.title'
+        }}</AuHeading>
+      <form class='ar-importer-overview__form'>
+        <AuFormRow>
+          {{#let (uuidv4) as |id|}}
+            <AuLabel class='ar-importer-overview__form__label' for={{id}}>
+              {{t 'ar-importer.overview.filters.name.label'}}
+            </AuLabel>
+            <AuInput
+              id={{id}}
+              @width='block'
+              value={{@nameFilter}}
+              {{on 'input' @setNameFilter}}
             />
-            <header.Sortable
-              @field='date'
-              @label={{t 'ar-importer.overview.table.headers.date'}}
-            />
-            <th>{{t 'ar-importer.overview.table.headers.status'}}</th>
-            <th />
-          </:header>
-          <:body as |arDesign|>
-            <td>
-              {{arDesign.name}}
-            </td>
-            <td>
-              {{detailedDate arDesign.date}}
-            </td>
-            <td>
-              {{#if arDesign.id}}
-                <UsageStatus @inDocs={{get @arDesigns.inDocs arDesign.id}} />
-              {{/if}}
-            </td>
-            <td>
-              <AuButtonGroup>
-                <AuButton
-                  @skin='link'
-                  @icon={{VisibleIcon}}
-                  @disabled={{this.disabled}}
-                  {{on 'click' (fn @onShowPreview arDesign)}}
-                >{{t 'ar-importer.overview.table.actions.preview'}}</AuButton>
-                <AuButton
-                  @skin='link'
-                  @icon={{PlusIcon}}
-                  @disabled={{this.disabled}}
-                  @loading={{eq @insertingDesign.id arDesign.id}}
-                  @loadingMessage={{t 'application.loading'}}
-                  {{on
-                    'click'
-                    (fn @onInsertAr arDesign afterLastArticle false)
-                  }}
-                >{{t 'ar-importer.overview.table.actions.insert'}}</AuButton>
-              </AuButtonGroup>
-            </td>
-          </:body>
-        </ReactiveTable>
-      </div>
+          {{/let}}
+        </AuFormRow>
+        <AuButton
+          class='ar-importer-overview__reset-filters-button'
+          @skin='naked'
+          @size='large'
+          @icon={{CrossIcon}}
+          {{on 'click' @resetFilters}}
+        >{{t 'ar-importer.overview.filters.reset'}}</AuButton>
+      </form>
     </div>
-  </template>
-}
+    <div class='ar-importer-overview__content'>
+      <ReactiveTable
+        @content={{@arDesigns.designs}}
+        @isLoading={{@loading}}
+        @page={{@pageNumber}}
+        @pageSize={{@pageSize}}
+        @onPageChange={{@updatePageNumber}}
+        @onSortChange={{@updateSort}}
+        @sort={{@sort}}
+        @noDataMessage={{t 'ar-importer.overview.table.no-data'}}
+        @hidePagination={{false}}
+      >
+        <:header as |header|>
+          <header.Sortable
+            @field=':no-case:name'
+            @label={{t 'ar-importer.overview.table.headers.name'}}
+          />
+          <header.Sortable
+            @field='date'
+            @label={{t 'ar-importer.overview.table.headers.date'}}
+          />
+          <th>{{t 'ar-importer.overview.table.headers.status'}}</th>
+          <th />
+        </:header>
+        <:body as |arDesign|>
+          <td>
+            {{arDesign.name}}
+          </td>
+          <td>
+            {{detailedDate arDesign.date}}
+          </td>
+          <td>
+            {{#if arDesign.id}}
+              <UsageStatus @inDocs={{get @arDesigns.inDocs arDesign.id}} />
+            {{/if}}
+          </td>
+          <td>
+            <AuButtonGroup>
+              <AuButton
+                @skin='link'
+                @icon={{VisibleIcon}}
+                {{on 'click' (fn @onShowPreview arDesign)}}
+              >{{t 'ar-importer.overview.table.actions.select'}}</AuButton>
+            </AuButtonGroup>
+          </td>
+        </:body>
+      </ReactiveTable>
+    </div>
+  </div>
+</template>;
+
+export default ArDesignOverview;
 
 type UsageStatusSig = {
   Args: {

--- a/app/components/editor-plugins/ar-importer/preview.gts
+++ b/app/components/editor-plugins/ar-importer/preview.gts
@@ -45,6 +45,36 @@ export default class ArPreview extends Component<ArPreviewSignature> {
             {{on 'click' this.returnToOverview}}
           >{{t 'ar-importer.preview.return-to-overview'}}</AuButton>
         </Group>
+      </AuToolbar>
+      <div class='ar-importer-preview__content au-o-layout'>
+        {{#if this.preview.isLoading}}
+          <AuLoader @centered={{true}} @hideMessage={{false}}>
+            {{t 'application.loading'}}
+          </AuLoader>
+        {{/if}}
+        {{#if this.preview.isError}}
+          <AuAlert @icon='alert-triangle' @skin='error'>
+            {{t 'ar-importer.message.error-processing-design'}}
+          </AuAlert>
+        {{/if}}
+        {{#if this.preview.value}}
+          {{#if this.preview.value.warnings}}
+            <AuAlert
+              @icon='alert-triangle'
+              @skin='warning'
+              class='au-u-margin-left au-u-margin-right'
+            >
+              {{#each this.preview.value.warnings as |warning|}}
+                <p>{{warning}}</p>
+              {{/each}}
+            </AuAlert>
+          {{/if}}
+          {{htmlSafe this.preview.value.result}}
+        {{/if}}
+      </div>
+
+      <AuToolbar @size='medium' as |Group|>
+        <Group />
         <InsertControls
           @arDesign={{@arDesign}}
           @onInsertAr={{@onInsertAr}}
@@ -52,33 +82,6 @@ export default class ArPreview extends Component<ArPreviewSignature> {
           @articles={{@articles}}
         />
       </AuToolbar>
-      {{#if this.preview.isLoading}}
-        <AuLoader @hideMessage={{true}}>
-          {{t 'application.loading'}}
-        </AuLoader>
-      {{/if}}
-      {{#if this.preview.isError}}
-        <AuAlert @icon='alert-triangle' @skin='error'>
-          {{t 'ar-importer.message.error-processing-design'}}
-        </AuAlert>
-      {{/if}}
-      {{#if this.preview.value}}
-        {{#if this.preview.value.warnings}}
-          <AuAlert
-            @icon='alert-triangle'
-            @skin='warning'
-            class='au-u-margin-left au-u-margin-right'
-          >
-            {{#each this.preview.value.warnings as |warning|}}
-              <p>{{warning}}</p>
-            {{/each}}
-          </AuAlert>
-        {{/if}}
-        <div class='ar-importer-preview__content au-o-layout'>
-          {{htmlSafe this.preview.value.result}}
-        </div>
-      {{/if}}
-
     </div>
   </template>
 }

--- a/app/components/editor-plugins/ar-importer/preview.gts
+++ b/app/components/editor-plugins/ar-importer/preview.gts
@@ -2,23 +2,18 @@ import Component from '@glimmer/component';
 import { service } from '@ember/service';
 import { on } from '@ember/modifier';
 import { htmlSafe } from '@ember/template';
-import { fn } from '@ember/helper';
 import t from 'ember-intl/helpers/t';
 import { trackedFunction } from 'reactiveweb/function';
 import AuToolbar from '@appuniversum/ember-appuniversum/components/au-toolbar';
 import AuButton from '@appuniversum/ember-appuniversum/components/au-button';
-import { PlusIcon } from '@appuniversum/ember-appuniversum/components/icons/plus';
 import { ArrowLeftIcon } from '@appuniversum/ember-appuniversum/components/icons/arrow-left';
 import AuLoader from '@appuniversum/ember-appuniversum/components/au-loader';
 import type ArImporterService from 'frontend-gelinkt-notuleren/services/ar-importer';
-import type ArDesign from 'frontend-gelinkt-notuleren/models/ar-design';
 import AuAlert from '@appuniversum/ember-appuniversum/components/au-alert';
+import { InsertControls, type ArInsertControlArgs } from './insert-controls';
 
 type ArPreviewSignature = {
-  Args: {
-    arDesign: ArDesign;
-    onInsertAr: (arDesign: ArDesign, skipWarnings?: boolean) => void;
-    insertLoading?: boolean;
+  Args: ArInsertControlArgs & {
     onReturnToOverview: () => unknown;
   };
   Element: HTMLDivElement;
@@ -50,14 +45,12 @@ export default class ArPreview extends Component<ArPreviewSignature> {
             {{on 'click' this.returnToOverview}}
           >{{t 'ar-importer.preview.return-to-overview'}}</AuButton>
         </Group>
-        <Group>
-          <AuButton
-            @icon={{PlusIcon}}
-            @loading={{@insertLoading}}
-            @loadingMessage={{t 'application.loading'}}
-            {{on 'click' (fn @onInsertAr @arDesign true)}}
-          >{{t 'ar-importer.preview.insert'}}</AuButton>
-        </Group>
+        <InsertControls
+          @arDesign={{@arDesign}}
+          @onInsertAr={{@onInsertAr}}
+          @insertLoading={{@insertLoading}}
+          @articles={{@articles}}
+        />
       </AuToolbar>
       {{#if this.preview.isLoading}}
         <AuLoader @hideMessage={{true}}>

--- a/app/components/editor-plugins/ar-importer/sidebar-widget.gts
+++ b/app/components/editor-plugins/ar-importer/sidebar-widget.gts
@@ -7,6 +7,8 @@ import AuModal from '@appuniversum/ember-appuniversum/components/au-modal';
 import type { SayController } from '@lblod/ember-rdfa-editor';
 import ArWidgetContents from './widget-contents';
 import { getCurrentBesluitRange } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/decision-utils';
+import { getArticleNodes } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/document-structure-utils';
+import type { ArticlePosition } from './common-types';
 
 type Sig = {
   Args: {
@@ -17,7 +19,9 @@ type Sig = {
 
 export default class ArImporterSidebarWidget extends Component<Sig> {
   @tracked modalOpen = false;
+  @tracked articles: ArticlePosition[] = [];
   openModal = () => {
+    this.articles = getArticleNodes(this.args.controller.mainEditorState);
     this.modalOpen = true;
   };
   closeModal = () => {
@@ -51,6 +55,7 @@ export default class ArImporterSidebarWidget extends Component<Sig> {
         <ArWidgetContents
           @controller={{@controller}}
           @onInsert={{this.closeModal}}
+          @articles={{this.articles}}
         />
       </modal.Body>
     </AuModal>

--- a/app/components/editor-plugins/ar-importer/widget-contents.gts
+++ b/app/components/editor-plugins/ar-importer/widget-contents.gts
@@ -19,6 +19,7 @@ import type EditorDocumentModel from 'frontend-gelinkt-notuleren/models/editor-d
 import type { Collection } from '@ember-data/store/-private/record-arrays/identifier-array';
 import type { GenerateImportResult } from 'frontend-gelinkt-notuleren/services/ar-importer';
 import type { ArticlePosition } from './common-types';
+import type { ArticleInsertPosition } from 'frontend-gelinkt-notuleren/utils/article-insert-position';
 
 const FILTER_TIMEOUT_MS = 300;
 
@@ -141,7 +142,7 @@ export default class ArWidgetContents extends Component<Sig> {
   insertAr = task(
     async (
       design: ArDesign,
-      insertPos: ArticlePosition | null,
+      insertPos: ArticleInsertPosition,
       skipWarnings?: boolean,
     ) => {
       this.insertingDesign = design;

--- a/app/components/editor-plugins/ar-importer/widget-contents.gts
+++ b/app/components/editor-plugins/ar-importer/widget-contents.gts
@@ -18,6 +18,7 @@ import {
 import type EditorDocumentModel from 'frontend-gelinkt-notuleren/models/editor-document';
 import type { Collection } from '@ember-data/store/-private/record-arrays/identifier-array';
 import type { GenerateImportResult } from 'frontend-gelinkt-notuleren/services/ar-importer';
+import type { ArticlePosition } from './common-types';
 
 const FILTER_TIMEOUT_MS = 300;
 
@@ -32,6 +33,7 @@ type Sig = {
   Args: {
     controller: SayController;
     onInsert?: () => void;
+    articles: ArticlePosition[];
   };
 };
 
@@ -136,20 +138,27 @@ export default class ArWidgetContents extends Component<Sig> {
     }
   };
 
-  insertAr = task(async (design: ArDesign, skipWarnings?: boolean) => {
-    this.insertingDesign = design;
-    const monadsResult = await this.arImporter.generateInsertionMonads(
-      this.args.controller,
-      design,
-    );
-    if (skipWarnings || monadsResult.warnings.length === 0) {
-      this.doInsert(monadsResult.result);
-    } else {
-      this.insertWarnings = monadsResult;
-      this.selectedDesign = design;
-      this.insertingDesign = null;
-    }
-  });
+  insertAr = task(
+    async (
+      design: ArDesign,
+      insertPos: ArticlePosition | null,
+      skipWarnings?: boolean,
+    ) => {
+      this.insertingDesign = design;
+      const monadsResult = await this.arImporter.generateInsertionMonads(
+        this.args.controller,
+        design,
+        insertPos,
+      );
+      if (skipWarnings || monadsResult.warnings.length === 0) {
+        this.doInsert(monadsResult.result);
+      } else {
+        this.insertWarnings = monadsResult;
+        this.selectedDesign = design;
+        this.insertingDesign = null;
+      }
+    },
+  );
 
   confirmInsert = () => {
     if (this.insertWarnings) {
@@ -170,6 +179,7 @@ export default class ArWidgetContents extends Component<Sig> {
         @onReturnToOverview={{this.abortInsert}}
         @onInsertAr={{this.confirmInsert}}
         @insertLoading={{this.insertAr.isRunning}}
+        @articles={{@articles}}
       />
     {{else if this.selectedDesign}}
       <ArPreview
@@ -177,6 +187,7 @@ export default class ArWidgetContents extends Component<Sig> {
         @onReturnToOverview={{this.returnToOverview}}
         @onInsertAr={{this.insertAr.perform}}
         @insertLoading={{this.insertAr.isRunning}}
+        @articles={{@articles}}
       />
     {{else}}
       <ArDesignOverview

--- a/app/components/editor-plugins/ar-importer/widget-contents.gts
+++ b/app/components/editor-plugins/ar-importer/widget-contents.gts
@@ -42,8 +42,6 @@ export default class ArWidgetContents extends Component<Sig> {
   @service declare arImporter: ArImporterService;
 
   @tracked selectedDesign?: ArDesign | null;
-  @tracked insertingDesign?: ArDesign | null;
-  @tracked insertWarnings?: GenerateImportResult | null;
 
   @service declare store: Store;
 
@@ -134,7 +132,6 @@ export default class ArWidgetContents extends Component<Sig> {
   doInsert = (monads: GenerateImportResult['result']) => {
     const isSuccess = this.arImporter.insertAr(this.args.controller, monads);
     if (isSuccess) {
-      this.insertingDesign = null;
       this.args.onInsert?.();
     }
   };
@@ -145,7 +142,6 @@ export default class ArWidgetContents extends Component<Sig> {
       insertPos: ArticleInsertPosition,
       skipWarnings?: boolean,
     ) => {
-      this.insertingDesign = design;
       const monadsResult = await this.arImporter.generateInsertionMonads(
         this.args.controller,
         design,
@@ -153,36 +149,12 @@ export default class ArWidgetContents extends Component<Sig> {
       );
       if (skipWarnings || monadsResult.warnings.length === 0) {
         this.doInsert(monadsResult.result);
-      } else {
-        this.insertWarnings = monadsResult;
-        this.selectedDesign = design;
-        this.insertingDesign = null;
       }
     },
   );
 
-  confirmInsert = () => {
-    if (this.insertWarnings) {
-      this.doInsert(this.insertWarnings.result);
-      this.insertWarnings = null;
-    }
-  };
-  abortInsert = () => {
-    this.insertWarnings = null;
-    this.insertingDesign = null;
-  };
-
   <template>
-    {{#if this.insertWarnings}}
-      <ArPreview
-        {{! @glint-expect-error ember-truth-helpers doesnt help so might as well just ignore }}
-        @arDesign={{this.selectedDesign}}
-        @onReturnToOverview={{this.abortInsert}}
-        @onInsertAr={{this.confirmInsert}}
-        @insertLoading={{this.insertAr.isRunning}}
-        @articles={{@articles}}
-      />
-    {{else if this.selectedDesign}}
+    {{#if this.selectedDesign}}
       <ArPreview
         @arDesign={{this.selectedDesign}}
         @onReturnToOverview={{this.returnToOverview}}
@@ -195,8 +167,6 @@ export default class ArWidgetContents extends Component<Sig> {
         @arDesigns={{this.arDesigns.value}}
         @loading={{this.arDesigns.isRunning}}
         @onShowPreview={{this.selectDesign}}
-        @onInsertAr={{this.insertAr.perform}}
-        @insertingDesign={{this.insertingDesign}}
         @nameFilter={{this.nameFilter}}
         @setNameFilter={{this.setNameFilter}}
         @resetFilters={{this.resetFilters}}

--- a/app/services/ar-importer.ts
+++ b/app/services/ar-importer.ts
@@ -22,7 +22,10 @@ import type TrafficSignal from 'frontend-gelinkt-notuleren/models/traffic-signal
 import type VariableInstance from 'frontend-gelinkt-notuleren/models/variable-instance';
 import { v4 as uuidv4 } from 'uuid';
 import { TRAFFIC_SIGNAL_EXISTING_STATUSES } from 'frontend-gelinkt-notuleren/config/constants';
-import type { ArticlePosition } from 'frontend-gelinkt-notuleren/components/editor-plugins/ar-importer/common-types';
+import {
+  ArticleInsertPosition,
+  afterLastArticle,
+} from 'frontend-gelinkt-notuleren/utils/article-insert-position';
 
 export type ImportResult<R> = {
   result: R;
@@ -105,7 +108,7 @@ export default class ArImporterService extends Service {
   async generateInsertionMonads(
     decisionUriOrController: string | SayController,
     design: ArDesign,
-    insertPosition: ArticlePosition | null,
+    insertPos: ArticleInsertPosition,
     isPreview?: boolean,
   ): Promise<GenerateImportResult> {
     let decisionUri: string;
@@ -205,6 +208,7 @@ export default class ArImporterService extends Service {
             variables: convertedVariableInstances,
             templateString: measureConcept.templateString,
             decisionUri,
+            position: insertPos.insertMeasureIndex,
             articleUriGenerator: () =>
               `http://data.lblod.info/artikels/${uuidv4()}`,
           }),
@@ -226,7 +230,7 @@ export default class ArImporterService extends Service {
     const { result: monads, warnings } = await this.generateInsertionMonads(
       decisionUri,
       design,
-      null,
+      afterLastArticle,
       true,
     );
     const document = this.agendapointEditor.processDocumentHeadlessly(

--- a/app/services/ar-importer.ts
+++ b/app/services/ar-importer.ts
@@ -22,6 +22,7 @@ import type TrafficSignal from 'frontend-gelinkt-notuleren/models/traffic-signal
 import type VariableInstance from 'frontend-gelinkt-notuleren/models/variable-instance';
 import { v4 as uuidv4 } from 'uuid';
 import { TRAFFIC_SIGNAL_EXISTING_STATUSES } from 'frontend-gelinkt-notuleren/config/constants';
+import type { ArticlePosition } from 'frontend-gelinkt-notuleren/components/editor-plugins/ar-importer/common-types';
 
 export type ImportResult<R> = {
   result: R;
@@ -104,6 +105,7 @@ export default class ArImporterService extends Service {
   async generateInsertionMonads(
     decisionUriOrController: string | SayController,
     design: ArDesign,
+    insertPosition: ArticlePosition | null,
     isPreview?: boolean,
   ): Promise<GenerateImportResult> {
     let decisionUri: string;
@@ -224,6 +226,7 @@ export default class ArImporterService extends Service {
     const { result: monads, warnings } = await this.generateInsertionMonads(
       decisionUri,
       design,
+      null,
       true,
     );
     const document = this.agendapointEditor.processDocumentHeadlessly(

--- a/app/styles/project/_c-ar-importer.scss
+++ b/app/styles/project/_c-ar-importer.scss
@@ -52,9 +52,12 @@
   max-width: 140rem;
 }
 .ar-importer-insert-controls {
+  width: 100%;
+  flex-shrink: 1;
   display: flex;
   column-gap: 1rem;
-  justify-content: center;
+  justify-content: end;
+  align-items: baseline;
 }
 .ar-importer-insert-controls__selector {
   flex-basis: 25rem;
@@ -62,7 +65,4 @@
   flex-grow: 0;
   justify-self: right;
   align-self: right;
-}
-.ar-importer-insert-controls__label {
-  margin: auto;
 }

--- a/app/styles/project/_c-ar-importer.scss
+++ b/app/styles/project/_c-ar-importer.scss
@@ -51,3 +51,18 @@
   margin-right: auto;
   max-width: 140rem;
 }
+.ar-importer-insert-controls {
+  display: flex;
+  column-gap: 1rem;
+  justify-content: center;
+}
+.ar-importer-insert-controls__selector {
+  flex-basis: 25rem;
+  flex-shrink: 0;
+  flex-grow: 0;
+  justify-self: right;
+  align-self: right;
+}
+.ar-importer-insert-controls__label {
+  margin: auto;
+}

--- a/app/utils/article-insert-position.ts
+++ b/app/utils/article-insert-position.ts
@@ -1,0 +1,36 @@
+type InsertSpec = 'first' | 'last' | number;
+
+type InsertMeasureIndex = number | undefined;
+
+// import for jsdoc link, @import seems to not work here
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type insertMeasure from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/roadsign-regulation-plugin/actions/insert-measure';
+
+/**
+ * Util class to encapsulate where to insert something in the editor, based
+ * on its relation to the existing articles
+ */
+export class ArticleInsertPosition {
+  private index;
+  constructor(articleIndex: InsertSpec) {
+    this.index = articleIndex;
+  }
+
+  /**
+   * The insertion index as understood by the {@link insertMeasure} function
+   * It expects the index of the article before which it will insert,
+   * or undefined, which it interprets as after last
+   */
+  get insertMeasureIndex(): InsertMeasureIndex {
+    if (this.index === 'last') {
+      return undefined;
+    } else if (this.index === 'first') {
+      return 0;
+    } else {
+      return this.index + 1;
+    }
+  }
+}
+
+export const afterLastArticle = new ArticleInsertPosition('last');
+export const beforeFirstArticle = new ArticleInsertPosition('first');

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@lblod/ember-environment-banner": "^0.6.0",
     "@lblod/ember-mock-login": "^0.14.0",
     "@lblod/ember-rdfa-editor": "catalog:",
-    "@lblod/ember-rdfa-editor-lblod-plugins": "35.6.0",
+    "@lblod/ember-rdfa-editor-lblod-plugins": "36.0.0",
     "@lblod/template-uuid-instantiator": "^1.0.3",
     "@nullvoxpopuli/ember-composable-helpers": "catalog:",
     "@rdfjs/types": "^2.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -296,8 +296,8 @@ importers:
         specifier: 13.7.1
         version: 13.7.1(a2cb0244dd9131bc305eb5466e43e69d)
       '@lblod/ember-rdfa-editor-lblod-plugins':
-        specifier: 35.6.0
-        version: 35.6.0(cc9eba76ea7044317ac64d65100624bd)
+        specifier: 36.0.0
+        version: 36.0.0(cc9eba76ea7044317ac64d65100624bd)
       '@lblod/template-uuid-instantiator':
         specifier: ^1.0.3
         version: 1.0.3
@@ -2069,8 +2069,8 @@ packages:
       ember-simple-auth: '>= 6.0.0'
       ember-source: '>= 4.0.0'
 
-  '@lblod/ember-rdfa-editor-lblod-plugins@35.6.0':
-    resolution: {integrity: sha512-ht46KN9jLAD7jmBDPX9ktiITrPnCtHwcLQt9BSpLc8qT5dU4gST/xwAMf9CZPP8kShddpYohNXSTf7XbNLNuIA==}
+  '@lblod/ember-rdfa-editor-lblod-plugins@36.0.0':
+    resolution: {integrity: sha512-JPE+ZuSYzOxrN3zSfiw3UQUt4InwzaZLGErhFXJtNb4MurCq2ByJhUCAyNxrRQLmrVHP0opgBQbSz9lN07NURw==}
     engines: {node: '>= 18'}
     peerDependencies:
       '@appuniversum/ember-appuniversum': ^3.12.0
@@ -12606,7 +12606,7 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  '@lblod/ember-rdfa-editor-lblod-plugins@35.6.0(cc9eba76ea7044317ac64d65100624bd)':
+  '@lblod/ember-rdfa-editor-lblod-plugins@36.0.0(cc9eba76ea7044317ac64d65100624bd)':
     dependencies:
       '@appuniversum/ember-appuniversum': 3.19.0(@ember/test-helpers@3.3.1(@babel/core@7.29.0)(@glint/template@1.7.7)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.106.2(postcss@8.5.14)))(webpack@5.106.2(postcss@8.5.14)))(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.106.2(postcss@8.5.14)))(eslint@9.39.4(jiti@2.6.1))(miragejs@0.1.48)(tracked-built-ins@4.1.2(@babel/core@7.29.0))(webpack@5.106.2(postcss@8.5.14))
       '@babel/core': 7.29.0

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -945,8 +945,7 @@ ar-importer:
         date: Last modified
         status: Usage status
       actions:
-        preview: Preview
-        insert: Insert
+        select: Select
       statuses:
         used: Used
         unused: Not yet used

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -955,6 +955,7 @@ ar-importer:
     first: Before the first article
     last: After the last article
     after-article-x: After article {articleNumber}
+    select-position: Choose insertion point
   preview:
     return-to-overview: Return to overview
     only-existing-label: existing

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -951,9 +951,13 @@ ar-importer:
         used: Used
         unused: Not yet used
       no-data: No designs found
+  controls:
+    insert: Insert
+    first: Before the first article
+    last: After the last article
+    after-article-x: After article {articleNumber}
   preview:
     return-to-overview: Return to overview
-    insert: Insert
     only-existing-label: existing
     only-existing: This design only includes existing Traffic Signals.
   message:

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -957,9 +957,13 @@ ar-importer:
         used: Gebruikt
         unused: Nog niet gebruikt
       no-data: Geen ontwerpen gevonden
+  controls:
+    insert: Voeg in
+    first: Voor het eerste artikel
+    last: Na het laatste artikel
+    after-article-x: Na artikel {articleNumber}
   preview:
     return-to-overview: Terug naar overzicht
-    insert: Voeg in
     only-existing-label: bestaand
     only-existing: Dit maatregelontwerp bevat enkel reeds bestaande verkeerstekens.
   message:

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -951,8 +951,7 @@ ar-importer:
         date: Laatste wijziging
         status: Gebruikstatus
       actions:
-        preview: Preview
-        insert: Voeg in
+        select: Selecteer
       statuses:
         used: Gebruikt
         unused: Nog niet gebruikt

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -961,6 +961,7 @@ ar-importer:
     first: Voor het eerste artikel
     last: Na het laatste artikel
     after-article-x: Na artikel {articleNumber}
+    select-position: Kies invoegpositie
   preview:
     return-to-overview: Terug naar overzicht
     only-existing-label: bestaand


### PR DESCRIPTION
### Overview
<!-- high level overview of changes (not just "implement ticket") + *why* + design document, special notes like ticket partially implemented etc. -->

- adds the requested insertion options, using the same UI logic as was used in the roadsign plugin

**UX Change**

I also made it so a user always has to go to the preview first before inserting. It simplifies the UX, while only adding a click in cases where there are no warnings to show.

If I didn't do this, I'd have had to add the insertion selector both in the preview window and in the table, which would be very messy.

##### connected issues and PRs:
<!-- links to connected jira tickets -->
<!-- Link to PRs that are related (and in what way) -->

[GN-6139](https://binnenland.atlassian.net/browse/GN-6139)

### Setup
<!-- PR dependencies -->
<!-- override snippets -->

Doesn't need any special backend, so you can proxy to dev

### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

Insert an AR, notice the "preview" and "insert" actions have been replaced by a single "select" action, which opens the preview. 
There, you can now see the same insertion options as we have in the roadsign plugin. 

The option list will populate with the amount of articles in the document.

### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->



### Checks PR readiness
- [x] UI: works on smaller screen sizes (until about 1/5 of the screen)
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
