### PR TITLE
Allow template selection from meeting edit

### DIFF
--- a/.changeset/yellow-worlds-admire.md
+++ b/.changeset/yellow-worlds-admire.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': minor
+---
+
+Allow template selection from meeting edit

--- a/app/components/behandeling-van-agendapunt.gts
+++ b/app/components/behandeling-van-agendapunt.gts
@@ -94,7 +94,6 @@ export default class BehandelingVanAgendapuntComponent extends Component<Signatu
   agendapointHasContent = trackedFunction(this, async () => {
     const container = await this.behandeling?.documentContainer;
     const current = await container?.currentVersion;
-    console.log(current?.content);
     return !!current?.content;
   });
 

--- a/app/components/behandeling-van-agendapunt.gts
+++ b/app/components/behandeling-van-agendapunt.gts
@@ -91,6 +91,19 @@ export default class BehandelingVanAgendapuntComponent extends Component<Signatu
     return this.args.meeting.nietToegekendeMandatarissen;
   });
 
+  agendapointHasContent = trackedFunction(this, async () => {
+    const container = await this.behandeling?.documentContainer;
+    const current = await container?.currentVersion;
+    console.log(current?.content);
+    return !!current?.content;
+  });
+
+  get editAgendapointRoute() {
+    return this.agendapointHasContent.value
+      ? 'meetings.edit.agendapoint.edit'
+      : 'meetings.edit.agendapoint.new';
+  }
+
   constructor(owner: unknown, args: Signature['Args']) {
     super(owner, args);
     void this.fetchParticipants.perform();
@@ -542,16 +555,22 @@ export default class BehandelingVanAgendapuntComponent extends Component<Signatu
             </WithTooltip>
           {{/unless}}
           {{#if (and this.editable @behandeling.documentContainer)}}
-            <AuLink
-              @route='meetings.edit.agendapoint.edit'
-              @model={{@behandeling.documentContainer.id}}
-              @skin='button-secondary'
-              @icon='pencil'
-              @iconAlignment='left'
-              class='au-u-hide-on-print'
-            >
-              {{t 'generic.edit'}}
-            </AuLink>
+            {{#unless this.agendapointHasContent.isLoading}}
+              <AuLink
+                @route={{this.editAgendapointRoute}}
+                @model={{@behandeling.documentContainer.id}}
+                @skin='button-secondary'
+                @icon='pencil'
+                @iconAlignment='left'
+                class='au-u-hide-on-print'
+              >
+                {{if
+                  this.agendapointHasContent.value
+                  (t 'generic.edit')
+                  (t 'utils.create')
+                }}
+              </AuLink>
+            {{/unless}}
           {{/if}}
         </div>
       </:button>

--- a/app/components/document-creator/modal.gts
+++ b/app/components/document-creator/modal.gts
@@ -25,6 +25,7 @@ import TemplatePicker, { type GetTemplates } from './template-picker';
 import MetadataForm, { type updateLinkedDecisionArgs } from './metadata-form';
 import type DocumentContainerModel from 'frontend-gelinkt-notuleren/models/document-container';
 import { localCopy } from 'tracked-toolbox';
+import type ConceptModel from 'frontend-gelinkt-notuleren/models/concept';
 
 const truthy = (test: unknown) => !!test;
 
@@ -34,9 +35,10 @@ interface Sig {
     getTemplates: GetTemplates;
     folderId: string;
     onCancel: () => void;
-    onCreate: (container: unknown, template: Template) => void;
+    onCreate: (container: unknown, template: Template) => Promise<void>;
     decisionTypeOptions?: BesluitTypePluginOptions;
     container?: DocumentContainerModel;
+    statusOfNewDocument?: ConceptModel;
     documentTitle?: string;
   };
 }
@@ -124,8 +126,9 @@ export default class DocumentCreatorModal extends Component<Sig> {
         decisionType: this.decisionType,
         linkedDecisionUri: this.linkedDecisionUri,
         container: this.args.container,
+        status: this.args.statusOfNewDocument,
       });
-      this.args.onCreate(container, this.selectedTemplate);
+      await this.args.onCreate(container, this.selectedTemplate);
     }
   });
 

--- a/app/components/document-creator/modal.gts
+++ b/app/components/document-creator/modal.gts
@@ -23,6 +23,8 @@ import type BestuurseenheidModel from 'frontend-gelinkt-notuleren/models/bestuur
 import type AgendapointEditorService from 'frontend-gelinkt-notuleren/services/editor/agendapoint';
 import TemplatePicker, { type GetTemplates } from './template-picker';
 import MetadataForm, { type updateLinkedDecisionArgs } from './metadata-form';
+import type DocumentContainerModel from 'frontend-gelinkt-notuleren/models/document-container';
+import { localCopy } from 'tracked-toolbox';
 
 const truthy = (test: unknown) => !!test;
 
@@ -34,6 +36,8 @@ interface Sig {
     onCancel: () => void;
     onCreate: (container: unknown, template: Template) => void;
     decisionTypeOptions?: BesluitTypePluginOptions;
+    container?: DocumentContainerModel;
+    documentTitle?: string;
   };
 }
 
@@ -43,7 +47,7 @@ export default class DocumentCreatorModal extends Component<Sig> {
   @service('editor/agendapoint')
   declare agendapointEditor: AgendapointEditorService;
   @tracked selectedTemplate: Template | undefined;
-  @tracked title = '';
+  @localCopy('args.documentTitle') title = '';
   @tracked invalidTitle = false;
   @tracked decisionType?: BesluitTypeInstance;
   @tracked decisionTypes?: BesluitType[];
@@ -77,6 +81,7 @@ export default class DocumentCreatorModal extends Component<Sig> {
     }
   };
   deselectTemplate = () => {
+    this.title = this.args.documentTitle ?? '';
     this.selectedTemplate = undefined;
   };
   setDecisionType = (selected: BesluitTypeInstance) => {
@@ -111,14 +116,16 @@ export default class DocumentCreatorModal extends Component<Sig> {
 
   create = task(async () => {
     if (this.selectedTemplate) {
-      const container = await this.documentService.persistDocument({
-        template: this.selectedTemplate,
-        title: this.title,
-        folderId: this.args.folderId,
-        group: this.currentSession.group as BestuurseenheidModel,
-        decisionType: this.decisionType,
-        linkedDecisionUri: this.linkedDecisionUri,
-      });
+      const container =
+        this.args.container ??
+        (await this.documentService.persistDocument({
+          template: this.selectedTemplate,
+          title: this.title,
+          folderId: this.args.folderId,
+          group: this.currentSession.group as BestuurseenheidModel,
+          decisionType: this.decisionType,
+          linkedDecisionUri: this.linkedDecisionUri,
+        }));
       this.args.onCreate(container, this.selectedTemplate);
     }
   });

--- a/app/components/document-creator/modal.gts
+++ b/app/components/document-creator/modal.gts
@@ -116,16 +116,15 @@ export default class DocumentCreatorModal extends Component<Sig> {
 
   create = task(async () => {
     if (this.selectedTemplate) {
-      const container =
-        this.args.container ??
-        (await this.documentService.persistDocument({
-          template: this.selectedTemplate,
-          title: this.title,
-          folderId: this.args.folderId,
-          group: this.currentSession.group as BestuurseenheidModel,
-          decisionType: this.decisionType,
-          linkedDecisionUri: this.linkedDecisionUri,
-        }));
+      const container = await this.documentService.persistDocument({
+        template: this.selectedTemplate,
+        title: this.title,
+        folderId: this.args.folderId,
+        group: this.currentSession.group as BestuurseenheidModel,
+        decisionType: this.decisionType,
+        linkedDecisionUri: this.linkedDecisionUri,
+        container: this.args.container,
+      });
       this.args.onCreate(container, this.selectedTemplate);
     }
   });

--- a/app/controllers/meetings/edit.ts
+++ b/app/controllers/meetings/edit.ts
@@ -10,9 +10,19 @@ export default class MeetingsEditController extends Controller {
   @tracked
   focused = false;
 
+  hiddenRoutes = [
+    'meetings.edit.agendapoint',
+    'meetings.edit.agendapoint.attachments',
+    'meetings.edit.agendapoint.copy',
+    'meetings.edit.agendapoint.edit',
+    // the create new modal looks odd without a background
+    // leaving it commented out to show it's intentionally omitted here
+    // 'meetings.edit.agendapoint.new',
+    'meetings.edit.agendapoint.revisions',
+  ];
+
   get hideMeetingForm() {
-    return this.router.currentRouteName?.startsWith(
-      'meetings.edit.agendapoint',
-    );
+    const { currentRouteName } = this.router;
+    return currentRouteName && this.hiddenRoutes.includes(currentRouteName);
   }
 }

--- a/app/controllers/meetings/edit/agendapoint/new.ts
+++ b/app/controllers/meetings/edit/agendapoint/new.ts
@@ -33,7 +33,7 @@ export default class MeetingsEditNewController extends Controller {
     void this.plausible.trackEvent('Create agendapoint', {
       templateTitle: chosenTemplate.title,
     });
-    this.router.transitionTo('agendapoints.edit', container.id);
+    this.router.transitionTo('meetings.edit.agendapoint.edit', container.id);
   }
 
   get editorConfig() {

--- a/app/controllers/meetings/edit/agendapoint/new.ts
+++ b/app/controllers/meetings/edit/agendapoint/new.ts
@@ -1,0 +1,78 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { service } from '@ember/service';
+import type RouterService from '@ember/routing/router-service';
+import type IntlService from 'ember-intl/services/intl';
+import type { SayController } from '@lblod/ember-rdfa-editor';
+import type MeetingsEditRoute from 'frontend-gelinkt-notuleren/routes/meetings/edit';
+import type { ModelFrom } from 'frontend-gelinkt-notuleren/utils/types';
+import type TemplateFetcher from 'frontend-gelinkt-notuleren/services/template-fetcher';
+import { EDITOR_FOLDERS } from 'frontend-gelinkt-notuleren/config/constants';
+import type AgendapointEditorService from 'frontend-gelinkt-notuleren/services/editor/agendapoint';
+import type DocumentContainerModel from 'frontend-gelinkt-notuleren/models/document-container';
+import type { Template } from 'frontend-gelinkt-notuleren/services/template-fetcher';
+import type Plausible from 'ember-plausible/services/plausible';
+
+export default class MeetingsEditIntroController extends Controller {
+  declare model: ModelFrom<MeetingsEditRoute>;
+  @service declare router: RouterService;
+  @service declare intl: IntlService;
+  @service declare templateFetcher: TemplateFetcher;
+  @service declare plausible: Plausible;
+  @service('editor/agendapoint')
+  declare agendapointEditor: AgendapointEditorService;
+  @tracked editor?: SayController;
+
+  folderId = EDITOR_FOLDERS.DECISION_DRAFTS;
+
+  @action
+  redirectToAgendapoint(
+    container: DocumentContainerModel,
+    chosenTemplate: Template,
+  ) {
+    // Plausible Analytics: post custom event about the template used to create the agendapoint
+    this.plausible.trackEvent('Create agendapoint', {
+      templateTitle: chosenTemplate.title,
+    });
+    this.router.transitionTo('agendapoints.edit', container.id);
+  }
+
+  get editorConfig() {
+    return this.agendapointEditor.config;
+  }
+
+  getTemplates = async ({
+    filter,
+    pagination,
+    favourites,
+    abortSignal,
+  }: {
+    filter: { title: string };
+    templateType: string;
+    titleFilter?: string;
+    pagination?: { pageSize: number; pageNumber: number };
+    favourites?: string[];
+    abortSignal?: AbortSignal;
+  }) => {
+    const dynamicTemplatesPromise = this.templateFetcher.fetch.perform({
+      templateType:
+        'http://data.lblod.info/vocabularies/gelinktnotuleren/BesluitTemplate',
+      titleFilter: filter?.title,
+      pagination,
+      favourites,
+      abortSignal,
+    });
+    const [results, totalCount] = await dynamicTemplatesPromise;
+    return { results, totalCount };
+  };
+
+  @action
+  cancelAgendapointCreation() {
+    this.router.transitionTo('meetings.edit', this.model.returnToMeeting.id);
+  }
+
+  get documentTitle() {
+    return this.model.editorDocument.title;
+  }
+}

--- a/app/controllers/meetings/edit/agendapoint/new.ts
+++ b/app/controllers/meetings/edit/agendapoint/new.ts
@@ -73,4 +73,8 @@ export default class MeetingsEditNewController extends Controller {
   get documentTitle() {
     return this.model.editorDocument?.title;
   }
+
+  get container() {
+    return this.model.documentContainer;
+  }
 }

--- a/app/controllers/meetings/edit/agendapoint/new.ts
+++ b/app/controllers/meetings/edit/agendapoint/new.ts
@@ -4,7 +4,6 @@ import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
 import type RouterService from '@ember/routing/router-service';
 import type { SayController } from '@lblod/ember-rdfa-editor';
-import type MeetingsEditAgendapointRoute from 'frontend-gelinkt-notuleren/routes/meetings/edit/agendapoint';
 import type { ModelFrom } from 'frontend-gelinkt-notuleren/utils/types';
 import type TemplateFetcher from 'frontend-gelinkt-notuleren/services/template-fetcher';
 import { EDITOR_FOLDERS } from 'frontend-gelinkt-notuleren/config/constants';
@@ -12,9 +11,12 @@ import type AgendapointEditorService from 'frontend-gelinkt-notuleren/services/e
 import type DocumentContainerModel from 'frontend-gelinkt-notuleren/models/document-container';
 import type { Template } from 'frontend-gelinkt-notuleren/services/template-fetcher';
 import type Plausible from 'ember-plausible/services/plausible';
+import type Store from 'frontend-gelinkt-notuleren/services/store';
+import type MeetingsEditAgendapointNewRoute from 'frontend-gelinkt-notuleren/routes/meetings/edit/agendapoint/new';
 
 export default class MeetingsEditNewController extends Controller {
-  declare model: ModelFrom<MeetingsEditAgendapointRoute>;
+  declare model: ModelFrom<MeetingsEditAgendapointNewRoute>;
+  @service declare store: Store;
   @service declare router: RouterService;
   @service declare templateFetcher: TemplateFetcher;
   @service declare plausible: Plausible;
@@ -25,11 +27,25 @@ export default class MeetingsEditNewController extends Controller {
   folderId = EDITOR_FOLDERS.DECISION_DRAFTS;
 
   @action
-  redirectToAgendapoint(
+  async redirectToAgendapoint(
     container: DocumentContainerModel,
     chosenTemplate: Template,
   ) {
+    const { agendapoint } = this.model;
+    if (agendapoint) {
+      const newTitle = (await container.currentVersion)?.title;
+
+      if (newTitle && agendapoint.titel !== newTitle) {
+        agendapoint.titel = newTitle;
+        await agendapoint.save();
+      }
+    } else {
+      console.warn(
+        "Couldn't find agendapoint that newly made container belongs to, very strange",
+      );
+    }
     // Plausible Analytics: post custom event about the template used to create the agendapoint
+
     void this.plausible.trackEvent('Create agendapoint', {
       templateTitle: chosenTemplate.title,
     });

--- a/app/controllers/meetings/edit/agendapoint/new.ts
+++ b/app/controllers/meetings/edit/agendapoint/new.ts
@@ -3,9 +3,8 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
 import type RouterService from '@ember/routing/router-service';
-import type IntlService from 'ember-intl/services/intl';
 import type { SayController } from '@lblod/ember-rdfa-editor';
-import type MeetingsEditRoute from 'frontend-gelinkt-notuleren/routes/meetings/edit';
+import type MeetingsEditAgendapointRoute from 'frontend-gelinkt-notuleren/routes/meetings/edit/agendapoint';
 import type { ModelFrom } from 'frontend-gelinkt-notuleren/utils/types';
 import type TemplateFetcher from 'frontend-gelinkt-notuleren/services/template-fetcher';
 import { EDITOR_FOLDERS } from 'frontend-gelinkt-notuleren/config/constants';
@@ -14,10 +13,9 @@ import type DocumentContainerModel from 'frontend-gelinkt-notuleren/models/docum
 import type { Template } from 'frontend-gelinkt-notuleren/services/template-fetcher';
 import type Plausible from 'ember-plausible/services/plausible';
 
-export default class MeetingsEditIntroController extends Controller {
-  declare model: ModelFrom<MeetingsEditRoute>;
+export default class MeetingsEditNewController extends Controller {
+  declare model: ModelFrom<MeetingsEditAgendapointRoute>;
   @service declare router: RouterService;
-  @service declare intl: IntlService;
   @service declare templateFetcher: TemplateFetcher;
   @service declare plausible: Plausible;
   @service('editor/agendapoint')
@@ -32,7 +30,7 @@ export default class MeetingsEditIntroController extends Controller {
     chosenTemplate: Template,
   ) {
     // Plausible Analytics: post custom event about the template used to create the agendapoint
-    this.plausible.trackEvent('Create agendapoint', {
+    void this.plausible.trackEvent('Create agendapoint', {
       templateTitle: chosenTemplate.title,
     });
     this.router.transitionTo('agendapoints.edit', container.id);
@@ -73,6 +71,6 @@ export default class MeetingsEditIntroController extends Controller {
   }
 
   get documentTitle() {
-    return this.model.editorDocument.title;
+    return this.model.editorDocument?.title;
   }
 }

--- a/app/router.js
+++ b/app/router.js
@@ -61,6 +61,7 @@ Router.map(function () {
       this.route('intro');
       this.route('outro');
       this.route('agendapoint', { path: ':agendapoint_id' }, function () {
+        this.route('new');
         this.route('edit');
         this.route('copy');
         this.route('revisions');

--- a/app/routes/meetings/edit/agendapoint/edit.ts
+++ b/app/routes/meetings/edit/agendapoint/edit.ts
@@ -9,13 +9,22 @@ export default class MeetingsEditAgendapointEditRoute extends Route {
   @service declare standardTemplate: StandardTemplateService;
 
   async model() {
-    const parentModel = this.modelFor(
+    console.log('agendapoint edit route hook running');
+
+    // deliberately not using the editorDocument from the parent route, since
+    // this.modelFor does not rerun the parent's route hook if it's already loaded.
+    // So if we transition here from a sibling route, such as the .new route,
+    // we might have an out-of-date currentVersion on the container
+    const { returnToMeeting, documentContainer } = this.modelFor(
       'meetings.edit.agendapoint',
     ) as ModelFrom<MeetingsEditAgendapointRoute>;
     const templates = this.standardTemplate.fetchTemplates.perform();
 
     return RSVP.hash({
-      ...parentModel,
+      returnToMeeting,
+      documentContainer,
+      // asking ember-data to fetch the currentVersion again
+      editorDocument: documentContainer.currentVersion,
       // This does not include dynamic templates as it is only used for the standard template plugin
       templates,
     });

--- a/app/routes/meetings/edit/agendapoint/new.ts
+++ b/app/routes/meetings/edit/agendapoint/new.ts
@@ -1,0 +1,28 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+import RSVP from 'rsvp';
+import type { ModelFrom } from 'frontend-gelinkt-notuleren/utils/types';
+import type MeetingsEditAgendapointRoute from '../agendapoint';
+import type Store from 'frontend-gelinkt-notuleren/services/gn-store';
+import type ConceptModel from 'frontend-gelinkt-notuleren/models/concept';
+import { SCHEDULED_STATUS_ID } from 'frontend-gelinkt-notuleren/utils/constants';
+
+export default class MeetingsEditAgendapointNewRoute extends Route {
+  @service declare store: Store;
+
+  async model() {
+    const parentModel = this.modelFor(
+      'meetings.edit.agendapoint',
+    ) as ModelFrom<MeetingsEditAgendapointRoute>;
+
+    const scheduledStatus = this.store.findRecord<ConceptModel>(
+      'concept',
+      SCHEDULED_STATUS_ID,
+    );
+
+    return RSVP.hash({
+      ...parentModel,
+      scheduledStatus,
+    });
+  }
+}

--- a/app/routes/meetings/edit/agendapoint/new.ts
+++ b/app/routes/meetings/edit/agendapoint/new.ts
@@ -6,6 +6,7 @@ import type MeetingsEditAgendapointRoute from '../agendapoint';
 import type Store from 'frontend-gelinkt-notuleren/services/gn-store';
 import type ConceptModel from 'frontend-gelinkt-notuleren/models/concept';
 import { SCHEDULED_STATUS_ID } from 'frontend-gelinkt-notuleren/utils/constants';
+import type AgendapuntModel from 'frontend-gelinkt-notuleren/models/agendapunt';
 
 export default class MeetingsEditAgendapointNewRoute extends Route {
   @service declare store: Store;
@@ -20,7 +21,16 @@ export default class MeetingsEditAgendapointNewRoute extends Route {
       SCHEDULED_STATUS_ID,
     );
 
+    const agendapoints = this.store.query<AgendapuntModel>('agendapunt', {
+      filter: {
+        behandeling: {
+          'document-container': { ':id:': parentModel.documentContainer.id },
+        },
+      },
+    });
+
     return RSVP.hash({
+      agendapoint: (await agendapoints).slice()[0],
       ...parentModel,
       scheduledStatus,
     });

--- a/app/services/document-service.ts
+++ b/app/services/document-service.ts
@@ -27,6 +27,7 @@ interface PersistDocumentArgs {
   decisionType?: BesluitTypeInstance;
   linkedDecisionUri?: string;
   container?: DocumentContainerModel;
+  status?: ConceptModel;
 }
 
 function hasTypePredicate(triple: Triple): boolean {
@@ -207,6 +208,7 @@ export default class DocumentService extends Service {
     group,
     decisionType,
     linkedDecisionUri,
+    status,
     container = this.store.createRecord<DocumentContainerModel>(
       'document-container',
       {},
@@ -226,11 +228,10 @@ export default class DocumentService extends Service {
       );
     }
 
-    const draftStatus = await this.store.findRecord<ConceptModel>(
-      'concept',
-      DRAFT_STATUS_ID,
-    );
-    container.set('status', draftStatus);
+    const containerStatus =
+      status ??
+      (await this.store.findRecord<ConceptModel>('concept', DRAFT_STATUS_ID));
+    container.set('status', containerStatus);
     const folder = await this.store.findRecord<EditorDocumentFolderModel>(
       'editor-document-folder',
       folderId,

--- a/app/services/document-service.ts
+++ b/app/services/document-service.ts
@@ -26,6 +26,7 @@ interface PersistDocumentArgs {
   group: BestuurseenheidModel;
   decisionType?: BesluitTypeInstance;
   linkedDecisionUri?: string;
+  container?: DocumentContainerModel;
 }
 
 function hasTypePredicate(triple: Triple): boolean {
@@ -206,6 +207,10 @@ export default class DocumentService extends Service {
     group,
     decisionType,
     linkedDecisionUri,
+    container = this.store.createRecord<DocumentContainerModel>(
+      'document-container',
+      {},
+    ),
   }: PersistDocumentArgs) => {
     let generatedTemplate = await this.buildTemplate(template);
     if (decisionType) {
@@ -221,10 +226,6 @@ export default class DocumentService extends Service {
       );
     }
 
-    const container = this.store.createRecord<DocumentContainerModel>(
-      'document-container',
-      {},
-    );
     const draftStatus = await this.store.findRecord<ConceptModel>(
       'concept',
       DRAFT_STATUS_ID,
@@ -237,7 +238,13 @@ export default class DocumentService extends Service {
     container.set('folder', folder);
     container.set('publisher', group);
     await container.save();
-    await this.createEditorDocument(title, generatedTemplate, container);
+    const previousDocument = await container.currentVersion;
+    await this.createEditorDocument(
+      title,
+      generatedTemplate,
+      container,
+      previousDocument ?? undefined,
+    );
 
     return container;
   };

--- a/app/templates/meetings/edit/agendapoint/new.hbs
+++ b/app/templates/meetings/edit/agendapoint/new.hbs
@@ -9,4 +9,5 @@
   @decisionTypeOptions={{this.editorConfig.besluitType}}
   @documentTitle={{this.documentTitle}}
   @container={{this.container}}
+  @statusOfNewDocument={{this.model.scheduledStatus}}
 />

--- a/app/templates/meetings/edit/agendapoint/new.hbs
+++ b/app/templates/meetings/edit/agendapoint/new.hbs
@@ -1,0 +1,11 @@
+{{page-title (t 'inbox.agendapoints.new.title')}}
+
+<DocumentCreator::Modal
+  @modalTitle={{t 'inbox.agendapoints.new.title'}}
+  @getTemplates={{this.getTemplates}}
+  @onCancel={{this.cancelAgendapointCreation}}
+  @folderId={{this.folderId}}
+  @onCreate={{this.redirectToAgendapoint}}
+  @decisionTypeOptions={{this.editorConfig.besluitType}}
+  @documentTitle={{this.documentTitle}}
+/>

--- a/app/templates/meetings/edit/agendapoint/new.hbs
+++ b/app/templates/meetings/edit/agendapoint/new.hbs
@@ -1,4 +1,4 @@
-{{page-title (t 'inbox.agendapoints.new.title')}}
+{{! @glint-nocheck }}
 
 <DocumentCreator::Modal
   @modalTitle={{t 'inbox.agendapoints.new.title'}}

--- a/app/templates/meetings/edit/agendapoint/new.hbs
+++ b/app/templates/meetings/edit/agendapoint/new.hbs
@@ -8,4 +8,5 @@
   @onCreate={{this.redirectToAgendapoint}}
   @decisionTypeOptions={{this.editorConfig.besluitType}}
   @documentTitle={{this.documentTitle}}
+  @container={{this.container}}
 />

--- a/app/utils/htmlToRdf.ts
+++ b/app/utils/htmlToRdf.ts
@@ -4,6 +4,7 @@ import type { Quad, DatasetCore } from '@rdfjs/types';
 
 export default function htmlToRdf(html: string): Promise<DatasetCore<Quad>> {
   return new Promise((res, rej) => {
+    const wrapped = `<div prefix="besluit: http://data.vlaanderen.be/ns/besluit#">${html}</div>`;
     const myParser = new RdfaParser({ contentType: 'text/html' });
     const dataset = factory.dataset();
     myParser
@@ -12,7 +13,7 @@ export default function htmlToRdf(html: string): Promise<DatasetCore<Quad>> {
       })
       .on('error', rej)
       .on('end', () => res(dataset));
-    myParser.write(html);
+    myParser.write(wrapped);
     myParser.end();
   });
 }

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "ember-modifier": "catalog:",
     "ember-mu-transform-helpers": "^2.1.3",
     "ember-page-title": "^8.2.3",
-    "ember-plausible": "^0.2.0",
+    "ember-plausible": "^0.5.0",
     "ember-power-select": "catalog:",
     "ember-power-select-with-create": "catalog:",
     "ember-promise-helpers": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -458,8 +458,8 @@ importers:
         specifier: ^8.2.3
         version: 8.2.4(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.106.2(postcss@8.5.14)))
       ember-plausible:
-        specifier: ^0.2.0
-        version: 0.2.0(@glint/template@1.7.7)(webpack@5.106.2(postcss@8.5.14))
+        specifier: ^0.5.0
+        version: 0.5.0(@babel/core@7.29.0)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.106.2(postcss@8.5.14)))
       ember-power-select:
         specifier: 'catalog:'
         version: 8.12.2(ea9bbe796db1f2f78b4d68ca78bd7576)
@@ -5190,9 +5190,10 @@ packages:
     peerDependencies:
       ember-source: '>= 3.28.0'
 
-  ember-plausible@0.2.0:
-    resolution: {integrity: sha512-XaqCzsO1qUqa0VlK1JKqBKMr2FixgXl1WplxUleJBHZU3ivNo8CfvI9Id4JDhuv4YaO3gaMUXW4uyMM6hA2yiA==}
-    engines: {node: 14.* || 16.* || >= 18}
+  ember-plausible@0.5.0:
+    resolution: {integrity: sha512-b+O40X+lMygw1QAvB5uDe8XgnLK8Vj2SM9XrN92rnO6kWx+uRGyektxM72BEglEpaCr0wqSPmi+jAMnZTHt0FA==}
+    peerDependencies:
+      ember-source: '>= 4.12.0'
 
   ember-power-select-with-create@3.1.0:
     resolution: {integrity: sha512-Ul34nNYBfitnXgv8IjnQ4WmoHN2h/nuuB5jLJnnuFa6aLEQM/dP2QWXQaCCybCzj9vytBDZIFO+/Egdk8uSY4w==}
@@ -17080,16 +17081,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-plausible@0.2.0(@glint/template@1.7.7)(webpack@5.106.2(postcss@8.5.14)):
+  ember-plausible@0.5.0(@babel/core@7.29.0)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.106.2(postcss@8.5.14))):
     dependencies:
-      ember-auto-import: 2.13.1(@glint/template@1.7.7)(webpack@5.106.2(postcss@8.5.14))
-      ember-cli-babel: 7.26.11
-      ember-cli-htmlbars: 5.7.2
+      '@embroider/addon-shim': 1.10.2
+      decorator-transforms: 2.3.2(@babel/core@7.29.0)
+      ember-source: 5.12.0(@glimmer/component@1.1.2(@babel/core@7.29.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.106.2(postcss@8.5.14))
       plausible-tracker: 0.3.9
     transitivePeerDependencies:
-      - '@glint/template'
+      - '@babel/core'
       - supports-color
-      - webpack
 
   ember-power-select-with-create@3.1.0(c8b4d00671b7d283954bea441d47d96e):
     dependencies:


### PR DESCRIPTION
### Overview
Until now it was not possible to select a template when using the edit agendapoint content button on the meeting edit page. This PR shows the template selector when the agendapoint document has no content yet.

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-6166

### How to test/reproduce
Add an agendapoint via the meeting edit page. Click the "bewerk" button on its content, the template selector modal should appear.

### Challenges/uncertainties
The modal is now opened when a agendapoint document has not content yet, this feels like a heuristic but it should work most of the time.

### Checks PR readiness
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
